### PR TITLE
fix(editor): working Chrome paste + add issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,0 +1,80 @@
+name: Bug report
+description: Report a problem with the OpenSCAD Web app, runtime, or tooling.
+title: '[Bug]: '
+labels: ['bug']
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for taking the time to file a bug report. Please fill in as much
+        of the form below as you can — reproduction steps and environment
+        details make issues much faster to resolve.
+  - type: checkboxes
+    id: preflight
+    attributes:
+      label: Preflight checklist
+      options:
+        - label: I searched existing issues and did not find a duplicate.
+          required: true
+        - label: I can reproduce this on the hosted demo or a current build.
+          required: false
+  - type: textarea
+    id: what-happened
+    attributes:
+      label: What happened?
+      description: A clear description of the bug, including what you expected to happen instead.
+      placeholder: When I do X, the app does Y. I expected Z.
+    validations:
+      required: true
+  - type: textarea
+    id: repro
+    attributes:
+      label: Steps to reproduce
+      description: The exact steps someone else can follow to see the bug.
+      placeholder: |
+        1. Open the app at ...
+        2. Click ...
+        3. Observe ...
+    validations:
+      required: true
+  - type: dropdown
+    id: mode
+    attributes:
+      label: Which mode?
+      description: Which surface of the app does this affect?
+      options:
+        - Editor (default)
+        - Customizer
+        - Embed
+        - Build / tooling / not applicable
+    validations:
+      required: true
+  - type: input
+    id: url
+    attributes:
+      label: App URL
+      description: The URL where you saw the bug (you can trim any model fragment if it is large).
+      placeholder: https://cameronbrooks11.github.io/openscad-web/
+  - type: input
+    id: browser
+    attributes:
+      label: Browser and version
+      placeholder: Chrome 126, Firefox 127, Safari 17 ...
+    validations:
+      required: true
+  - type: input
+    id: os
+    attributes:
+      label: Operating system
+      placeholder: Windows 11, macOS 14, Ubuntu 24.04, Android 14 ...
+  - type: textarea
+    id: logs
+    attributes:
+      label: Console output / logs
+      description: Relevant errors from the browser devtools console or the in-app logs panel. This is automatically formatted as code.
+      render: shell
+  - type: textarea
+    id: extra
+    attributes:
+      label: Additional context
+      description: Screenshots, a minimal .scad snippet that triggers the bug, or anything else that helps.

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,8 @@
+blank_issues_enabled: false
+contact_links:
+  - name: OpenSCAD language documentation
+    url: https://openscad.org/documentation.html
+    about: Questions about the OpenSCAD language itself (not this web app) are best answered here.
+  - name: Project documentation
+    url: https://github.com/CameronBrooks11/openscad-web#readme
+    about: Setup, usage, deployment, publishing, and security notes for OpenSCAD Web.

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,0 +1,42 @@
+name: Feature request
+description: Suggest a new capability or an improvement to OpenSCAD Web.
+title: '[Feature]: '
+labels: ['enhancement']
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for suggesting an improvement. Please describe the problem you are
+        trying to solve, not just the solution — it helps us find the best fit.
+  - type: checkboxes
+    id: preflight
+    attributes:
+      label: Preflight checklist
+      options:
+        - label: I searched existing issues and did not find a duplicate.
+          required: true
+  - type: textarea
+    id: problem
+    attributes:
+      label: Problem / motivation
+      description: What are you trying to do, and what makes it hard or impossible today?
+      placeholder: I'm always frustrated when ...
+    validations:
+      required: true
+  - type: textarea
+    id: solution
+    attributes:
+      label: Proposed solution
+      description: What would you like to see happen?
+    validations:
+      required: true
+  - type: textarea
+    id: alternatives
+    attributes:
+      label: Alternatives considered
+      description: Other approaches or workarounds you have tried or thought about.
+  - type: textarea
+    id: extra
+    attributes:
+      label: Additional context
+      description: Mockups, links to relevant OpenSCAD features or libraries, or other context.

--- a/src/components/elements/osc-editor-panel.ts
+++ b/src/components/elements/osc-editor-panel.ts
@@ -440,6 +440,15 @@ export class OscEditorPanel extends LitElement {
                   <hr />
                   <button
                     role="menuitem"
+                    @click=${async () => {
+                      this._menuOpen = false;
+                      await this._pasteFromClipboard();
+                    }}
+                  >
+                    Paste
+                  </button>
+                  <button
+                    role="menuitem"
                     @click=${() => {
                       this._editor?.trigger(activePath, 'editor.action.selectAll', null);
                       this._menuOpen = false;
@@ -540,6 +549,33 @@ export class OscEditorPanel extends LitElement {
   private _toggleMenu(e: Event) {
     e.stopPropagation();
     this._menuOpen = !this._menuOpen;
+  }
+
+  /**
+   * Insert clipboard text at the current selection via the async Clipboard API.
+   *
+   * Monaco's right-click "Paste" relies on `document.execCommand('paste')`,
+   * which Chrome and Safari no longer support, so it silently does nothing
+   * (see GitHub issue #38). Keyboard Ctrl/Cmd+V still works because the browser
+   * delivers a native paste event. This provides a working paste affordance in
+   * the app's own editor menu without touching Monaco's internal context menu.
+   */
+  private async _pasteFromClipboard() {
+    const editor = this._editor;
+    if (!editor) return;
+    let text: string;
+    try {
+      text = await navigator.clipboard.readText();
+    } catch {
+      // Clipboard read can be blocked (denied permission or insecure context).
+      // Ctrl/Cmd+V remains available as the fallback.
+      return;
+    }
+    if (!text) return;
+    const selection = editor.getSelection();
+    if (!selection) return;
+    editor.executeEdits('clipboard-paste', [{ range: selection, text, forceMoveMarkers: true }]);
+    editor.focus();
   }
 }
 


### PR DESCRIPTION
Resolves two open issues.

## #38 — Can't copy-paste on Chrome

**Root cause:** Monaco's right-click **Paste** uses `document.execCommand('paste')`, which Chrome and Safari no longer support, so the menu item silently does nothing. Keyboard Ctrl/Cmd+V was never affected.

**Fix:** Add a working **Paste** entry to the app's own editor (`⋯`) menu, backed by the async Clipboard API (`navigator.clipboard.readText()` → `editor.executeEdits`).
- Public Monaco API only — no internal context-menu surgery, so it is robust against Monaco version bumps.
- Falls back silently if clipboard read is blocked (denied permission / insecure context); Ctrl/Cmd+V remains the keyboard path.
- Verified live in the dev app: `⋯` → Paste inserts clipboard text at the cursor.

Closes #38

## #37 — Issue templates

Add `.github/ISSUE_TEMPLATE/`:
- `bug_report.yml` — captures browser, OS, and app mode (editor/customizer/embed), the details most often missing from runtime reports
- `feature_request.yml`
- `config.yml` — disables blank issues, links to OpenSCAD and project docs

Closes #37

## Verification

- `npm run typecheck` — pass
- `eslint` (changed files) — clean
- `prettier --check` — clean
- `npm run test:unit` — 186/186 pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)