### PR TITLE
Feat/deploy foundations

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,83 @@
+name: Release Publish Artifact
+
+on:
+  push:
+    tags:
+      - 'v*.*.*'
+
+jobs:
+  release:
+    runs-on: ubuntu-24.04
+    permissions:
+      contents: write
+    env:
+      CI: 'true'
+
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+
+      - uses: actions/setup-node@v6
+        with:
+          node-version: '24'
+          cache: 'npm'
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Install Playwright Chromium
+        run: npx playwright install --with-deps chromium
+
+      - name: Restore build-libs cache
+        id: cache-libs
+        uses: actions/cache@v4
+        with:
+          path: |
+            libs/
+            src/wasm/
+            public/libraries/
+          key: v2-libs-${{ hashFiles('libs-config.json') }}
+
+      - name: Build libs
+        if: steps.cache-libs.outputs.cache-hit != 'true'
+        run: npm run build:libs
+
+      - name: Build publish artifact
+        run: npm run build:publish
+
+      - name: Browser E2E (publish artifact)
+        run: npm run test:e2e:publish
+        env:
+          CI: 'true'
+          E2E_PUBLISH_SKIP_BUILD: 'true'
+
+      - name: Verify publish archive structure
+        run: npm run verify:publish-archive
+
+      - name: Upload Playwright artifacts
+        if: always()
+        uses: actions/upload-artifact@v7
+        with:
+          name: playwright-artifacts-release
+          path: |
+            playwright-report/
+            test-results/
+          if-no-files-found: ignore
+
+      - name: Create GitHub release
+        uses: softprops/action-gh-release@v2
+        with:
+          files: openscad-web-publish.zip
+          generate_release_notes: true
+          draft: false
+
+      - name: Move v0 tag
+        shell: bash
+        run: |
+          version="${GITHUB_REF_NAME#v}"
+          major_tag="v${version%%.*}"
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git tag -f "${major_tag}" "${GITHUB_SHA}"
+          git push origin "refs/tags/${major_tag}" --force

--- a/.gitignore
+++ b/.gitignore
@@ -3,7 +3,10 @@ node_modules/
 
 # Build outputs
 dist/
+dist-publish/
 libs/
+openscad-web-publish.zip
+.publish-e2e/
 
 # OpenSCAD WASM artifacts (built from openscad-wasm repo)
 public/openscad.js

--- a/docs/DEPLOYMENT.md
+++ b/docs/DEPLOYMENT.md
@@ -1,13 +1,16 @@
 # Deployment
 
-OpenSCAD Web deploys as a static `dist/` directory produced by Vite plus a post-build Workbox service worker step.
+OpenSCAD Web now has two deployment artifacts:
+
+- `dist/` for this repo's own fixed-base deployment
+- `dist-publish/` / `openscad-web-publish.zip` for relocatable consumer publishing
 
 Security headers, CSP guidance, and external-source loading assumptions are documented in [docs/SECURITY.md](./SECURITY.md).
 For iframe embed deployments and the `postMessage` API contract, see [docs/EMBED.md](./EMBED.md).
 
 ## Deployment Model
 
-The shipped output includes:
+The fixed-base repo deployment includes:
 
 - `dist/index.html`
 - hashed app, worker, and wasm assets under `dist/assets/`
@@ -15,6 +18,21 @@ The shipped output includes:
 - `dist/sw.js` and Workbox runtime files
 
 The app expects to be served from a specific base path. That base path is controlled at build time through `PUBLIC_URL`, and the repo default is also reflected in `package.json#homepage`.
+
+## Publish Artifact
+
+The consumer-facing publish artifact is built separately:
+
+- `dist-publish/`
+- `openscad-web-publish.zip`
+
+This artifact is relocatable by construction:
+
+- Vite builds it with `base: './'`
+- runtime asset resolution derives from `document.baseURI`
+- no post-build `<base href>` rewrite step is required
+
+The publish artifact intentionally does **not** include a service worker in v1.
 
 ## Build Commands
 
@@ -29,6 +47,12 @@ Build the app for the current default deployment root:
 
 ```bash
 npm run build
+```
+
+Build the relocatable publish artifact:
+
+```bash
+npm run build:publish
 ```
 
 Build everything in one shot:
@@ -52,6 +76,8 @@ PUBLIC_URL=/ npm run build
 ```
 
 The build output must be served from the same path it was built for. If `PUBLIC_URL` and the actual hosting path do not match, runtime asset URLs, worker URLs, and service worker scope will be wrong.
+
+The publish artifact is different: it can be mounted at `/` or a subpath like `/model/` without rebuilding because it resolves runtime assets relative to the served page URL.
 
 ## Local Production Smoke Test
 
@@ -96,6 +122,8 @@ Current behavior:
 
 This means deployment behavior is sensitive to the final `dist/` contents, not just the app JS bundle.
 
+The relocatable publish artifact skips the service worker step entirely.
+
 ## Hosting Requirements
 
 Your static host should:
@@ -113,6 +141,13 @@ Before shipping a deployment change, run:
 ```bash
 npm run verify
 npm run test:e2e
