### PR TITLE
fix: handle saveProject/importProjectZip failures and add missing ARIA attributes

### DIFF
--- a/src/components/elements/osc-app-shell.ts
+++ b/src/components/elements/osc-app-shell.ts
@@ -167,6 +167,8 @@ export class OscAppShell extends LitElement {
         <div class="panels-single">
           <osc-editor-panel
             id="panel-editor"
+            role="tabpanel"
+            aria-label="Editor panel"
             class="absolute-fill opacity-animated ${focus !== 'editor' ? 'opacity-0' : ''}"
             style="z-index:${zOf('editor')};"
             ?inert=${focus !== 'editor'}
@@ -174,6 +176,8 @@ export class OscAppShell extends LitElement {
           ></osc-editor-panel>
           <osc-viewer-panel
             id="panel-viewer"
+            role="tabpanel"
+            aria-label="Viewer panel"
             class="absolute-fill"
             style="z-index:${zOf('viewer')};"
             ?inert=${focus !== 'viewer'}
@@ -181,6 +185,8 @@ export class OscAppShell extends LitElement {
           ></osc-viewer-panel>
           <osc-customizer-panel
             id="panel-customizer"
+            role="tabpanel"
+            aria-label="Customizer panel"
             class="absolute-fill opacity-animated ${focus !== 'customizer' ? 'opacity-0' : ''}"
             style="z-index:${zOf('customizer')};overflow-y:auto;"
             ?inert=${focus !== 'customizer'}

--- a/src/components/elements/osc-footer.ts
+++ b/src/components/elements/osc-footer.ts
@@ -208,7 +208,13 @@ export class OscFooter extends LitElement {
             </div>
           `
         : ''}
-      <div class="progress-bar-track" style="visibility:${busy ? 'visible' : 'hidden'};">
+      <div
+        class="progress-bar-track"
+        style="visibility:${busy ? 'visible' : 'hidden'};"
+        role="status"
+        aria-live="polite"
+        aria-label=${busy ? 'Working…' : 'Idle'}
+      >
         <div class="progress-bar-indeterminate"></div>
       </div>
       <div class="footer-row">
@@ -237,6 +243,8 @@ export class OscFooter extends LitElement {
                     ? 'warning'
                     : ''}"
                 title="Toggle log output"
+                aria-label="Toggle log output"
+                aria-pressed=${st.view.logs ? 'true' : 'false'}
                 @click=${() => {
                   this._model.logsVisible = !st.view.logs;
                 }}

--- a/src/state/model.ts
+++ b/src/state/model.ts
@@ -458,34 +458,40 @@ export class Model extends EventTarget {
 
   /** F6: Extracts a ZIP archive into /home/ and activates the entry .scad. */
   async importProjectZip(zipBuffer: ArrayBuffer): Promise<void> {
-    const zip = await JSZip.loadAsync(zipBuffer);
-    const files: [string, string][] = [];
-    for (const [relPath, zipObj] of Object.entries(zip.files)) {
-      if (!zipObj.dir) {
-        files.push([relPath, await zipObj.async('string')]);
+    try {
+      const zip = await JSZip.loadAsync(zipBuffer);
+      const files: [string, string][] = [];
+      for (const [relPath, zipObj] of Object.entries(zip.files)) {
+        if (!zipObj.dir) {
+          files.push([relPath, await zipObj.async('string')]);
+        }
       }
-    }
-    for (const [relPath, content] of files) {
-      try {
-        this.fs.writeFile(`/home/${relPath}`, content);
-      } catch {
-        /* ignore */
+      for (const [relPath, content] of files) {
+        try {
+          this.fs.writeFile(`/home/${relPath}`, content);
+        } catch {
+          /* ignore */
+        }
       }
-    }
-    const entryRel = (files.find(([p]) => p === 'main.scad') ??
-      files.find(([p]) => p.endsWith('.scad')) ??
-      files[0])?.[0];
-    if (entryRel) {
-      const fullEntry = `/home/${entryRel}`;
+      const entryRel = (files.find(([p]) => p === 'main.scad') ??
+        files.find(([p]) => p.endsWith('.scad')) ??
+        files[0])?.[0];
+      if (entryRel) {
+        const fullEntry = `/home/${entryRel}`;
+        this.mutate((s) => {
+          s.params.sources = files.map(([p, content]) => ({ path: `/home/${p}`, content }));
+          s.params.activePath = fullEntry;
+          s.lastCheckerRun = undefined;
+          s.output = undefined;
+          s.error = undefined;
+          s.errorDetails = undefined;
+        });
+        this.processSource();
+      }
+    } catch (err) {
       this.mutate((s) => {
-        s.params.sources = files.map(([p, content]) => ({ path: `/home/${p}`, content }));
-        s.params.activePath = fullEntry;
-        s.lastCheckerRun = undefined;
-        s.output = undefined;
-        s.error = undefined;
-        s.errorDetails = undefined;
+        this.applyUserFacingError(s, err, 'model');
       });
-      this.processSource();
     }
   }
 
@@ -526,18 +532,23 @@ export class Model extends EventTarget {
       const file = new File([blob], this.state.params.activePath.split('/').pop()!);
       downloadUrl(URL.createObjectURL(file), file.name);
     } else {
-      const zip = new JSZip();
-      for (const source of this.state.params.sources) {
-        let path = source.path;
-        if (path.startsWith('/')) {
-          path = path.substring(1);
+      try {
+        const zip = new JSZip();
+        for (const source of this.state.params.sources) {
+          let path = source.path;
+          if (path.startsWith('/')) {
+            path = path.substring(1);
+          }
+          zip.file(path, await fetchSource(this.fs, source));
         }
-        zip.file(path, await fetchSource(this.fs, source));
-      }
-      zip.generateAsync({ type: 'blob' }).then((blob) => {
+        const blob = await zip.generateAsync({ type: 'blob' });
         const file = new File([blob], 'project.zip');
         downloadUrl(URL.createObjectURL(file), file.name);
-      });
+      } catch (err) {
+        this.mutate((s) => {
+          this.applyUserFacingError(s, err, 'model');
+        });
+      }
     }
   }
 


### PR DESCRIPTION
This pull request focuses on improving accessibility and error handling in the application. The main updates add ARIA attributes to key UI components for better screen reader support, and wrap ZIP project import/export logic in try/catch blocks to surface user-facing errors more reliably.

**Accessibility improvements:**

* Added `role="tabpanel"` and descriptive `aria-label` attributes to the `osc-editor-panel`, `osc-viewer-panel`, and `osc-customizer-panel` components in `osc-app-shell.ts` to enhance screen reader navigation.
* Updated the progress bar in `osc-footer.ts` to include `role="status"`, `aria-live="polite"`, and a dynamic `aria-label` indicating whether the app is working or idle.
* Improved the log toggle button in `osc-footer.ts` by adding `aria-label` and `aria-pressed` attributes for better accessibility and state indication.

**Error handling enhancements:**

* Wrapped the ZIP project import logic in `model.ts` (`importProjectZip`) in a try/catch block to catch and display user-facing errors if extraction fails. [[1]](diffhunk://#diff-49b8f607a5d016417814935026e65e59e1ae969b14ae1c92a17bf478a8128d2bR461) [[2]](diffhunk://#diff-49b8f607a5d016417814935026e65e59e1ae969b14ae1c92a17bf478a8128d2bR491-R495)
* Wrapped the ZIP project export logic in `model.ts` in a try/catch block to catch and display errors if ZIP creation or download fails. [[1]](diffhunk://#diff-49b8f607a5d016417814935026e65e59e1ae969b14ae1c92a17bf478a8128d2bR535) [[2]](diffhunk://#diff-49b8f607a5d016417814935026e65e59e1ae969b14ae1c92a17bf478a8128d2bL537-R553)