### PR TITLE
chore(security): enforce lockfile install-script allowlist in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,6 +28,9 @@ jobs:
       - name: Install dependencies
         run: npm ci
 
+      - name: Guard dependency install scripts
+        run: npm run security:check-install-scripts
+
       - name: Lint
         run: npm run lint
 
@@ -84,6 +87,9 @@ jobs:
       - name: Install dependencies
         run: npm ci
 
+      - name: Guard dependency install scripts
+        run: npm run security:check-install-scripts
+
       - name: Assembly tests
         run: npm run test:assembly
 
@@ -123,6 +129,9 @@ jobs:
 
       - name: Install dependencies
         run: npm ci
+
+      - name: Guard dependency install scripts
+        run: npm run security:check-install-scripts
 
       - name: Install Playwright Chromium
         run: npx playwright install --with-deps chromium
@@ -171,6 +180,9 @@ jobs:
       - name: Install dependencies
         run: npm ci
 
+      - name: Guard dependency install scripts
+        run: npm run security:check-install-scripts
+
       - name: Install Playwright Chromium
         run: npx playwright install --with-deps chromium
 
@@ -217,6 +229,9 @@ jobs:
 
       - name: Install dependencies
         run: npm ci
+
+      - name: Guard dependency install scripts
+        run: npm run security:check-install-scripts
 
       - name: Cache build libs
         id: cache-libs

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -29,6 +29,9 @@ jobs:
 
       - run: npm ci
 
+      - name: Guard dependency install scripts
+        run: npm run security:check-install-scripts
+
       - name: Restore build-libs cache
         id: cache-libs
         uses: actions/cache@v5

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -31,6 +31,9 @@ jobs:
       - name: Install dependencies
         run: npm ci
 
+      - name: Guard dependency install scripts
+        run: npm run security:check-install-scripts
+
       - name: Install Playwright Chromium
         run: npx playwright install --with-deps chromium
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -29,6 +29,7 @@ jobs:
         with:
           node-version: ${{ matrix.node.version }}
       - run: npm ci
+      - run: npm run security:check-install-scripts
 
       - name: Install Playwright Chromium
         if: matrix.node.name == 'supported'

--- a/docs/SECURITY.md
+++ b/docs/SECURITY.md
@@ -125,5 +125,6 @@ The repo automation also includes:
 
 - a pull-request dependency review workflow for dependency diffs
 - a scheduled/manual production dependency audit workflow that runs `npm audit --omit=dev`
+- a lockfile install-script allowlist check (`npm run security:check-install-scripts`) that fails CI when new install-script dependencies appear without an explicit allowlist update
 
 Dependency notices and bundled third-party attributions are maintained in `LICENSE.md`.

--- a/package.json
+++ b/package.json
@@ -51,6 +51,7 @@
     "perf:accept": "node scripts/perf/accept-baseline.mjs",
     "perf:accept:local": "node scripts/perf/accept-baseline.mjs --baseline perf-baseline.local.json",
     "perf:ci": "npm run perf:capture:series && npm run perf:compare",
+    "security:check-install-scripts": "node ./scripts/security/check-install-scripts.mjs",
     "verify:publish-archive": "node ./scripts/verify-publish-archive.mjs",
     "verify": "npm run format:check && npm run lint && npm run typecheck && npm run test:unit && npm run test:assembly && npm run build && npm run build:publish && npm run verify:publish-archive",
     "verify:full": "npm run verify && npm run test:e2e && npm run test:e2e:publish:skip-build"

--- a/scripts/security/check-install-scripts.mjs
+++ b/scripts/security/check-install-scripts.mjs
@@ -6,7 +6,12 @@ const currentFilePath = fileURLToPath(import.meta.url);
 const scriptsSecurityDir = path.dirname(currentFilePath);
 const repoRootDir = path.resolve(scriptsSecurityDir, '..', '..');
 const lockfilePath = path.join(repoRootDir, 'package-lock.json');