+```
+
+Before shipping a publish-artifact change, run:
+
+```bash
+npm run build:publish
+npm run test:e2e:publish
 ```
 
 If you changed dev/prod server behavior or are debugging a local issue:
@@ -134,6 +169,8 @@ Then confirm there are no 404s for:
 - wasm
 - `sw.js`
 - packaged library ZIPs
+
+For publish-artifact validation, confirm both root-mount and subpath-mount smoke runs succeed and that there is no `sw.js` in `dist-publish/` or `openscad-web-publish.zip`.
 
 ## Common Failure Modes
 

--- a/package.json
+++ b/package.json
@@ -24,11 +24,13 @@
   "scripts": {
     "test:e2e": "playwright test",
     "test:e2e:dev": "cross-env E2E_SERVER_MODE=dev NODE_ENV=development playwright test",
+    "test:e2e:publish": "node ./scripts/run-publish-e2e.mjs",
     "test:unit": "vitest run",
     "start:development": "cross-env NODE_ENV=development vite",
     "start:production": "cross-env PUBLIC_URL=/dist/ npm run build && serve -l 3000 .",
     "start": "npm run start:development",
     "build": "cross-env NODE_ENV=production vite build && node ./scripts/build-sw.mjs && node ./scripts/verify-production-build.mjs",
+    "build:publish": "node ./scripts/build-publish.mjs",
     "build:libs": "cross-env LIBS_BUILD_MODE=all node ./scripts/build-assets/cli.mjs",
     "build:libs:clean": "cross-env LIBS_BUILD_MODE=clean node ./scripts/build-assets/cli.mjs",
     "build:libs:wasm": "cross-env LIBS_BUILD_MODE=wasm node ./scripts/build-assets/cli.mjs",
@@ -47,6 +49,7 @@
     "perf:accept": "node scripts/perf/accept-baseline.mjs",
     "perf:accept:local": "node scripts/perf/accept-baseline.mjs --baseline perf-baseline.local.json",
     "perf:ci": "npm run perf:capture:series && npm run perf:compare",
+    "verify:publish-archive": "node ./scripts/verify-publish-archive.mjs",
     "verify": "npm run lint && npm run typecheck && npm run test:unit && npm run build"
   },
   "browserslist": {

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -1,8 +1,21 @@
 import { defineConfig } from '@playwright/test';
 
-const serverMode = process.env.E2E_SERVER_MODE === 'dev' ? 'dev' : 'prod';
-const isProductionServer = serverMode === 'prod';
-const appUrl = isProductionServer ? 'http://localhost:3000/dist/' : 'http://localhost:4000/';
+const serverMode = process.env.E2E_SERVER_MODE ?? 'prod';
+const isDevelopmentServer = serverMode === 'dev';
+const isPublishRootServer = serverMode === 'publish-root';
+const isPublishSubpathServer = serverMode === 'publish-subpath';
+const appUrl = isDevelopmentServer
+  ? 'http://localhost:4000/'
+  : isPublishRootServer
+    ? 'http://localhost:3000/'
+    : isPublishSubpathServer
+      ? 'http://localhost:3000/openscad-web/'
+      : 'http://localhost:3000/dist/';
+const webServerCommand = isDevelopmentServer
+  ? 'npm run start:development'
+  : isPublishRootServer || isPublishSubpathServer
+    ? 'node ./scripts/serve-publish-e2e.mjs'
+    : 'npm run start:production';
 
 export default defineConfig({
   testDir: './tests',
@@ -23,9 +36,10 @@ export default defineConfig({
     },
   },
   webServer: {
-    command: isProductionServer ? 'npm run start:production' : 'npm run start:development',
+    command: webServerCommand,
     url: appUrl,
     timeout: 180_000,
-    reuseExistingServer: process.env.CI !== 'true',
+    reuseExistingServer:
+      process.env.CI !== 'true' && !isPublishRootServer && !isPublishSubpathServer,
   },
 });

--- a/scripts/build-publish.mjs
+++ b/scripts/build-publish.mjs
@@ -1,0 +1,65 @@
+#!/usr/bin/env node
+
+import AdmZip from 'adm-zip';
+import path from 'node:path';
+import { access, rm } from 'node:fs/promises';
+import { spawn } from 'node:child_process';
+import { fileURLToPath } from 'node:url';
+
+const repoRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..');
+const viteBinPath = path.join(repoRoot, 'node_modules', 'vite', 'bin', 'vite.js');
+const verifyBuildScriptPath = path.join(repoRoot, 'scripts', 'verify-production-build.mjs');
+const verifyArchiveScriptPath = path.join(repoRoot, 'scripts', 'verify-publish-archive.mjs');
+const publishConfigPath = path.join(repoRoot, 'vite.publish.config.ts');
+const publishDirPath = path.join(repoRoot, 'dist-publish');
+const publishArchivePath = path.join(repoRoot, 'openscad-web-publish.zip');
+
+function runNodeCommand(args) {
+  return new Promise((resolve, reject) => {
+    const child = spawn(process.execPath, args, {
+      cwd: repoRoot,
+      stdio: 'inherit',
+      env: process.env,
+    });
+
+    child.on('exit', (code) => {
+      if (code === 0) {
+        resolve();
+        return;
+      }
+      reject(new Error(`Command failed with exit code ${code}: ${args.join(' ')}`));
+    });
+
+    child.on('error', reject);
+  });
+}
+
+async function writePublishArchive() {
+  await rm(publishArchivePath, { force: true });
+
+  const archive = new AdmZip();
+  archive.addLocalFolder(publishDirPath);
+  archive.writeZip(publishArchivePath);
+
+  console.log(`[build-publish] Wrote ${publishArchivePath}`);
+}
+
+async function assertPublishDirHasNoServiceWorker() {
+  try {
+    await access(path.join(publishDirPath, 'sw.js'));
+  } catch {
+    return;
+  }
+
+  throw new Error('dist-publish must not include sw.js.');
+}
+
+async function main() {
+  await runNodeCommand([viteBinPath, 'build', '--config', publishConfigPath]);
+  await runNodeCommand([verifyBuildScriptPath, '--dir', publishDirPath]);
+  await assertPublishDirHasNoServiceWorker();
+  await writePublishArchive();
+  await runNodeCommand([verifyArchiveScriptPath, '--zip', publishArchivePath]);
+}
+
+await main();

--- a/scripts/run-publish-e2e.mjs
+++ b/scripts/run-publish-e2e.mjs
@@ -1,0 +1,42 @@
+#!/usr/bin/env node
+
+import { spawn } from 'node:child_process';
+
+function resolveCommand(baseName) {
+  return process.platform === 'win32' ? `${baseName}.cmd` : baseName;
+}
+
+function runCommand(command, args, envOverrides = {}) {
+  return new Promise((resolve, reject) => {
+    const child = spawn(command, args, {
+      stdio: 'inherit',
+      env: {
+        ...process.env,
+        ...envOverrides,
+      },
+    });
+
+    child.on('exit', (code) => {
+      if (code === 0) {
+        resolve();
+        return;
+      }
+      reject(new Error(`Command failed with exit code ${code}: ${command} ${args.join(' ')}`));
+    });
+
+    child.on('error', reject);
+  });
+}
+
+async function main() {
+  const playwrightArgs = ['playwright', 'test', ...process.argv.slice(2)];
+
+  if (process.env.E2E_PUBLISH_SKIP_BUILD !== 'true') {
+    await runCommand(resolveCommand('npm'), ['run', 'build:publish']);
+  }
+
+  await runCommand(resolveCommand('npx'), playwrightArgs, { E2E_SERVER_MODE: 'publish-root' });
+  await runCommand(resolveCommand('npx'), playwrightArgs, { E2E_SERVER_MODE: 'publish-subpath' });
+}
+
+await main();

--- a/scripts/run-publish-e2e.mjs
+++ b/scripts/run-publish-e2e.mjs
@@ -10,6 +10,7 @@ function runCommand(command, args, envOverrides = {}) {
   return new Promise((resolve, reject) => {
     const child = spawn(command, args, {
       stdio: 'inherit',
+      shell: process.platform === 'win32',
       env: {
         ...process.env,
         ...envOverrides,

--- a/scripts/serve-publish-e2e.mjs
+++ b/scripts/serve-publish-e2e.mjs
@@ -1,0 +1,83 @@
+#!/usr/bin/env node
+
+import path from 'node:path';
+import { cp, mkdir, readdir, rm } from 'node:fs/promises';
+import { spawn } from 'node:child_process';
+import { fileURLToPath } from 'node:url';
+
+const repoRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..');
+const publishDirPath = path.join(repoRoot, 'dist-publish');
+const fixtureRootDirPath = path.join(repoRoot, '.publish-e2e');
+const serveBinPath = path.join(repoRoot, 'node_modules', 'serve', 'build', 'main.js');
+
+function getFixtureMode() {
+  const mode = process.env.E2E_SERVER_MODE;
+  if (mode === 'publish-root' || mode === 'publish-subpath') {
+    return mode;
+  }
+
+  throw new Error(`Unsupported E2E_SERVER_MODE for publish fixture server: ${mode ?? '<unset>'}`);
+}
+
+async function prepareFixtureRoot(mode) {
+  const fixtureDirPath = path.join(fixtureRootDirPath, mode);
+  await rm(fixtureDirPath, { recursive: true, force: true });
+  await mkdir(fixtureDirPath, { recursive: true });
+
+  const copyPublishContents = async (targetDirPath) => {
+    await mkdir(targetDirPath, { recursive: true });
+    const entryNames = await readdir(publishDirPath);
+    await Promise.all(
+      entryNames.map((entryName) =>
+        cp(path.join(publishDirPath, entryName), path.join(targetDirPath, entryName), {
+          recursive: true,
+        }),
+      ),
+    );
+  };
+
+  if (mode === 'publish-root') {
+    await copyPublishContents(fixtureDirPath);
+    return fixtureDirPath;
+  }
+
+  const subpathRootDirPath = path.join(fixtureDirPath, 'openscad-web');
+  await copyPublishContents(subpathRootDirPath);
+  return fixtureDirPath;
+}
+
+async function main() {
+  const mode = getFixtureMode();
+  const fixtureServeDirPath = await prepareFixtureRoot(mode);
+
+  console.log(`[serve-publish-e2e] Serving ${fixtureServeDirPath} for ${mode}`);
+
+  const child = spawn(process.execPath, [serveBinPath, '-l', '3000', fixtureServeDirPath], {
+    cwd: repoRoot,
+    stdio: 'inherit',
+    env: process.env,
+  });
+
+  const forwardSignal = (signal) => {
+    if (!child.killed) {
+      child.kill(signal);
+    }
+  };
+
+  process.on('SIGINT', forwardSignal);
+  process.on('SIGTERM', forwardSignal);
+
+  child.on('exit', (code, signal) => {
+    if (signal) {
+      process.kill(process.pid, signal);
+      return;
+    }
+    process.exitCode = code ?? 0;
+  });
+
+  child.on('error', (error) => {
+    throw error;
+  });
+}
+
+await main();

--- a/scripts/verify-production-build.mjs
+++ b/scripts/verify-production-build.mjs
@@ -1,11 +1,22 @@
 import { readdir, readFile } from 'node:fs/promises';
 import path from 'node:path';
 
-const distAssetsDir = path.resolve('dist/assets');
 const forbiddenMarkers = [
   'Logging is enabled!',
   'Lit is in dev mode. Not recommended for production!',
 ];
+
+function getAssetsDirPath() {
+  const dirFlagIndex = process.argv.indexOf('--dir');
+  const buildDirPath =
+    dirFlagIndex === -1 ? path.resolve('dist') : path.resolve(process.argv[dirFlagIndex + 1] ?? '');
+
+  if (dirFlagIndex !== -1 && !process.argv[dirFlagIndex + 1]) {
+    throw new Error('Missing path after --dir');
+  }
+
+  return path.join(buildDirPath, 'assets');
+}
 
 async function listJavaScriptAssets(directory) {
   const entries = await readdir(directory, { withFileTypes: true });
@@ -15,6 +26,7 @@ async function listJavaScriptAssets(directory) {
 }
 
 async function main() {
+  const distAssetsDir = getAssetsDirPath();
   const assetFiles = await listJavaScriptAssets(distAssetsDir);
   if (assetFiles.length === 0) {
     throw new Error(`No JavaScript assets found under ${distAssetsDir}`);

--- a/scripts/verify-publish-archive.mjs
+++ b/scripts/verify-publish-archive.mjs
@@ -1,0 +1,52 @@
+#!/usr/bin/env node
+
+import AdmZip from 'adm-zip';
+import path from 'node:path';
+
+function getArchivePath() {
+  const zipFlagIndex = process.argv.indexOf('--zip');
+  if (zipFlagIndex === -1) {
+    return path.resolve('openscad-web-publish.zip');
+  }
+
+  const zipArg = process.argv[zipFlagIndex + 1];
+  if (!zipArg) {
+    throw new Error('Missing path after --zip');
+  }
+
+  return path.resolve(zipArg);
+}
+
+function assertArchiveHas(entries, entryPath) {
+  if (!entries.has(entryPath)) {
+    throw new Error(`Publish archive is missing required entry: ${entryPath}`);
+  }
+}
+
+function assertArchiveHasPrefix(entryNames, prefix) {
+  if (!entryNames.some((entryName) => entryName.startsWith(prefix))) {
+    throw new Error(`Publish archive is missing required subtree: ${prefix}`);
+  }
+}
+
+async function main() {
+  const archivePath = getArchivePath();
+  const archive = new AdmZip(archivePath);
+  const entryNames = archive
+    .getEntries()
+    .map((entry) => entry.entryName)
+    .filter(Boolean);
+  const entrySet = new Set(entryNames);
+
+  assertArchiveHas(entrySet, 'index.html');
+  assertArchiveHasPrefix(entryNames, 'assets/');
+  assertArchiveHasPrefix(entryNames, 'libraries/');
+
+  if (entrySet.has('sw.js')) {
+    throw new Error('Publish archive must not include sw.js.');
+  }
+
+  console.log(`[verify-publish-archive] Verified ${archivePath}`);
+}
+
+await main();

--- a/src/index.ts
+++ b/src/index.ts
@@ -7,6 +7,7 @@ import {
   shouldPreloadEditorLibraries,
 } from './fs/library-delivery.ts';
 import { ensureBrowserFSLoaded, getBrowserFS } from './runtime/browserfs-runtime.ts';
+import { loadBootConfig, mergeConfigIntoSearch } from './runtime/boot-config.ts';
 import { isProductionBuild } from './runtime/build-env.ts';
 import { registerAppServiceWorker } from './runtime/service-worker.ts';
 import { readStateFromFragment, writeStateInFragment } from './state/fragment-state.ts';
@@ -45,7 +46,12 @@ injectBootstrapPrefetchHints(
 
 window.addEventListener('load', async () => {
   const rootEl = document.getElementById('root')!;
-  const urlModeResult = parseUrlMode(window.location.search);
+  const bootConfig = await loadBootConfig();
+  if (typeof bootConfig.title === 'string' && bootConfig.title.trim() !== '') {
+    document.title = bootConfig.title;
+  }
+
+  const urlModeResult = parseUrlMode(mergeConfigIntoSearch(window.location.search, bootConfig));
 
   if ('error' in urlModeResult) {
     markPerf('osc:app-bootstrap-error');

--- a/src/runner/openscad-worker.ts
+++ b/src/runner/openscad-worker.ts
@@ -19,7 +19,10 @@ import {
 import { fetchSource } from '../utils.ts';
 
 declare const self: DedicatedWorkerGlobalScope;
-const appBaseUrl = new URL(import.meta.env.BASE_URL, self.location.origin).href;
+// The worker bundle always lives under <mount>/assets/, so one parent hop from
+// import.meta.url recovers the app mount regardless of whether the build is
+// fixed-base (/openscad-web/) or relocatable (./).
+const appBaseUrl = new URL('../', import.meta.url).href;
 
 // WASM initializes exactly once per worker lifetime (R4)
 let currentJobId: string | null = null;

--- a/src/runtime/__tests__/asset-urls.test.ts
+++ b/src/runtime/__tests__/asset-urls.test.ts
@@ -37,8 +37,7 @@ describe('resolveDefaultRuntimeBaseUrl', () => {
     expect(
       resolveDefaultRuntimeBaseUrl('./', {
         documentBaseURI: null,
-        workerHref:
-          'https://example.com/openscad-web/assets/openscad-worker-D3It6O_Y.js',
+        workerHref: 'https://example.com/openscad-web/assets/openscad-worker-D3It6O_Y.js',
       }),
     ).toBe('https://example.com/openscad-web/');
   });

--- a/src/runtime/__tests__/asset-urls.test.ts
+++ b/src/runtime/__tests__/asset-urls.test.ts
@@ -32,4 +32,23 @@ describe('resolveDefaultRuntimeBaseUrl', () => {
       }),
     ).toBe('https://example.com/openscad-web/');
   });
+
+  it('uses worker self.location.href to recover mount root for relocatable builds in worker context', () => {
+    expect(
+      resolveDefaultRuntimeBaseUrl('./', {
+        documentBaseURI: null,
+        workerHref:
+          'https://example.com/openscad-web/assets/openscad-worker-D3It6O_Y.js',
+      }),
+    ).toBe('https://example.com/openscad-web/');
+  });
+
+  it('uses worker self.location.href at root mount for relocatable builds in worker context', () => {
+    expect(
+      resolveDefaultRuntimeBaseUrl('./', {
+        documentBaseURI: null,
+        workerHref: 'https://example.com/assets/openscad-worker-D3It6O_Y.js',
+      }),
+    ).toBe('https://example.com/');
+  });
 });

--- a/src/runtime/__tests__/asset-urls.test.ts
+++ b/src/runtime/__tests__/asset-urls.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from 'vitest';
 
-import { resolveRuntimeAssetUrl } from '../asset-urls.ts';
+import { resolveDefaultRuntimeBaseUrl, resolveRuntimeAssetUrl } from '../asset-urls.ts';
 
 describe('resolveRuntimeAssetUrl', () => {
   it('resolves dot-slash asset specifiers against a base URL', () => {
@@ -13,5 +13,23 @@ describe('resolveRuntimeAssetUrl', () => {
     expect(
       resolveRuntimeAssetUrl('assets/runtime-worker.js', 'https://example.com/openscad-web/'),
     ).toBe('https://example.com/openscad-web/assets/runtime-worker.js');
+  });
+});
+
+describe('resolveDefaultRuntimeBaseUrl', () => {
+  it('uses document.baseURI directly for relocatable publish builds', () => {
+    expect(
+      resolveDefaultRuntimeBaseUrl('./', {
+        documentBaseURI: 'https://example.com/store/model/',
+      }),
+    ).toBe('https://example.com/store/model/');
+  });
+
+  it('resolves fixed-base builds against the runtime origin', () => {
+    expect(
+      resolveDefaultRuntimeBaseUrl('/openscad-web/', {
+        runtimeOrigin: 'https://example.com',
+      }),
+    ).toBe('https://example.com/openscad-web/');
   });
 });

--- a/src/runtime/__tests__/boot-config.test.ts
+++ b/src/runtime/__tests__/boot-config.test.ts
@@ -1,0 +1,132 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+import { BOOT_CONFIG_TIMEOUT_MS, loadBootConfig, mergeConfigIntoSearch } from '../boot-config.ts';
+
+describe('loadBootConfig', () => {
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it('returns an empty config for a 404 response', async () => {
+    const fetchImpl = vi.fn(async () => new Response('missing', { status: 404 }));
+
+    await expect(
+      loadBootConfig({
+        fetchImpl: fetchImpl as typeof fetch,
+        configUrl: 'https://example.com/openscad-web.config.json',
+      }),
+    ).resolves.toEqual({});
+  });
+
+  it('returns an empty config for malformed JSON', async () => {
+    const fetchImpl = vi.fn(
+      async () =>
+        new Response('{', {
+          status: 200,
+          headers: { 'content-type': 'application/json' },
+        }),
+    );
+
+    await expect(
+      loadBootConfig({
+        fetchImpl: fetchImpl as typeof fetch,
+        configUrl: 'https://example.com/openscad-web.config.json',
+      }),
+    ).resolves.toEqual({});
+  });
+
+  it('returns an empty config when the fetch times out', async () => {
+    vi.useFakeTimers();
+    const fetchImpl = vi.fn(
+      (_input, init) =>
+        new Promise((_resolve, reject) => {
+          init?.signal?.addEventListener('abort', () => {
+            reject(new DOMException('Aborted', 'AbortError'));
+          });
+        }),
+    );
+
+    const pendingConfig = loadBootConfig({
+      fetchImpl: fetchImpl as typeof fetch,
+      configUrl: 'https://example.com/openscad-web.config.json',
+      timeoutMs: 25,
+    });
+
+    await vi.advanceTimersByTimeAsync(25);
+
+    await expect(pendingConfig).resolves.toEqual({});
+  });
+
+  it('returns the parsed config for a valid response', async () => {
+    const fetchImpl = vi.fn(
+      async () =>
+        new Response(
+          JSON.stringify({
+            model: './project/main.scad',
+            mode: 'customizer',
+            controls: true,
+            download: false,
+            parentOrigin: 'https://store.example.com',
+            title: 'Configured Project',
+            unknown: 'ignored',
+          }),
+          {
+            status: 200,
+            headers: { 'content-type': 'application/json' },
+          },
+        ),
+    );
+
+    await expect(
+      loadBootConfig({
+        fetchImpl: fetchImpl as typeof fetch,
+        configUrl: 'https://example.com/openscad-web.config.json',
+      }),
+    ).resolves.toEqual({
+      model: './project/main.scad',
+      mode: 'customizer',
+      controls: true,
+      download: false,
+      parentOrigin: 'https://store.example.com',
+      title: 'Configured Project',
+    });
+  });
+
+  it('uses the documented default timeout window', () => {
+    expect(BOOT_CONFIG_TIMEOUT_MS).toBe(2_000);
+  });
+});
+
+describe('mergeConfigIntoSearch', () => {
+  it('projects config values into the search string when the URL search is empty', () => {
+    expect(
+      mergeConfigIntoSearch('', {
+        mode: 'embed',
+        model: './project/widget.scad',
+        controls: true,
+        download: false,
+        parentOrigin: 'https://store.example.com',
+        title: 'Ignored Title',
+      }),
+    ).toBe(
+      '?mode=embed&model=.%2Fproject%2Fwidget.scad&controls=true&download=false&parentOrigin=https%3A%2F%2Fstore.example.com',
+    );
+  });
+
+  it('lets URL params override matching config fields', () => {
+    expect(
+      mergeConfigIntoSearch('?mode=customizer&download=true', {
+        mode: 'embed',
+        download: false,
+      }),
+    ).toBe('?mode=customizer&download=true');
+  });
+
+  it('does not include title in the merged search string', () => {
+    expect(
+      mergeConfigIntoSearch('', {
+        title: 'Configured Project',
+      }),
+    ).toBe('');
+  });
+});

--- a/src/runtime/asset-urls.ts
+++ b/src/runtime/asset-urls.ts
@@ -4,18 +4,46 @@ function normalizeAssetSpecifier(assetSpecifier: string): string {
   return assetSpecifier.replace(/^\.\//, '');
 }
 
-function getRuntimeOriginBaseUrl(): string {
-  if (typeof self === 'object' && 'location' in self && self.location?.origin) {
-    return `${self.location.origin}/`;
+function getRuntimeOriginBaseUrl(
+  documentBaseURI?: string | null,
+  runtimeOrigin?: string | null,
+): string {
+  if (runtimeOrigin) {
+    return `${runtimeOrigin}/`;
   }
-  if (typeof document === 'object' && document.baseURI) {
-    return new URL('/', document.baseURI).toString();
+  if (documentBaseURI) {
+    return new URL('/', documentBaseURI).toString();
   }
   throw new Error('Unable to determine a runtime origin for asset resolution.');
 }
 
+export function resolveDefaultRuntimeBaseUrl(
+  baseUrl: string,
+  {
+    documentBaseURI = typeof document === 'object' ? document.baseURI : null,
+    runtimeOrigin = typeof self === 'object' && 'location' in self && self.location?.origin
+      ? self.location.origin
+      : null,
+  }: {
+    documentBaseURI?: string | null;
+    runtimeOrigin?: string | null;
+  } = {},
+): string {
+  if (baseUrl === './') {
+    if (!documentBaseURI) {
+      throw new Error('Unable to determine document.baseURI for relocatable asset resolution.');
+    }
+    return documentBaseURI;
+  }
+
+  return new URL(
+    normalizeBasePath(baseUrl),
+    getRuntimeOriginBaseUrl(documentBaseURI, runtimeOrigin),
+  ).toString();
+}
+
 function getDefaultRuntimeBaseUrl(): string {
-  return new URL(normalizeBasePath(import.meta.env.BASE_URL), getRuntimeOriginBaseUrl()).toString();
+  return resolveDefaultRuntimeBaseUrl(import.meta.env.BASE_URL);
 }
 
 export function resolveRuntimeAssetUrl(

--- a/src/runtime/asset-urls.ts
+++ b/src/runtime/asset-urls.ts
@@ -24,16 +24,29 @@ export function resolveDefaultRuntimeBaseUrl(
     runtimeOrigin = typeof self === 'object' && 'location' in self && self.location?.origin
       ? self.location.origin
       : null,
+    workerHref =
+      typeof document !== 'object' &&
+      typeof self === 'object' &&
+      'location' in self &&
+      (self as { location?: { href?: string } }).location?.href
+        ? (self as { location?: { href?: string } }).location!.href!
+        : null,
   }: {
     documentBaseURI?: string | null;
     runtimeOrigin?: string | null;
+    workerHref?: string | null;
   } = {},
 ): string {
   if (baseUrl === './') {
-    if (!documentBaseURI) {
-      throw new Error('Unable to determine document.baseURI for relocatable asset resolution.');
+    if (documentBaseURI) {
+      return documentBaseURI;
     }
-    return documentBaseURI;
+    if (workerHref) {
+      // Worker context: the worker script lives at <mount>/assets/worker-HASH.js.
+      // Navigate up one level to recover the app mount root.
+      return new URL('../', workerHref).toString();
+    }
+    throw new Error('Unable to determine document.baseURI for relocatable asset resolution.');
   }
 
   return new URL(

--- a/src/runtime/asset-urls.ts
+++ b/src/runtime/asset-urls.ts
@@ -24,13 +24,12 @@ export function resolveDefaultRuntimeBaseUrl(
     runtimeOrigin = typeof self === 'object' && 'location' in self && self.location?.origin
       ? self.location.origin
       : null,
-    workerHref =
-      typeof document !== 'object' &&
-      typeof self === 'object' &&
-      'location' in self &&
-      (self as { location?: { href?: string } }).location?.href
-        ? (self as { location?: { href?: string } }).location!.href!
-        : null,
+    workerHref = typeof document !== 'object' &&
+    typeof self === 'object' &&
+    'location' in self &&
+    (self as { location?: { href?: string } }).location?.href
+      ? (self as { location?: { href?: string } }).location!.href!
+      : null,
   }: {
     documentBaseURI?: string | null;
     runtimeOrigin?: string | null;

--- a/src/runtime/boot-config.ts
+++ b/src/runtime/boot-config.ts
@@ -1,0 +1,90 @@
+export interface BootConfig {
+  model?: string;
+  mode?: string;
+  controls?: boolean;
+  download?: boolean;
+  parentOrigin?: string;
+  title?: string;
+}
+
+export const BOOT_CONFIG_TIMEOUT_MS = 2_000;
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return value != null && typeof value === 'object' && !Array.isArray(value);
+}
+
+function normalizeBootConfig(value: unknown): BootConfig {
+  if (!isRecord(value)) {
+    return {};
+  }
+
+  const config: BootConfig = {};
+
+  if (typeof value.model === 'string') config.model = value.model;
+  if (typeof value.mode === 'string') config.mode = value.mode;
+  if (typeof value.controls === 'boolean') config.controls = value.controls;
+  if (typeof value.download === 'boolean') config.download = value.download;
+  if (typeof value.parentOrigin === 'string') config.parentOrigin = value.parentOrigin;
+  if (typeof value.title === 'string') config.title = value.title;
+
+  return config;
+}
+
+function getBootConfigUrl(): string {
+  if (typeof document === 'object' && document.baseURI) {
+    return new URL('./openscad-web.config.json', document.baseURI).toString();
+  }
+  if (typeof globalThis.location?.href === 'string') {
+    return new URL('./openscad-web.config.json', globalThis.location.href).toString();
+  }
+  return './openscad-web.config.json';
+}
+
+export async function loadBootConfig({
+  fetchImpl = fetch,
+  timeoutMs = BOOT_CONFIG_TIMEOUT_MS,
+  configUrl = getBootConfigUrl(),
+}: {
+  fetchImpl?: typeof fetch;
+  timeoutMs?: number;
+  configUrl?: string;
+} = {}): Promise<BootConfig> {
+  const controller = new AbortController();
+  const timeoutId = setTimeout(() => controller.abort(), timeoutMs);
+
+  try {
+    const response = await fetchImpl(configUrl, {
+      signal: controller.signal,
+      cache: 'no-store',
+    });
+
+    if (!response.ok) {
+      return {};
+    }
+
+    return normalizeBootConfig(await response.json());
+  } catch {
+    return {};
+  } finally {
+    clearTimeout(timeoutId);
+  }
+}
+
+export function mergeConfigIntoSearch(search: string, config: BootConfig): string {
+  const mergedParams = new URLSearchParams();
+
+  if (typeof config.mode === 'string') mergedParams.set('mode', config.mode);
+  if (typeof config.model === 'string') mergedParams.set('model', config.model);
+  if (typeof config.controls === 'boolean') mergedParams.set('controls', String(config.controls));
+  if (typeof config.download === 'boolean') mergedParams.set('download', String(config.download));
+  if (typeof config.parentOrigin === 'string') {
+    mergedParams.set('parentOrigin', config.parentOrigin);
+  }
+
+  for (const [key, value] of new URLSearchParams(search).entries()) {
+    mergedParams.set(key, value);
+  }
+
+  const mergedSearch = mergedParams.toString();
+  return mergedSearch === '' ? '' : `?${mergedSearch}`;
+}

--- a/src/runtime/service-worker.ts
+++ b/src/runtime/service-worker.ts
@@ -2,7 +2,11 @@ import { isProductionBuild } from './build-env.ts';
 import { resolveRuntimeAssetUrl } from './asset-urls.ts';
 
 export async function registerAppServiceWorker(): Promise<ServiceWorkerRegistration | null> {
-  if (!isProductionBuild() || !('serviceWorker' in navigator)) {
+  if (
+    !isProductionBuild() ||
+    import.meta.env.BASE_URL === './' ||
+    !('serviceWorker' in navigator)
+  ) {
     return null;
   }
 

--- a/tests/e2e.spec.ts
+++ b/tests/e2e.spec.ts
@@ -12,7 +12,14 @@ type LoggedMessage = {
 
 const isProductionServer = process.env.E2E_SERVER_MODE !== 'dev';
 const appOrigin = isProductionServer ? 'http://localhost:3000' : 'http://localhost:4000';
-const appBasePath = isProductionServer ? '/dist/' : '/';
+const appBasePath =
+  process.env.E2E_SERVER_MODE === 'publish-root'
+    ? '/'
+    : process.env.E2E_SERVER_MODE === 'publish-subpath'
+      ? '/openscad-web/'
+      : isProductionServer
+        ? '/dist/'
+        : '/';
 const appBaseUrl = new URL(appBasePath, appOrigin).toString();
 const renderTimeoutMs = 60_000;
 const pageMessages = new WeakMap<Page, LoggedMessage[]>();
@@ -290,6 +297,26 @@ async function waitForViewer(page: Page): Promise<void> {
   await waitForRenderState(page);
 }
 
+async function waitForCustomizerShell(page: Page): Promise<void> {
+  await page.waitForSelector('osc-customizer-shell', { timeout: renderTimeoutMs });
+  await page.waitForFunction(
+    () => {
+      const shell = document.querySelector('osc-customizer-shell') as
+        | (Element & { _st?: unknown })
+        | null;
+      const state =
+        shell && '_st' in shell ? (shell._st as Record<string, unknown> | undefined) : null;
+      const output =
+        state && typeof state === 'object' && 'output' in state
+          ? (state.output as Record<string, unknown> | undefined)
+          : undefined;
+      return Boolean(state && !state.rendering && !state.previewing && output);
+    },
+    null,
+    { timeout: renderTimeoutMs },
+  );
+}
+
 async function waitForEmbedViewer(frame: Frame): Promise<void> {
   // Playwright locators pierce shadow DOM; waitForSelector does as well.
   await frame.waitForSelector('[data-testid="viewer-canvas"] canvas', { timeout: renderTimeoutMs });
@@ -499,6 +526,30 @@ test.describe('e2e', () => {
 
     expect(parameter).not.toBeNull();
     expect(parameter?.initial).toBe(10);
+  });
+});
+
+test.describe('boot config', () => {
+  test('can select a default surface, model, and title before URL params are applied', async ({
+    page,
+  }) => {
+    await page.route('**/openscad-web.config.json', async (route) => {
+      await route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify({
+          mode: 'customizer',
+          model: './test-fixture.scad',
+          title: 'Configured Fixture',
+        }),
+      });
+    });
+
+    await page.goto(appBaseUrl);
+    await waitForCustomizerShell(page);
+
+    await expect(page).toHaveTitle('Configured Fixture');
+    await expect(page.locator('osc-customizer-shell')).toHaveCount(1);
   });
 });
 

--- a/tests/e2e.spec.ts
+++ b/tests/e2e.spec.ts
@@ -437,6 +437,8 @@ test.afterEach(async ({ page }, testInfo) => {
     if (message.type !== 'error' && message.type !== 'pageerror') return false;
     if (message.text.includes('net::ERR_CONTENT_LENGTH_MISMATCH')) return false;
     if (message.text.includes('net::ERR_INCOMPLETE_CHUNKED_ENCODING')) return false;
+    // openscad-web.config.json is an optional boot config file; a 404 is expected when not present
+    if (message.location?.url?.includes('openscad-web.config.json')) return false;
     return true;
   });
 

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -1,23 +1,6 @@
-import { readFileSync } from 'node:fs';
-
 import { defineConfig } from 'vite';
 import { normalizeBasePath } from './src/runtime/base-path.ts';
-
-type PackageJsonShape = {
-  homepage?: string;
-};
-
-function getPackageHomepagePath(): string {
-  const packageJson = JSON.parse(
-    readFileSync(new URL('./package.json', import.meta.url), 'utf-8'),
-  ) as PackageJsonShape;
-
-  if (!packageJson.homepage) {
-    return '/';
-  }
-
-  return new URL(packageJson.homepage).pathname;
-}
+import { createAppViteConfig, getPackageHomepagePath } from './vite.shared.ts';
 
 export default defineConfig(({ command }) => {
   const base =
@@ -25,24 +8,5 @@ export default defineConfig(({ command }) => {
       ? '/'
       : normalizeBasePath(process.env.PUBLIC_URL ?? getPackageHomepagePath());
 
-  return {
-    base,
-    publicDir: 'public',
-    optimizeDeps: {
-      entries: ['index.html'],
-    },
-    build: {
-      outDir: 'dist',
-      target: 'es2022',
-      emptyOutDir: true,
-    },
-    server: {
-      host: '127.0.0.1',
-      port: 4000,
-      strictPort: true,
-    },
-    worker: {
-      format: 'iife',
-    },
-  };
+  return createAppViteConfig({ base, outDir: 'dist' });
 });

--- a/vite.publish.config.ts
+++ b/vite.publish.config.ts
@@ -1,0 +1,4 @@
+import { defineConfig } from 'vite';
+import { createAppViteConfig } from './vite.shared.ts';
+
+export default defineConfig(createAppViteConfig({ base: './', outDir: 'dist-publish' }));

--- a/vite.shared.ts
+++ b/vite.shared.ts
@@ -1,0 +1,48 @@
+import { readFileSync } from 'node:fs';
+
+import type { UserConfig } from 'vite';
+
+type PackageJsonShape = {
+  homepage?: string;
+};
+
+export function getPackageHomepagePath(): string {
+  const packageJson = JSON.parse(
+    readFileSync(new URL('./package.json', import.meta.url), 'utf-8'),
+  ) as PackageJsonShape;
+
+  if (!packageJson.homepage) {
+    return '/';
+  }
+
+  return new URL(packageJson.homepage).pathname;
+}
+
+export function createAppViteConfig({
+  base,
+  outDir,
+}: {
+  base: string;
+  outDir: string;
+}): UserConfig {
+  return {
+    base,
+    publicDir: 'public',
+    optimizeDeps: {
+      entries: ['index.html'],
+    },
+    build: {
+      outDir,
+      target: 'es2022',
+      emptyOutDir: true,
+    },
+    server: {
+      host: '127.0.0.1',
+      port: 4000,
+      strictPort: true,
+    },
+    worker: {
+      format: 'iife',
+    },
+  };
+}


### PR DESCRIPTION
This pull request introduces a new "relocatable publish artifact" build for OpenSCAD Web, enabling consumers to deploy the app at any URL path without rebuilding. It adds a dedicated build pipeline, archive packaging, and E2E testing for this artifact, and updates documentation to clarify deployment models and verification steps. Several scripts and configuration changes support this new workflow, ensuring the publish artifact is self-contained, does not include a service worker, and is validated automatically.

**Key changes:**

### New Publish Artifact Build & Verification

* Adds a new npm script `build:publish` that builds a relocatable publish artifact (`dist-publish/` and `openscad-web-publish.zip`) using a dedicated script (`scripts/build-publish.mjs`). This script ensures the artifact is correctly built, excludes the service worker, and is packaged as a zip. [[1]](diffhunk://#diff-83c802b21c751c7ad3a5a6f19035477ab7e4f3521a66f45476076854a8001360R1-R65) [[2]](diffhunk://#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519R27-R33) [[3]](diffhunk://#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519R52)
* Introduces `scripts/verify-publish-archive.mjs` to validate the structure and contents of the publish zip, ensuring required files are present and `sw.js` is absent.
* Updates the release CI workflow (`.github/workflows/release.yml`) to build, test, verify, and publish the new artifact, including moving the major version tag.

### End-to-End Testing for Publish Artifact

* Adds `test:e2e:publish` npm script and supporting scripts (`scripts/run-publish-e2e.mjs`, `scripts/serve-publish-e2e.mjs`) to run E2E tests against both root and subpath deployments of the publish artifact. [[1]](diffhunk://#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519R27-R33) [[2]](diffhunk://#diff-ba4c85669293acbe03e2bf3796a77c86cfde7cca1b54be502e5e46435e72d3caR1-R43) [[3]](diffhunk://#diff-66a479d63ee822df09a53bc27c521bdd572dc2ff6d9fb18317686522a652c13aR1-R83)
* Updates `playwright.config.ts` to support new server modes for E2E tests, allowing tests to run against both standard and publish artifact deployments. [[1]](diffhunk://#diff-f679bf1e58e8dddfc6cff0fa37c8e755c8d2cfc9e6b5dc5520a5800beba59a92L3-R18) [[2]](diffhunk://#diff-f679bf1e58e8dddfc6cff0fa37c8e755c8d2cfc9e6b5dc5520a5800beba59a92L26-R43)

### Documentation Updates

* Expands `docs/DEPLOYMENT.md` to describe the new publish artifact, its relocatable nature, build commands, verification steps, and differences from the fixed-base deployment. [[1]](diffhunk://#diff-ea9864292e6e392d0c8edbabfe41014d61d6ebd2e08f34d8ae21bf9d070fb274L3-R13) [[2]](diffhunk://#diff-ea9864292e6e392d0c8edbabfe41014d61d6ebd2e08f34d8ae21bf9d070fb274R22-R36) [[3]](diffhunk://#diff-ea9864292e6e392d0c8edbabfe41014d61d6ebd2e08f34d8ae21bf9d070fb274R52-R57) [[4]](diffhunk://#diff-ea9864292e6e392d0c8edbabfe41014d61d6ebd2e08f34d8ae21bf9d070fb274R80-R81) [[5]](diffhunk://#diff-ea9864292e6e392d0c8edbabfe41014d61d6ebd2e08f34d8ae21bf9d070fb274R125-R126) [[6]](diffhunk://#diff-ea9864292e6e392d0c8edbabfe41014d61d6ebd2e08f34d8ae21bf9d070fb274R146-R152) [[7]](diffhunk://#diff-ea9864292e6e392d0c8edbabfe41014d61d6ebd2e08f34d8ae21bf9d070fb274R173-R174)

### Application Code Robustness

* Updates asset and base URL resolution logic in `src/runner/openscad-worker.ts` to work for both fixed-base and relocatable builds, ensuring correct runtime asset loading.
* Adjusts boot config and URL mode parsing in `src/index.ts` to merge boot config into search params, supporting dynamic configuration in relocatable deployments. [[1]](diffhunk://#diff-a2a171449d862fe29692ce031981047d7ab755ae7f84c707aef80701b3ea0c80R10) [[2]](diffhunk://#diff-a2a171449d862fe29692ce031981047d7ab755ae7f84c707aef80701b3ea0c80L48-R54)
* Refactors build verification script to accept a custom build directory, supporting validation of both standard and publish artifacts. [[1]](diffhunk://#diff-e42ec4117bfcfb426cb55c24bd60814d69fb02f9565711dfdd1dd4062e3d3ca6L4-R20) [[2]](diffhunk://#diff-e42ec4117bfcfb426cb55c24bd60814d69fb02f9565711dfdd1dd4062e3d3ca6R29)

### Test Improvements

* Adds coverage for new asset URL resolution logic in tests.