### PR TITLE
Feat/embed postmessage api

### DIFF
--- a/docs/DEPLOYMENT.md
+++ b/docs/DEPLOYMENT.md
@@ -3,6 +3,7 @@
 OpenSCAD Web deploys as a static `dist/` directory produced by Vite plus a post-build Workbox service worker step.
 
 Security headers, CSP guidance, and external-source loading assumptions are documented in [docs/SECURITY.md](./SECURITY.md).
+For iframe embed deployments and the `postMessage` API contract, see [docs/EMBED.md](./EMBED.md).
 
 ## Deployment Model
 

--- a/docs/EMBED.md
+++ b/docs/EMBED.md
@@ -1,0 +1,147 @@
+# Embed
+
+OpenSCAD Web supports a hosted iframe integration via `?mode=embed`.
+
+This document describes the parent/iframe `postMessage` contract, origin-handling expectations, and the recommended integration pattern for storefront or product-page embeds.
+
+## URL Parameters
+
+Embed mode is enabled with:
+
+```text
+?mode=embed
+```
+
+Supported embed-specific query parameters:
+
+- `model`: optional external model URL; same-origin paths and cross-origin `https://` URLs are allowed
+- `controls=true`: show the built-in customizer panel
+- `download=true`: show the built-in download button
+- `parentOrigin=https://host.example.com`: optional origin hardening for parent/iframe messaging
+
+`parentOrigin` must be an absolute `http://` or `https://` origin. Paths, query strings, and fragments are ignored and normalized to the origin.
+
+## Message Types
+
+### Host → iframe
+
+| Type | Payload | Description |
+|---|---|---|
+| `setModel` | `{ type: 'setModel', source: string }` | Replace the current model with raw source text |
+| `setVar` | `{ type: 'setVar', name: string, value: unknown }` | Set one customizer variable |
+| `getVars` | `{ type: 'getVars', requestId?: string }` | Request the current effective variable map |
+
+Notes:
+
+- `setModel` is a source-text replacement API, not a URL-loading API.
+- External URL loading remains attached to the `model=` boot flow, not `postMessage`.
+
+### iframe → host
+
+| Type | Payload | Description |
+|---|---|---|
+| `ready` | `{ type: 'ready', vars, parameterSet? }` | Initial embed state is ready for host interaction |
+| `varsChanged` | `{ type: 'varsChanged', vars }` | Effective variable map changed |
+| `parameterSetLoaded` | `{ type: 'parameterSetLoaded', parameterSet }` | Parameter metadata is available |
+| `varsSnapshot` | `{ type: 'varsSnapshot', vars, requestId? }` | Response to `getVars` |
+| `renderComplete` | `{ type: 'renderComplete', outFileURL }` | A render finished and produced a new output blob URL |
+| `stateChange` | `{ type: 'stateChange', error }` | Legacy error event used for external model-load failures |
+
+Notes:
+
+- `ready` fires once.
+- `varsChanged` carries the current effective values, including parameter defaults when available.
+- `parameterSetLoaded` may arrive after `ready`.
+- if the host needs a fully default-expanded variable map for a parameterized model, call `getVars` after `parameterSetLoaded`.
+- `stateChange` is retained for backward compatibility.
+
+## Security Model
+
+### Parent origin hardening
+
+If `parentOrigin` is provided:
+
+- outbound messages are posted only to that origin
+- inbound messages are accepted only when:
+  - `event.source === window.parent`
+  - `event.origin === parentOrigin`
+
+If `parentOrigin` is omitted:
+
+- outbound messages use `'*'`
+- inbound messages only check `event.source === window.parent`
+
+For production embeds, prefer setting `parentOrigin` explicitly.
+
+### Host-side validation
+
+The parent page should still validate messages before acting on them:
+
+```js
+window.addEventListener('message', (event) => {
+  if (event.source !== iframe.contentWindow) return;
+  if (event.origin !== 'https://your-app.example.com') return;
+  // handle event.data
+});
+```
+
+### CSP and framing
+
+If you publish an embed intended for only known host pages, set a CSP with a narrow `frame-ancestors` policy instead of leaving framing wide open.
+
+See [docs/SECURITY.md](./SECURITY.md) for the current baseline CSP guidance.
+
+## Integration Example
+
+```html
+<iframe
+  id="osc"
+  src="https://example.com/openscad/?mode=embed&controls=true&parentOrigin=https%3A%2F%2Fstore.example.com"
+  width="100%"
+  height="500"
+  loading="lazy"
+></iframe>
+
+<script>
+  const iframe = document.getElementById('osc');
+  const currentVars = {};
+
+  window.addEventListener('message', (event) => {
+    if (event.source !== iframe.contentWindow) return;
+    if (event.origin !== 'https://example.com') return;
+
+    switch (event.data.type) {
+      case 'ready':
+        Object.assign(currentVars, event.data.vars || {});
+        break;
+      case 'varsChanged':
+      case 'varsSnapshot':
+        Object.assign(currentVars, event.data.vars || {});
+        break;
+      case 'parameterSetLoaded':
+        console.log('Parameter metadata:', event.data.parameterSet);
+        break;
+      case 'renderComplete':
+        console.log('Output blob URL:', event.data.outFileURL);
+        break;
+      case 'stateChange':
+        console.error(event.data.error);
+        break;
+    }
+  });
+
+  function setVar(name, value) {
+    iframe.contentWindow.postMessage({ type: 'setVar', name, value }, 'https://example.com');
+  }
+
+  function refreshVars() {
+    iframe.contentWindow.postMessage({ type: 'getVars', requestId: 'checkout' }, 'https://example.com');
+  }
+</script>
+```
+
+## Blob URL Lifetime
+
+`renderComplete.outFileURL` is a blob URL owned by the iframe document.
+
+If the host page fetches or reuses blob URLs over time, it should revoke old URLs with `URL.revokeObjectURL()` when they are no longer needed to avoid memory leaks.

--- a/docs/EMBED.md
+++ b/docs/EMBED.md
@@ -25,11 +25,11 @@ Supported embed-specific query parameters:
 
 ### Host → iframe
 
