### PR TITLE
fix(editor): make paste work via Ctrl/Cmd+V (#38)

### DIFF
--- a/src/components/elements/osc-editor-panel.ts
+++ b/src/components/elements/osc-editor-panel.ts
@@ -160,6 +160,20 @@ export class OscEditorPanel extends LitElement {
       run: () => this._model.saveProject(),
     });
 
+    // Make paste work across browsers. Monaco's built-in Ctrl/Cmd+V suppresses
+    // the native paste event in this setup but cannot complete its own clipboard
+    // read, so nothing is inserted (see GitHub issue #38). Bind paste explicitly
+    // to the async Clipboard API, which is the path that actually works here.
+    editor.addAction({
+      id: 'openscad-clipboard-paste',
+      label: 'Paste',
+      keybindings: [
+        monaco.KeyMod.CtrlCmd | monaco.KeyCode.KeyV,
+        monaco.KeyMod.Shift | monaco.KeyCode.Insert,
+      ],
+      run: () => this._pasteFromClipboard(),
+    });
+
     // Push source changes to model
     editor.onDidChangeModelContent(() => {
       if (!this._updatingFromState) {
@@ -554,11 +568,12 @@ export class OscEditorPanel extends LitElement {
   /**
    * Insert clipboard text at the current selection via the async Clipboard API.
    *
-   * Monaco's right-click "Paste" relies on `document.execCommand('paste')`,
-   * which Chrome and Safari no longer support, so it silently does nothing
-   * (see GitHub issue #38). Keyboard Ctrl/Cmd+V still works because the browser
-   * delivers a native paste event. This provides a working paste affordance in
-   * the app's own editor menu without touching Monaco's internal context menu.
+   * In this Monaco setup, pressing Ctrl/Cmd+V does not deliver a native paste
+   * event to the editor, and Monaco's own paste (which relies on
+   * `document.execCommand('paste')`) is blocked by the browser — so neither the
+   * keyboard shortcut nor the right-click "Paste" inserts anything (see GitHub
+   * issue #38). This method is bound to Ctrl/Cmd+V (and exposed in the editor
+   * menu) so paste works regardless of the browser's clipboard event behavior.
    */
   private async _pasteFromClipboard() {
     const editor = this._editor;

--- a/tests/paste.spec.ts
+++ b/tests/paste.spec.ts
@@ -1,0 +1,84 @@
+import { expect, test, type Page } from '@playwright/test';
+
+// Regression coverage for issue #38: pasting copied code into the editor.
+// In this Monaco setup the browser's native Ctrl/Cmd+V does not reach the
+// editor, so paste is bound explicitly to the async Clipboard API. These tests
+// exercise the real key path in a browser with a real system clipboard.
+
+const isProductionServer = process.env.E2E_SERVER_MODE !== 'dev';
+const appOrigin = isProductionServer ? 'http://localhost:3000' : 'http://localhost:4000';
+const appBasePath =
+  process.env.E2E_SERVER_MODE === 'publish-root'
+    ? '/'
+    : process.env.E2E_SERVER_MODE === 'publish-subpath'
+      ? '/openscad-web/'
+      : isProductionServer
+        ? '/dist/'
+        : '/';
+const appBaseUrl = new URL(appBasePath, appOrigin).toString();
+
+async function loadSrc(page: Page, src: string): Promise<void> {
+  const url = new URL(appBaseUrl);
+  url.hash = `src=${encodeURIComponent(src)}`;
+  await page.goto(url.toString());
+}
+
+async function waitForEditor(page: Page): Promise<void> {
+  await page.waitForFunction(
+    () => {
+      const p = document.querySelector('osc-editor-panel') as
+        | (Element & { _editor?: { getValue(): string } })
+        | null;
+      return Boolean(p && p._editor);
+    },
+    null,
+    { timeout: 30_000 },
+  );
+}
+
+async function editorValue(page: Page): Promise<string> {
+  return page.evaluate(() => {
+    const p = document.querySelector('osc-editor-panel') as
+      | (Element & { _editor?: { getValue(): string } })
+      | null;
+    return p?._editor?.getValue() ?? '<no-editor>';
+  });
+}
+
+test.describe('editor paste (#38)', () => {
+  // grantPermissions for the clipboard is Chromium-only; skip elsewhere.
+  test.skip(
+    ({ browserName }) => browserName !== 'chromium',
+    'clipboard permission grant is Chromium-only',
+  );
+
+  test('Ctrl/Cmd+V pastes clipboard text into the editor', async ({ page, context }) => {
+    await context.grantPermissions(['clipboard-read', 'clipboard-write']);
+    await loadSrc(page, 'cube(1);');
+    await waitForEditor(page);
+
+    const marker = 'PASTED_VIA_CTRL_V_OK';
+    await page.evaluate((t) => navigator.clipboard.writeText(t), marker);
+
+    await page.locator('.osc-editor-monaco .monaco-editor').click();
+    await page.keyboard.press('Control+A');
+    await page.keyboard.press('Control+V');
+
+    await expect.poll(() => editorValue(page)).toContain(marker);
+  });
+
+  test('editor menu "Paste" inserts clipboard text', async ({ page, context }) => {
+    await context.grantPermissions(['clipboard-read', 'clipboard-write']);
+    await loadSrc(page, 'cube(1);');
+    await waitForEditor(page);
+
+    const marker = 'PASTED_VIA_MENU_OK';
+    await page.evaluate((t) => navigator.clipboard.writeText(t), marker);
+
+    await page.locator('.osc-editor-monaco .monaco-editor').click();
+    await page.getByRole('button', { name: 'Editor menu' }).click();
+    await page.getByRole('menuitem', { name: 'Paste' }).click();
+
+    await expect.poll(() => editorValue(page)).toContain(marker);
+  });
+});


### PR DESCRIPTION
## Description
Pasting into the Monaco editor did nothing on Chrome, Edge, and Firefox. The browser's native paste event never reaches the editor in this setup, and Monaco's own paste (`document.execCommand('paste')`) is blocked, so neither the keyboard shortcut nor the right-click menu inserted anything.

This binds **Ctrl/Cmd+V** (and Shift+Insert) to the async Clipboard API, inserting via `executeEdits` — the path that works regardless of the browser's clipboard-event behavior.

## How to test
1. Copy text from any app.
2. Click into the editor and press Ctrl/Cmd+V (Chrome shows a one-time "allow clipboard" dialog — allow it).
3. Text is inserted. The ⋯ → Paste menu item also works.

Verified manually on Chrome, Edge, and Firefox, plus an automated real-Chromium Playwright regression test (`tests/paste.spec.ts`).

Refs #38