-const allowlistPath = path.join(repoRootDir, 'scripts', 'security', 'install-script-allowlist.json');
+const allowlistPath = path.join(
+  repoRootDir,
+  'scripts',
+  'security',
+  'install-script-allowlist.json',
+);
 
 function extractPackageName(lockPackagePath) {
   if (!lockPackagePath.includes('node_modules/')) {
@@ -30,7 +35,10 @@ async function readJson(filePath) {
 }
 
 async function main() {
-  const [lockfileJson, allowlistJson] = await Promise.all([readJson(lockfilePath), readJson(allowlistPath)]);
+  const [lockfileJson, allowlistJson] = await Promise.all([
+    readJson(lockfilePath),
+    readJson(allowlistPath),
+  ]);
   const lockfilePackages = lockfileJson.packages;
 
   if (!lockfilePackages || typeof lockfilePackages !== 'object') {
@@ -66,7 +74,9 @@ async function main() {
   }
 
   const observedPackageNames = [...observedByPackageName.keys()].sort();
-  const unexpectedPackages = observedPackageNames.filter((packageName) => !allowedPackageNames.has(packageName));
+  const unexpectedPackages = observedPackageNames.filter(
+    (packageName) => !allowedPackageNames.has(packageName),
+  );
   const staleAllowlistEntries = [...allowedPackageNames].filter(
     (packageName) => !observedByPackageName.has(packageName),
   );
@@ -91,12 +101,16 @@ async function main() {
       }
     }
 
-    console.error('\nReview dependency changes and update scripts/security/install-script-allowlist.json.');
+    console.error(
+      '\nReview dependency changes and update scripts/security/install-script-allowlist.json.',
+    );
     process.exit(1);
   }
 
   const summary = observedPackageNames.join(', ');
-  console.log(`Dependency install-script policy check passed: ${summary || 'no install-script packages'}`);
+  console.log(
+    `Dependency install-script policy check passed: ${summary || 'no install-script packages'}`,
+  );
 }
 
 await main();

--- a/scripts/security/check-install-scripts.mjs
+++ b/scripts/security/check-install-scripts.mjs
@@ -1,0 +1,102 @@
+import { readFile } from 'node:fs/promises';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const currentFilePath = fileURLToPath(import.meta.url);
+const scriptsSecurityDir = path.dirname(currentFilePath);
+const repoRootDir = path.resolve(scriptsSecurityDir, '..', '..');
+const lockfilePath = path.join(repoRootDir, 'package-lock.json');
+const allowlistPath = path.join(repoRootDir, 'scripts', 'security', 'install-script-allowlist.json');
+
+function extractPackageName(lockPackagePath) {
+  if (!lockPackagePath.includes('node_modules/')) {
+    return null;
+  }
+
+  const pathParts = lockPackagePath.split('node_modules/').filter(Boolean);
+  return pathParts[pathParts.length - 1] ?? null;
+}
+
+function formatObservedEntry(entry) {
+  const flags = [];
+  flags.push(entry.dev ? 'dev' : 'prod');
+  flags.push(entry.optional ? 'optional' : 'required');
+  return `${entry.packagePath} @ ${entry.version} (${flags.join(', ')})`;
+}
+
+async function readJson(filePath) {
+  const contents = await readFile(filePath, 'utf8');
+  return JSON.parse(contents);
+}
+
+async function main() {
+  const [lockfileJson, allowlistJson] = await Promise.all([readJson(lockfilePath), readJson(allowlistPath)]);
+  const lockfilePackages = lockfileJson.packages;
+
+  if (!lockfilePackages || typeof lockfilePackages !== 'object') {
+    throw new Error('package-lock.json is missing a valid "packages" object');
+  }
+
+  const allowedPackageNotes = allowlistJson.allowedPackages;
+  if (!allowedPackageNotes || typeof allowedPackageNotes !== 'object') {
+    throw new Error('install-script-allowlist.json must define an "allowedPackages" object');
+  }
+
+  const allowedPackageNames = new Set(Object.keys(allowedPackageNotes));
+  const observedByPackageName = new Map();
+
+  for (const [packagePath, metadata] of Object.entries(lockfilePackages)) {
+    if (!metadata || metadata.hasInstallScript !== true) {
+      continue;
+    }
+
+    const packageName = extractPackageName(packagePath);
+    if (!packageName) {
+      continue;
+    }
+
+    const list = observedByPackageName.get(packageName) ?? [];
+    list.push({
+      packagePath,
+      version: metadata.version ?? 'unknown',
+      optional: Boolean(metadata.optional),
+      dev: Boolean(metadata.dev),
+    });
+    observedByPackageName.set(packageName, list);
+  }
+
+  const observedPackageNames = [...observedByPackageName.keys()].sort();
+  const unexpectedPackages = observedPackageNames.filter((packageName) => !allowedPackageNames.has(packageName));
+  const staleAllowlistEntries = [...allowedPackageNames].filter(
+    (packageName) => !observedByPackageName.has(packageName),
+  );
+
+  if (unexpectedPackages.length > 0 || staleAllowlistEntries.length > 0) {
+    console.error('Dependency install-script policy check failed.');
+
+    if (unexpectedPackages.length > 0) {
+      console.error('\nUnexpected packages with install scripts:');
+      for (const packageName of unexpectedPackages) {
+        const entries = observedByPackageName.get(packageName) ?? [];
+        for (const entry of entries) {
+          console.error(`- ${packageName}: ${formatObservedEntry(entry)}`);
+        }
+      }
+    }
+
+    if (staleAllowlistEntries.length > 0) {
+      console.error('\nStale allowlist entries (no longer present with install scripts):');
+      for (const packageName of staleAllowlistEntries.sort()) {
+        console.error(`- ${packageName}`);
+      }
+    }
+
+    console.error('\nReview dependency changes and update scripts/security/install-script-allowlist.json.');
+    process.exit(1);
+  }
+
+  const summary = observedPackageNames.join(', ');
+  console.log(`Dependency install-script policy check passed: ${summary || 'no install-script packages'}`);
+}
+
+await main();

--- a/scripts/security/install-script-allowlist.json
+++ b/scripts/security/install-script-allowlist.json
@@ -1,0 +1,6 @@
+{
+  "allowedPackages": {
+    "fsevents": "Optional macOS file watcher dependency.",
+    "puppeteer": "Downloads Chromium binaries used by browser-based test tooling."
+  }
+}


### PR DESCRIPTION
This pull request introduces a new security check to the CI/CD pipeline that enforces an allowlist policy for dependencies with install scripts. The main goal is to prevent unexpected or potentially unsafe dependencies from being added without explicit review and approval. The check is integrated into all major workflow files and will fail CI if any new install-script dependencies are detected or if the allowlist becomes outdated.

**Security improvements:**

* Added a new script `security:check-install-scripts` in `package.json` that checks for dependencies with install scripts against an allowlist.
* Implemented the check logic in `scripts/security/check-install-scripts.mjs`, which scans `package-lock.json` for install scripts and compares them to `scripts/security/install-script-allowlist.json`. The script fails if unauthorized packages are found or if the allowlist contains stale entries.
* Created `scripts/security/install-script-allowlist.json` to explicitly allow only trusted packages (`fsevents` and `puppeteer`).

**CI/CD pipeline integration:**

* Inserted the `npm run security:check-install-scripts` step into all main workflow files (`ci.yml`, `deploy.yml`, `release.yml`, `test.yml`) immediately after dependency installation to ensure the check runs on every pipeline. [[1]](diffhunk://#diff-b803fcb7f17ed9235f1e5cb1fcd2f5d3b2838429d4368ae4c57ce4436577f03fR31-R33) [[2]](diffhunk://#diff-b803fcb7f17ed9235f1e5cb1fcd2f5d3b2838429d4368ae4c57ce4436577f03fR90-R92) [[3]](diffhunk://#diff-b803fcb7f17ed9235f1e5cb1fcd2f5d3b2838429d4368ae4c57ce4436577f03fR133-R135) [[4]](diffhunk://#diff-b803fcb7f17ed9235f1e5cb1fcd2f5d3b2838429d4368ae4c57ce4436577f03fR183-R185) [[5]](diffhunk://#diff-b803fcb7f17ed9235f1e5cb1fcd2f5d3b2838429d4368ae4c57ce4436577f03fR233-R235) [[6]](diffhunk://#diff-28802fbf11c83a2eee09623fb192785e7ca92a3f40602a517c011b947a1822d3R32-R34) [[7]](diffhunk://#diff-87db21a973eed4fef5f32b267aa60fcee5cbdf03c67fafdc2a9b553bb0b15f34R34-R36) [[8]](diffhunk://#diff-faff1af3d8ff408964a57b2e475f69a6b7c7b71c9978cccc8f471798caac2c88R32)

**Documentation updates:**

* Updated `SECURITY.md` to document the new install-script allowlist check and its enforcement in CI.