-| Type | Payload | Description |
-|---|---|---|
-| `setModel` | `{ type: 'setModel', source: string }` | Replace the current model with raw source text |
-| `setVar` | `{ type: 'setVar', name: string, value: unknown }` | Set one customizer variable |
-| `getVars` | `{ type: 'getVars', requestId?: string }` | Request the current effective variable map |
+| Type       | Payload                                            | Description                                    |
+| ---------- | -------------------------------------------------- | ---------------------------------------------- |
+| `setModel` | `{ type: 'setModel', source: string }`             | Replace the current model with raw source text |
+| `setVar`   | `{ type: 'setVar', name: string, value: unknown }` | Set one customizer variable                    |
+| `getVars`  | `{ type: 'getVars', requestId?: string }`          | Request the current effective variable map     |
 
 Notes:
 
@@ -38,14 +38,14 @@ Notes:
 
 ### iframe → host
 
-| Type | Payload | Description |
-|---|---|---|
-| `ready` | `{ type: 'ready', vars, parameterSet? }` | Initial embed state is ready for host interaction |
-| `varsChanged` | `{ type: 'varsChanged', vars }` | Effective variable map changed |
-| `parameterSetLoaded` | `{ type: 'parameterSetLoaded', parameterSet }` | Parameter metadata is available |
-| `varsSnapshot` | `{ type: 'varsSnapshot', vars, requestId? }` | Response to `getVars` |
-| `renderComplete` | `{ type: 'renderComplete', outFileURL }` | A render finished and produced a new output blob URL |
-| `stateChange` | `{ type: 'stateChange', error }` | Legacy error event used for external model-load failures |
+| Type                 | Payload                                        | Description                                              |
+| -------------------- | ---------------------------------------------- | -------------------------------------------------------- |
+| `ready`              | `{ type: 'ready', vars, parameterSet? }`       | Initial embed state is ready for host interaction        |
+| `varsChanged`        | `{ type: 'varsChanged', vars }`                | Effective variable map changed                           |
+| `parameterSetLoaded` | `{ type: 'parameterSetLoaded', parameterSet }` | Parameter metadata is available                          |
+| `varsSnapshot`       | `{ type: 'varsSnapshot', vars, requestId? }`   | Response to `getVars`                                    |
+| `renderComplete`     | `{ type: 'renderComplete', outFileURL }`       | A render finished and produced a new output blob URL     |
+| `stateChange`        | `{ type: 'stateChange', error }`               | Legacy error event used for external model-load failures |
 
 Notes:
 
@@ -135,7 +135,10 @@ See [docs/SECURITY.md](./SECURITY.md) for the current baseline CSP guidance.
   }
 
   function refreshVars() {
-    iframe.contentWindow.postMessage({ type: 'getVars', requestId: 'checkout' }, 'https://example.com');
+    iframe.contentWindow.postMessage(
+      { type: 'getVars', requestId: 'checkout' },
+      'https://example.com',
+    );
   }
 </script>
 ```

--- a/docs/SECURITY.md
+++ b/docs/SECURITY.md
@@ -4,6 +4,8 @@ OpenSCAD Web is a static browser application. It does not ship a server-side API
 
 This document records the current production security model and the deployment assumptions that follow from it.
 
+For the iframe `postMessage` contract and integration examples, see [docs/EMBED.md](./EMBED.md).
+
 ## Current Security Model
 
 The current app enforces these runtime constraints:
@@ -49,8 +51,9 @@ This avoids silent background fetches to arbitrary origins when a fragment link 
 
 `?mode=embed` is designed to be hosted inside another page and exposes a small `postMessage` API to the parent frame. The embedding page is therefore a trust boundary:
 
-- the parent page can send `setModel` and `setVar` messages to the iframe
-- the iframe sends render lifecycle messages back to `window.parent`
+- the parent page can send `setModel`, `setVar`, and `getVars` messages to the iframe
+- the iframe sends lifecycle and render messages back to `window.parent`
+- when `parentOrigin` is configured, the iframe narrows both outbound `targetOrigin` and inbound origin acceptance to that specific origin
 
 If you deploy the embed mode on the open web, use host-side `frame-ancestors` restrictions to limit who can embed it.
 

--- a/public/test-host.html
+++ b/public/test-host.html
@@ -1,0 +1,9 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>Embed Test Host</title>
+  </head>
+  <body></body>
+</html>

--- a/src/components/elements/osc-embed-shell.ts
+++ b/src/components/elements/osc-embed-shell.ts
@@ -120,7 +120,7 @@ export class OscEmbedShell extends LitElement {
       this._notifyHost('varsChanged', { vars: getVarsSnapshot(st) });
     }
 
-    if (st.parameterSet && prev?.parameterSet !== st.parameterSet) {
+    if (this._readyNotified && st.parameterSet && prev?.parameterSet !== st.parameterSet) {
       this._notifyHost('parameterSetLoaded', { parameterSet: st.parameterSet });
     }
 

--- a/src/components/elements/osc-embed-shell.ts
+++ b/src/components/elements/osc-embed-shell.ts
@@ -83,6 +83,9 @@ export class OscEmbedShell extends LitElement {
   @state() private _loadError: string | null = null;
   private _model!: Model;
   private _readyNotified = false;
+  private _lastSentParamSet: object | null = null;
+  private _lastSentRenderURL: string | null = null;
+  private _lastSentVars: Record<string, unknown> | null | undefined = undefined;
   private _targetOrigin() {
     return this.urlParams?.parentOrigin ?? '*';
   }
@@ -100,32 +103,31 @@ export class OscEmbedShell extends LitElement {
     if (!st.output && !st.parameterSet && !st.error) return;
 
     this._readyNotified = true;
+    this._lastSentVars = st.params.vars;
     this._notifyHost('ready', {
       vars: getVarsSnapshot(st),
       ...(st.parameterSet ? { parameterSet: st.parameterSet } : {}),
     });
   }
   private _onState = (e: Event) => {
-    const prev = this._st;
     const st = (e as CustomEvent<State>).detail;
     this._st = st;
 
     this._maybeNotifyReady(st);
 
-    if (
-      this._readyNotified &&
-      prev != null &&
-      prev.params.vars !== st.params.vars
-    ) {
+    if (this._readyNotified && st.params.vars !== this._lastSentVars) {
+      this._lastSentVars = st.params.vars;
       this._notifyHost('varsChanged', { vars: getVarsSnapshot(st) });
     }
 
-    if (this._readyNotified && st.parameterSet && prev?.parameterSet !== st.parameterSet) {
+    if (this._readyNotified && st.parameterSet && st.parameterSet !== this._lastSentParamSet) {
+      this._lastSentParamSet = st.parameterSet;
       this._notifyHost('parameterSetLoaded', { parameterSet: st.parameterSet });
     }
 
     if (st.output && !st.rendering && !st.previewing) {
-      if (!prev?.output || prev.output.outFileURL !== st.output.outFileURL) {
+      if (st.output.outFileURL !== this._lastSentRenderURL) {
+        this._lastSentRenderURL = st.output.outFileURL;
         this._notifyHost('renderComplete', { outFileURL: st.output.outFileURL });
       }
     }

--- a/src/components/elements/osc-embed-shell.ts
+++ b/src/components/elements/osc-embed-shell.ts
@@ -15,11 +15,12 @@ import './osc-customizer-panel.ts';
 // ---------------------------------------------------------------------------
 type SetModelMsg = { type: 'setModel'; source: string };
 type SetVarMsg = { type: 'setVar'; name: string; value: unknown };
-type InboundMsg = SetModelMsg | SetVarMsg;
+type GetVarsMsg = { type: 'getVars'; requestId?: string };
+type InboundMsg = SetModelMsg | SetVarMsg | GetVarsMsg;
 
-function notifyHost(type: string, payload?: Record<string, unknown>) {
+function notifyHost(type: string, targetOrigin: string, payload?: Record<string, unknown>) {
   if (window.parent !== window) {
-    window.parent.postMessage({ type, ...payload }, '*');
+    window.parent.postMessage({ type, ...payload }, targetOrigin);
   }
 }
 
@@ -34,6 +35,13 @@ function coerceUrlVars(vars: Record<string, string>): Record<string, unknown> {
     }
   }
   return result;
+}
+
+function getVarsSnapshot(st: State): Record<string, unknown> {
+  const defaults = Object.fromEntries(
+    (st.parameterSet?.parameters ?? []).map((parameter) => [parameter.name, parameter.initial]),
+  );
+  return { ...defaults, ...(st.params.vars ?? {}) };
 }
 
 @customElement('osc-embed-shell')
@@ -74,19 +82,57 @@ export class OscEmbedShell extends LitElement {
   @state() private _st: State | null = null;
   @state() private _loadError: string | null = null;
   private _model!: Model;
+  private _readyNotified = false;
+  private _targetOrigin() {
+    return this.urlParams?.parentOrigin ?? '*';
+  }
+  private _notifyHost(type: string, payload?: Record<string, unknown>) {
+    notifyHost(type, this._targetOrigin(), payload);
+  }
+  private _acceptsMessage(event: MessageEvent) {
+    if (event.source !== window.parent) return false;
+    const expectedOrigin = this.urlParams?.parentOrigin;
+    return expectedOrigin == null || event.origin === expectedOrigin;
+  }
+  private _maybeNotifyReady(st: State) {
+    if (this._readyNotified) return;
+    if (st.previewing || st.rendering) return;
+    if (!st.output && !st.parameterSet && !st.error) return;
+
+    this._readyNotified = true;
+    this._notifyHost('ready', {
+      vars: getVarsSnapshot(st),
+      ...(st.parameterSet ? { parameterSet: st.parameterSet } : {}),
+    });
+  }
   private _onState = (e: Event) => {
     const prev = this._st;
     const st = (e as CustomEvent<State>).detail;
     this._st = st;
+
+    this._maybeNotifyReady(st);
+
+    if (
+      this._readyNotified &&
+      prev != null &&
+      prev.params.vars !== st.params.vars
+    ) {
+      this._notifyHost('varsChanged', { vars: getVarsSnapshot(st) });
+    }
+
+    if (st.parameterSet && prev?.parameterSet !== st.parameterSet) {
+      this._notifyHost('parameterSetLoaded', { parameterSet: st.parameterSet });
+    }
+
     if (st.output && !st.rendering && !st.previewing) {
       if (!prev?.output || prev.output.outFileURL !== st.output.outFileURL) {
-        notifyHost('renderComplete', { outFileURL: st.output.outFileURL });
+        this._notifyHost('renderComplete', { outFileURL: st.output.outFileURL });
       }
     }
   };
 
   private _messageHandler = (event: MessageEvent) => {
-    if (event.source !== window.parent) return;
+    if (!this._acceptsMessage(event)) return;
     const msg = event.data as InboundMsg;
     if (!msg || typeof msg.type !== 'string') return;
     if (msg.type === 'setModel') {
@@ -95,6 +141,12 @@ export class OscEmbedShell extends LitElement {
     } else if (msg.type === 'setVar') {
       const m = msg as SetVarMsg;
       if (typeof m.name === 'string') this._model.setVar(m.name, m.value as never);
+    } else if (msg.type === 'getVars') {
+      const m = msg as GetVarsMsg;
+      this._notifyHost('varsSnapshot', {
+        vars: getVarsSnapshot(this._model.state),
+        ...(typeof m.requestId === 'string' ? { requestId: m.requestId } : {}),
+      });
     }
   };
 
@@ -137,7 +189,7 @@ export class OscEmbedShell extends LitElement {
       const result = await fetchExternalModel(params.modelUrl!);
       if (typeof result === 'object' && 'error' in result) {
         this._loadError = result.error;
-        notifyHost('stateChange', { error: result.error });
+        this._notifyHost('stateChange', { error: result.error });
         return;
       }
       const preVars = params.prePopulatedVars;

--- a/src/state/__tests__/url-mode.test.ts
+++ b/src/state/__tests__/url-mode.test.ts
@@ -65,6 +65,20 @@ describe('parseUrlMode — mode routing', () => {
     expect(result.embedDownload).toBe(true);
   });
 
+  it('parses and canonicalizes parentOrigin', () => {
+    const result = parseUrlMode(
+      '?mode=embed&parentOrigin=https%3A%2F%2Fstore.example.com%2Fcheckout',
+    );
+    expect('error' in result).toBe(false);
+    if ('error' in result) return;
+    expect(result.parentOrigin).toBe('https://store.example.com');
+  });
+
+  it('rejects invalid parentOrigin values', () => {
+    const result = parseUrlMode('?mode=embed&parentOrigin=javascript:alert(1)');
+    expect('error' in result).toBe(true);
+  });
+
   it('collects unknown params as prePopulatedVars', () => {
     const result = parseUrlMode('?mode=customizer&model=https://x.com/m.scad&teeth=30&height=5');
     expect('error' in result).toBe(false);

--- a/src/state/url-mode.ts
+++ b/src/state/url-mode.ts
@@ -82,8 +82,7 @@ export function parseUrlMode(search: string): UrlModeParams | { error: string } 
   }
 
   const rawParentOrigin = params.get('parentOrigin');
-  const parentOrigin =
-    rawParentOrigin === null ? null : normalizeParentOrigin(rawParentOrigin);
+  const parentOrigin = rawParentOrigin === null ? null : normalizeParentOrigin(rawParentOrigin);
   if (rawParentOrigin !== null && parentOrigin === null) {
     return {
       error: `parentOrigin must be an absolute http(s) origin. Got: ${rawParentOrigin.slice(0, 40)}`,

--- a/src/state/url-mode.ts
+++ b/src/state/url-mode.ts
@@ -14,6 +14,7 @@ export type AppMode = 'editor' | 'customizer' | 'embed';
 export interface UrlModeParams {
   mode: AppMode;
   modelUrl: string | null;
+  parentOrigin: string | null;
   prePopulatedVars: Record<string, string>;
   embedControls: boolean;
   embedDownload: boolean;
@@ -29,6 +30,7 @@ export interface UrlModeParams {
 const KNOWN_PARAMS = new Set([
   'mode',
   'model',
+  'parentOrigin',
   'controls',
   'download',
   'showAxes',
@@ -45,6 +47,21 @@ export function isAllowedModelUrl(modelUrl: string): boolean {
     allowCrossOriginHttps: true,
     baseUrl: window.location.href,
   });
+}
+
+function normalizeParentOrigin(parentOrigin: string): string | null {
+  const value = parentOrigin.trim();
+  if (value === '') return null;
+
+  try {
+    const parsed = new URL(value);
+    if (!['http:', 'https:'].includes(parsed.protocol)) {
+      return null;
+    }
+    return parsed.origin;
+  } catch {
+    return null;
+  }
 }
 
 /** Parse `window.location.search` into a UrlModeParams object.
@@ -64,6 +81,15 @@ export function parseUrlMode(search: string): UrlModeParams | { error: string } 
     };
   }
 
+  const rawParentOrigin = params.get('parentOrigin');
+  const parentOrigin =
+    rawParentOrigin === null ? null : normalizeParentOrigin(rawParentOrigin);
+  if (rawParentOrigin !== null && parentOrigin === null) {
+    return {
+      error: `parentOrigin must be an absolute http(s) origin. Got: ${rawParentOrigin.slice(0, 40)}`,
+    };
+  }
+
   const prePopulatedVars: Record<string, string> = {};
   for (const [key, value] of params.entries()) {
     if (!KNOWN_PARAMS.has(key)) {
@@ -74,6 +100,7 @@ export function parseUrlMode(search: string): UrlModeParams | { error: string } 
   return {
     mode,
     modelUrl,
+    parentOrigin,
     prePopulatedVars,
     embedControls: params.get('controls') === 'true',
     embedDownload: params.get('download') === 'true',

--- a/tests/e2e.spec.ts
+++ b/tests/e2e.spec.ts
@@ -109,15 +109,17 @@ async function getEmbedMessages(page: Page) {
 }
 
 async function waitForEmbedMessage(page: Page, type: string, timeout = renderTimeoutMs): Promise<void> {
-  await page.waitForFunction(
-    (expectedType) => {
+  const deadline = Date.now() + timeout;
+  while (Date.now() < deadline) {
+    const found = await page.evaluate((expectedType) => {
       const messages = (window as Window & { __embedMessages?: Array<{ data?: { type?: string } }> })
         .__embedMessages;
       return Boolean(messages?.some((message) => message?.data?.type === expectedType));
-    },
-    type,
-    { timeout },
-  );
+    }, type);
+    if (found) return;
+    await page.waitForTimeout(100);
+  }
+  throw new Error(`Timeout ${timeout}ms waiting for embed message of type '${type}'`);
 }
 
 async function waitForEmbedMessageCount(
@@ -126,17 +128,20 @@ async function waitForEmbedMessageCount(
   count: number,
   timeout = renderTimeoutMs,
 ): Promise<void> {
-  await page.waitForFunction(
-    ([expectedType, expectedCount]) => {
-      const messages = (window as Window & { __embedMessages?: Array<{ data?: { type?: string } }> })
-        .__embedMessages;
-      const actualCount =
-        messages?.filter((message) => message?.data?.type === expectedType).length ?? 0;
-      return actualCount >= expectedCount;
-    },
-    [type, count],
-    { timeout },
-  );
+  const deadline = Date.now() + timeout;
+  while (Date.now() < deadline) {
+    const actualCount = await page.evaluate(
+      ([expectedType, expectedCount]) => {
+        const messages = (window as Window & { __embedMessages?: Array<{ data?: { type?: string } }> })
+          .__embedMessages;
+        return messages?.filter((message) => message?.data?.type === (expectedType as string)).length ?? 0;
+      },
+      [type, count] as [string, number],
+    );
+    if (actualCount >= count) return;
+    await page.waitForTimeout(100);
+  }
+  throw new Error(`Timeout ${timeout}ms waiting for ${count}x embed message(s) of type '${type}'`);
 }
 
 async function getAppShellState(page: Page) {
@@ -277,13 +282,15 @@ async function waitForViewer(page: Page): Promise<void> {
 }
 
 async function waitForEmbedViewer(frame: Frame): Promise<void> {
+  // Playwright locators pierce shadow DOM; waitForSelector does as well.
   await frame.waitForSelector('[data-testid="viewer-canvas"] canvas', { timeout: renderTimeoutMs });
   await frame.waitForFunction(
     () => {
-      const container = document.querySelector(
-        '[data-testid="viewer-canvas"]',
-      ) as HTMLElement | null;
-      return Boolean(container && container.dataset.geometryLoaded === 'true');
+      // osc-embed-shell uses shadow DOM; reach through it to find the viewer container.
+      const shell = document.querySelector('osc-embed-shell');
+      const root = shell?.shadowRoot ?? shell;
+      const container = root?.querySelector('[data-testid="viewer-canvas"]') as HTMLElement | null;
+      return Boolean(container?.dataset.geometryLoaded === 'true');
     },
     null,
     { timeout: renderTimeoutMs },
@@ -649,6 +656,7 @@ test.describe('embed mode', () => {
     const frame = await getEmbedFrame(page);
 
     await waitForEmbedViewer(frame);
+
     await waitForEmbedMessage(page, 'ready');
     await waitForEmbedMessage(page, 'renderComplete');
 
@@ -670,6 +678,8 @@ test.describe('embed mode', () => {
     expect(allMessages.filter((m) => m.data?.type === 'renderComplete')).toHaveLength(2);
   });
 });
+
+test.describe('conformance — geometry primitives', () => {
   test('cube(10) produces a PolySet', async ({ page }) => {
     await loadSrc(page, 'cube(10);');
     await waitForViewer(page);

--- a/tests/e2e.spec.ts
+++ b/tests/e2e.spec.ts
@@ -1,4 +1,4 @@
-import { expect, test, type ConsoleMessage, type Page } from '@playwright/test';
+import { expect, test, type ConsoleMessage, type Frame, type Page } from '@playwright/test';
 
 type LoggedMessage = {
   type: string;
@@ -29,6 +29,28 @@ function buildAppUrl(relativePath = ''): string {
   return new URL(relativePath, appBaseUrl).toString();
 }
 
+function buildEmbedUrl({
+  source,
+  controls = true,
+  download = false,
+  parentOrigin = appOrigin,
+}: {
+  source?: string;
+  controls?: boolean;
+  download?: boolean;
+  parentOrigin?: string;
+} = {}): string {
+  const url = new URL(appBaseUrl);
+  url.searchParams.set('mode', 'embed');
+  if (controls) url.searchParams.set('controls', 'true');
+  if (download) url.searchParams.set('download', 'true');
+  if (parentOrigin) url.searchParams.set('parentOrigin', parentOrigin);
+  if (source != null) {
+    url.hash = `src=${encodeURIComponent(source)}`;
+  }
+  return url.toString();
+}
+
 async function loadWithHash(page: Page, fragment: string): Promise<void> {
   const url = new URL(appBaseUrl);
   url.hash = fragment;
@@ -45,6 +67,76 @@ async function loadPath(page: Page, path: string): Promise<void> {
 
 async function loadUrl(page: Page, url: string): Promise<void> {
   await loadWithHash(page, `url=${encodeURIComponent(url)}`);
+}
+
+async function loadEmbedHost(page: Page, iframeUrl: string): Promise<void> {
+  await page.goto(buildAppUrl('test-host.html'));
+  await page.evaluate((src) => {
+    (window as Window & { __embedMessages?: unknown[] }).__embedMessages = [];
+    window.addEventListener('message', (event) => {
+      (window as Window & { __embedMessages?: unknown[] }).__embedMessages?.push({
+        origin: event.origin,
+        data: event.data,
+      });
+    });
+
+    const iframe = document.createElement('iframe');
+    iframe.id = 'embed-frame';
+    iframe.src = src;
+    iframe.width = '1000';
+    iframe.height = '800';
+    document.body.replaceChildren(iframe);
+  }, iframeUrl);
+}
+
+async function getEmbedFrame(page: Page): Promise<Frame> {
+  await page.waitForSelector('#embed-frame', { timeout: renderTimeoutMs });
+  const handle = await page.locator('#embed-frame').elementHandle();
+  const frame = await handle?.contentFrame();
+  if (!frame) {
+    throw new Error('Failed to resolve the embed iframe frame.');
+  }
+  return frame;
+}
+
+async function getEmbedMessages(page: Page) {
+  return page.evaluate(() => {
+    return ((window as Window & { __embedMessages?: unknown[] }).__embedMessages ?? []) as Array<{
+      origin: string;
+      data: Record<string, unknown>;
+    }>;
+  });
+}
+
+async function waitForEmbedMessage(page: Page, type: string, timeout = renderTimeoutMs): Promise<void> {
+  await page.waitForFunction(
+    (expectedType) => {
+      const messages = (window as Window & { __embedMessages?: Array<{ data?: { type?: string } }> })
+        .__embedMessages;
+      return Boolean(messages?.some((message) => message?.data?.type === expectedType));
+    },
+    type,
+    { timeout },
+  );
+}
+
+async function waitForEmbedMessageCount(
+  page: Page,
+  type: string,
+  count: number,
+  timeout = renderTimeoutMs,
+): Promise<void> {
+  await page.waitForFunction(
+    ([expectedType, expectedCount]) => {
+      const messages = (window as Window & { __embedMessages?: Array<{ data?: { type?: string } }> })
+        .__embedMessages;
+      const actualCount =
+        messages?.filter((message) => message?.data?.type === expectedType).length ?? 0;
+      return actualCount >= expectedCount;
+    },
+    [type, count],
+    { timeout },
+  );
 }
 
 async function getAppShellState(page: Page) {
@@ -182,6 +274,58 @@ async function waitForViewer(page: Page): Promise<void> {
     { timeout: renderTimeoutMs },
   );
   await waitForRenderState(page);
+}
+
+async function waitForEmbedViewer(frame: Frame): Promise<void> {
+  await frame.waitForSelector('[data-testid="viewer-canvas"] canvas', { timeout: renderTimeoutMs });
+  await frame.waitForFunction(
+    () => {
+      const container = document.querySelector(
+        '[data-testid="viewer-canvas"]',
+      ) as HTMLElement | null;
+      return Boolean(container && container.dataset.geometryLoaded === 'true');
+    },
+    null,
+    { timeout: renderTimeoutMs },
+  );
+  await frame.waitForFunction(
+    () => {
+      const shell = document.querySelector('osc-embed-shell') as (Element & { _st?: unknown }) | null;
+      const state =
+        shell && '_st' in shell ? (shell._st as Record<string, unknown> | undefined) : null;
+      const output =
+        state && typeof state === 'object' && 'output' in state
+          ? (state.output as Record<string, unknown> | undefined)
+          : undefined;
+      return Boolean(state && !state.rendering && !state.previewing && output);
+    },
+    null,
+    { timeout: renderTimeoutMs },
+  );
+}
+
+async function waitForEmbedParameter(frame: Frame, name: string, timeout = 45_000): Promise<void> {
+  await frame.waitForFunction(
+    (expectedName) => {
+      const shell = document.querySelector('osc-embed-shell') as (Element & { _st?: unknown }) | null;
+      const state =
+        shell && '_st' in shell ? (shell._st as Record<string, unknown> | undefined) : null;
+      const parameterSet =
+        state && typeof state === 'object' && 'parameterSet' in state
+          ? (state.parameterSet as Record<string, unknown> | undefined)
+          : undefined;
+      const parameters =
+        parameterSet && typeof parameterSet === 'object' && 'parameters' in parameterSet
+          ? (parameterSet.parameters as Array<Record<string, unknown>> | undefined)
+          : undefined;
+      return (
+        Array.isArray(parameters) &&
+        parameters.some((parameter) => parameter?.name === expectedName)
+      );
+    },
+    name,
+    { timeout },
+  );
 }
 
 async function waitForParameter(page: Page, name: string, timeout = 45_000): Promise<void> {
@@ -393,6 +537,108 @@ test.describe('worker integration', () => {
     await expect(page.locator('[data-testid="error-banner"]')).toContainText(
       'OpenSCAD reported syntax errors',
     );
+  });
+});
+
+test.describe('embed mode', () => {
+  test('supports host messaging and emits the documented lifecycle events', async ({ page }) => {
+    const source = 'myVar = 10;\ncube(myVar);';
+
+    await loadEmbedHost(page, buildEmbedUrl({ source, parentOrigin: appOrigin }));
+    const frame = await getEmbedFrame(page);
+
+    await waitForEmbedViewer(frame);
+    await waitForEmbedMessage(page, 'ready');
+    await waitForEmbedMessage(page, 'parameterSetLoaded');
+    await waitForEmbedMessage(page, 'renderComplete');
+    await waitForEmbedParameter(frame, 'myVar');
+
+    await page.evaluate(() => {
+      const iframe = document.getElementById('embed-frame') as HTMLIFrameElement | null;
+      iframe?.contentWindow?.postMessage(
+        { type: 'setVar', name: 'myVar', value: 20 },
+        window.location.origin,
+      );
+    });
+
+    await waitForEmbedMessage(page, 'varsChanged');
+    await waitForEmbedMessageCount(page, 'renderComplete', 2);
+    await frame.waitForFunction(
+      () => {
+        const shell = document.querySelector('osc-embed-shell') as (Element & { _st?: unknown }) | null;
+        const state =
+          shell && '_st' in shell ? (shell._st as Record<string, unknown> | undefined) : null;
+        return state?.params && (state.params as { vars?: Record<string, unknown> }).vars?.myVar === 20;
+      },
+      null,
+      { timeout: renderTimeoutMs },
+    );
+
+    await page.evaluate(() => {
+      const iframe = document.getElementById('embed-frame') as HTMLIFrameElement | null;
+      iframe?.contentWindow?.postMessage(
+        { type: 'getVars', requestId: 'checkout' },
+        window.location.origin,
+      );
+    });
+
+    await waitForEmbedMessage(page, 'varsSnapshot');
+
+    const messages = await getEmbedMessages(page);
+    const readyMessage = messages.find((message) => message.data?.type === 'ready');
+    const parameterSetMessage = messages.find((message) => message.data?.type === 'parameterSetLoaded');
+    const varsChangedMessage = messages
+      .filter((message) => message.data?.type === 'varsChanged')
+      .at(-1);
+    const varsSnapshotMessage = messages
+      .filter((message) => message.data?.type === 'varsSnapshot')
+      .at(-1);
+
+    expect(readyMessage).toBeDefined();
+    expect(readyMessage?.data?.vars).toEqual(expect.any(Object));
+    expect(parameterSetMessage).toBeDefined();
+    expect(
+      (parameterSetMessage?.data?.parameterSet as { parameters?: Array<{ name?: string }> } | undefined)
+        ?.parameters
+        ?.some((parameter) => parameter?.name === 'myVar'),
+    ).toBe(true);
+    expect(varsChangedMessage?.data?.vars).toMatchObject({ myVar: 20 });
+    expect(varsSnapshotMessage?.data?.requestId).toBe('checkout');
+    expect(varsSnapshotMessage?.data?.vars).toMatchObject({ myVar: 20 });
+  });
+
+  test('rejects host messages when parentOrigin does not match the real parent origin', async ({
+    page,
+  }) => {
+    const source = 'myVar = 10;\ncube(myVar);';
+
+    await loadEmbedHost(page, buildEmbedUrl({ source, parentOrigin: 'https://example.com' }));
+    const frame = await getEmbedFrame(page);
+
+    await waitForEmbedViewer(frame);
+    await page.waitForTimeout(500);
+
+    await page.evaluate(() => {
+      const iframe = document.getElementById('embed-frame') as HTMLIFrameElement | null;
+      iframe?.contentWindow?.postMessage(
+        { type: 'setVar', name: 'myVar', value: 30 },
+        window.location.origin,
+      );
+    });
+
+    await page.waitForTimeout(500);
+
+    const messages = await getEmbedMessages(page);
+    const vars = await frame.evaluate(() => {
+      const shell = document.querySelector('osc-embed-shell') as (Element & { _st?: unknown }) | null;
+      const state =
+        shell && '_st' in shell ? (shell._st as Record<string, unknown> | undefined) : null;
+      return (state?.params as { vars?: Record<string, unknown> } | undefined)?.vars ?? null;
+    });
+
+    expect(messages.some((message) => message.data?.type === 'ready')).toBe(false);
+    expect(messages.some((message) => message.data?.type === 'varsChanged')).toBe(false);
+    expect(vars).toBeNull();
   });
 });
 

--- a/tests/e2e.spec.ts
+++ b/tests/e2e.spec.ts
@@ -640,9 +640,36 @@ test.describe('embed mode', () => {
     expect(messages.some((message) => message.data?.type === 'varsChanged')).toBe(false);
     expect(vars).toBeNull();
   });
-});
 
-test.describe('conformance — geometry primitives', () => {
+  test('setModel replaces the model source and triggers a re-render', async ({ page }) => {
+    const initialSource = 'cube(10);';
+    const replacedSource = 'sphere(5, $fn=8);';
+
+    await loadEmbedHost(page, buildEmbedUrl({ source: initialSource, parentOrigin: appOrigin }));
+    const frame = await getEmbedFrame(page);
+
+    await waitForEmbedViewer(frame);
+    await waitForEmbedMessage(page, 'ready');
+    await waitForEmbedMessage(page, 'renderComplete');
+
+    const firstMessages = await getEmbedMessages(page);
+    const firstComplete = firstMessages.filter((m) => m.data?.type === 'renderComplete');
+    expect(firstComplete).toHaveLength(1);
+
+    await page.evaluate((src) => {
+      const iframe = document.getElementById('embed-frame') as HTMLIFrameElement | null;
+      iframe?.contentWindow?.postMessage(
+        { type: 'setModel', source: src },
+        window.location.origin,
+      );
+    }, replacedSource);
+
+    await waitForEmbedMessageCount(page, 'renderComplete', 2);
+
+    const allMessages = await getEmbedMessages(page);
+    expect(allMessages.filter((m) => m.data?.type === 'renderComplete')).toHaveLength(2);
+  });
+});
   test('cube(10) produces a PolySet', async ({ page }) => {
     await loadSrc(page, 'cube(10);');
     await waitForViewer(page);

--- a/tests/e2e.spec.ts
+++ b/tests/e2e.spec.ts
@@ -108,12 +108,17 @@ async function getEmbedMessages(page: Page) {
   });
 }
 
-async function waitForEmbedMessage(page: Page, type: string, timeout = renderTimeoutMs): Promise<void> {
+async function waitForEmbedMessage(
+  page: Page,
+  type: string,
+  timeout = renderTimeoutMs,
+): Promise<void> {
   const deadline = Date.now() + timeout;
   while (Date.now() < deadline) {
     const found = await page.evaluate((expectedType) => {
-      const messages = (window as Window & { __embedMessages?: Array<{ data?: { type?: string } }> })
-        .__embedMessages;
+      const messages = (
+        window as Window & { __embedMessages?: Array<{ data?: { type?: string } }> }
+      ).__embedMessages;
       return Boolean(messages?.some((message) => message?.data?.type === expectedType));
     }, type);
     if (found) return;
@@ -132,9 +137,13 @@ async function waitForEmbedMessageCount(
   while (Date.now() < deadline) {
     const actualCount = await page.evaluate(
       ([expectedType, expectedCount]) => {
-        const messages = (window as Window & { __embedMessages?: Array<{ data?: { type?: string } }> })
-          .__embedMessages;
-        return messages?.filter((message) => message?.data?.type === (expectedType as string)).length ?? 0;
+        const messages = (
+          window as Window & { __embedMessages?: Array<{ data?: { type?: string } }> }
+        ).__embedMessages;
+        return (
+          messages?.filter((message) => message?.data?.type === (expectedType as string)).length ??
+          0
+        );
       },
       [type, count] as [string, number],
     );
@@ -297,7 +306,9 @@ async function waitForEmbedViewer(frame: Frame): Promise<void> {
   );
   await frame.waitForFunction(
     () => {
-      const shell = document.querySelector('osc-embed-shell') as (Element & { _st?: unknown }) | null;
+      const shell = document.querySelector('osc-embed-shell') as
+        | (Element & { _st?: unknown })
+        | null;
       const state =
         shell && '_st' in shell ? (shell._st as Record<string, unknown> | undefined) : null;
       const output =
@@ -314,7 +325,9 @@ async function waitForEmbedViewer(frame: Frame): Promise<void> {
 async function waitForEmbedParameter(frame: Frame, name: string, timeout = 45_000): Promise<void> {
   await frame.waitForFunction(
     (expectedName) => {
-      const shell = document.querySelector('osc-embed-shell') as (Element & { _st?: unknown }) | null;
+      const shell = document.querySelector('osc-embed-shell') as
+        | (Element & { _st?: unknown })
+        | null;
       const state =
         shell && '_st' in shell ? (shell._st as Record<string, unknown> | undefined) : null;
       const parameterSet =
@@ -572,10 +585,14 @@ test.describe('embed mode', () => {
     await waitForEmbedMessageCount(page, 'renderComplete', 2);
     await frame.waitForFunction(
       () => {
-        const shell = document.querySelector('osc-embed-shell') as (Element & { _st?: unknown }) | null;
+        const shell = document.querySelector('osc-embed-shell') as
+          | (Element & { _st?: unknown })
+          | null;
         const state =
           shell && '_st' in shell ? (shell._st as Record<string, unknown> | undefined) : null;
-        return state?.params && (state.params as { vars?: Record<string, unknown> }).vars?.myVar === 20;
+        return (
+          state?.params && (state.params as { vars?: Record<string, unknown> }).vars?.myVar === 20
+        );
       },
       null,
       { timeout: renderTimeoutMs },
@@ -593,7 +610,9 @@ test.describe('embed mode', () => {
 
     const messages = await getEmbedMessages(page);
     const readyMessage = messages.find((message) => message.data?.type === 'ready');
-    const parameterSetMessage = messages.find((message) => message.data?.type === 'parameterSetLoaded');
+    const parameterSetMessage = messages.find(
+      (message) => message.data?.type === 'parameterSetLoaded',
+    );
     const varsChangedMessage = messages
       .filter((message) => message.data?.type === 'varsChanged')
       .at(-1);
@@ -605,9 +624,11 @@ test.describe('embed mode', () => {
     expect(readyMessage?.data?.vars).toEqual(expect.any(Object));
     expect(parameterSetMessage).toBeDefined();
     expect(
-      (parameterSetMessage?.data?.parameterSet as { parameters?: Array<{ name?: string }> } | undefined)
-        ?.parameters
-        ?.some((parameter) => parameter?.name === 'myVar'),
+      (
+        parameterSetMessage?.data?.parameterSet as
+          | { parameters?: Array<{ name?: string }> }
+          | undefined
+      )?.parameters?.some((parameter) => parameter?.name === 'myVar'),
     ).toBe(true);
     expect(varsChangedMessage?.data?.vars).toMatchObject({ myVar: 20 });
     expect(varsSnapshotMessage?.data?.requestId).toBe('checkout');
@@ -637,7 +658,9 @@ test.describe('embed mode', () => {
 
     const messages = await getEmbedMessages(page);
     const vars = await frame.evaluate(() => {
-      const shell = document.querySelector('osc-embed-shell') as (Element & { _st?: unknown }) | null;
+      const shell = document.querySelector('osc-embed-shell') as
+        | (Element & { _st?: unknown })
+        | null;
       const state =
         shell && '_st' in shell ? (shell._st as Record<string, unknown> | undefined) : null;
       return (state?.params as { vars?: Record<string, unknown> } | undefined)?.vars ?? null;
@@ -666,10 +689,7 @@ test.describe('embed mode', () => {
 
     await page.evaluate((src) => {
       const iframe = document.getElementById('embed-frame') as HTMLIFrameElement | null;
-      iframe?.contentWindow?.postMessage(
-        { type: 'setModel', source: src },
-        window.location.origin,
-      );
+      iframe?.contentWindow?.postMessage({ type: 'setModel', source: src }, window.location.origin);
     }, replacedSource);
 
     await waitForEmbedMessageCount(page, 'renderComplete', 2);


### PR DESCRIPTION
This pull request introduces comprehensive support for secure iframe embedding of OpenSCAD Web via a documented `postMessage` API, enabling robust parent-iframe communication, origin hardening, and improved integration patterns. It also adds extensive documentation and automated tests for the new embed mode, enhances security guidance, and implements new runtime logic to enforce message origin checks and manage variable state snapshots.

**Embed mode and postMessage API enhancements:**

* Added a new `docs/EMBED.md` file detailing the iframe embed integration, supported URL parameters (including `parentOrigin`), the full postMessage contract, security model, and integration examples.
* Implemented support for the `parentOrigin` URL parameter in `parseUrlMode`, including normalization and validation to ensure only absolute HTTP(S) origins are accepted. [[1]](diffhunk://#diff-d19905c8691180b3b1c4173386cd51d54e497d4372376eed276c0131184f3f5aR17) [[2]](diffhunk://#diff-d19905c8691180b3b1c4173386cd51d54e497d4372376eed276c0131184f3f5aR33) [[3]](diffhunk://#diff-d19905c8691180b3b1c4173386cd51d54e497d4372376eed276c0131184f3f5aR52-R66) [[4]](diffhunk://#diff-d19905c8691180b3b1c4173386cd51d54e497d4372376eed276c0131184f3f5aR84-R92) [[5]](diffhunk://#diff-d19905c8691180b3b1c4173386cd51d54e497d4372376eed276c0131184f3f5aR103) [[6]](diffhunk://#diff-bc74749ddcba5ff95d6320248280106fd213dc52ab12c71b55b645f653aa716eR68-R81)
* Extended the embed shell (`osc-embed-shell.ts`) to:
  - Accept and validate `parentOrigin`, restricting both outbound and inbound messages to the specified origin.
  - Handle new inbound message type `getVars` and respond with a `varsSnapshot` containing the current variable state.
  - Track and send lifecycle events (`ready`, `varsChanged`, `parameterSetLoaded`, `renderComplete`, `stateChange`) only when state changes and only to the allowed origin. [[1]](diffhunk://#diff-9178e5b0b071fbc67f473606bc6bb4b257956cea5e82639457892472d3c8c84eL18-R23) [[2]](diffhunk://#diff-9178e5b0b071fbc67f473606bc6bb4b257956cea5e82639457892472d3c8c84eR40-R46) [[3]](diffhunk://#diff-9178e5b0b071fbc67f473606bc6bb4b257956cea5e82639457892472d3c8c84eR85-R137) [[4]](diffhunk://#diff-9178e5b0b071fbc67f473606bc6bb4b257956cea5e82639457892472d3c8c84eR146-R151) [[5]](diffhunk://#diff-9178e5b0b071fbc67f473606bc6bb4b257956cea5e82639457892472d3c8c84eL140-R194)

**Documentation and security guidance:**

* Updated `docs/DEPLOYMENT.md` and `docs/SECURITY.md` to reference the new embed documentation and clarify security and deployment assumptions for iframe embedding, including CSP and framing recommendations. [[1]](diffhunk://#diff-ea9864292e6e392d0c8edbabfe41014d61d6ebd2e08f34d8ae21bf9d070fb274R6) [[2]](diffhunk://#diff-2605206b7e64be69186fabc8e8fed35676e0015832ff630141aa4aecd73354e0R7-R8) [[3]](diffhunk://#diff-2605206b7e64be69186fabc8e8fed35676e0015832ff630141aa4aecd73354e0L52-R56)

**Testing and validation:**

* Added a new minimal `public/test-host.html` for e2e embed testing.
* Expanded Playwright e2e tests in `tests/e2e.spec.ts` to cover embed mode, including helpers for loading the embed host, capturing and waiting for postMessage events, and verifying origin restrictions and message flows. [[1]](diffhunk://#diff-01f5093ac81bb7c47ad2ff4bf7e4b66380a4dc4a1c10b06f3f127db8d3d55ed5L1-R1) [[2]](diffhunk://#diff-01f5093ac81bb7c47ad2ff4bf7e4b66380a4dc4a1c10b06f3f127db8d3d55ed5R32-R53) [[3]](diffhunk://#diff-01f5093ac81bb7c47ad2ff4bf7e4b66380a4dc4a1c10b06f3f127db8d3d55ed5R72-R146)

These changes collectively provide a secure, well-documented, and thoroughly tested foundation for using OpenSCAD Web as an embeddable component in external sites, with explicit controls over cross-origin communication and state synchronization.