### PR TITLE
refactor(tsconfig): type-check the OpenSCAD worker (#46)

### DIFF
--- a/src/__tests__/tsconfig-coverage.test.ts
+++ b/src/__tests__/tsconfig-coverage.test.ts
@@ -1,0 +1,32 @@
+import { readFileSync } from 'node:fs';
+import * as path from 'node:path';
+
+// Guards issue #46: the OpenSCAD worker — and any other authored TypeScript
+// source — must stay in the type-checked program. Excluding a real source file
+// from tsconfig hides type errors in critical code, so fail loudly if it ever
+// creeps back.
+
+function readTsconfigExclude(): string[] {
+  const tsconfigPath = path.join(process.cwd(), 'tsconfig.json');
+  const raw = readFileSync(tsconfigPath, 'utf8');
+  // tsconfig.json permits comments; strip whole-line `//` comments before parsing.
+  const stripped = raw
+    .split('\n')
+    .filter((line) => !/^\s*\/\//.test(line))
+    .join('\n');
+  const parsed = JSON.parse(stripped) as { exclude?: string[] };
+  return parsed.exclude ?? [];
+}
+
+describe('tsconfig type-check coverage', () => {
+  const exclude = readTsconfigExclude();
+
+  it('does not exclude the OpenSCAD worker', () => {
+    expect(exclude).not.toContain('src/runner/openscad-worker.ts');
+  });
+
+  it('does not exclude any authored .ts source file', () => {
+    const excludedTs = exclude.filter((entry) => entry.endsWith('.ts'));
+    expect(excludedTs).toEqual([]);
+  });
+});

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -25,5 +25,8 @@
     }
   },
   "include": ["src/**/*.ts", "src/**/*.js"],
-  "exclude": ["node_modules", "src/wasm/*.js", "src/runner/openscad-worker.ts"]
+  // src/wasm/*.js are generated Emscripten glue files that are not authored TypeScript.
+  // The worker (src/runner/openscad-worker.ts) is type-checked like the rest of src; it
+  // carries its own `/// <reference lib="webworker" />`.
+  "exclude": ["node_modules", "src/wasm/*.js"]
 }


### PR DESCRIPTION
## What
`src/runner/openscad-worker.ts` was excluded from `tsconfig.json`, so the worker — which owns the synchronous WASM `callMain` boundary — was never type-checked. This removes the exclusion; CI's `npx tsc --noEmit` now covers it. The worker type-checks cleanly under the project's existing `DOM` + `WebWorker` libs (it carries its own `/// <reference lib="webworker" />`).

## Scope decision
The issue floated a dedicated WebWorker-only tsconfig to isolate worker types from DOM. That isolation is **not achievable in this issue**: a WebWorker-only lib surfaces 26 errors in shared modules (`utils.ts`, `filesystem.ts`, `asset-urls.ts`, `browserfs-runtime.ts`) that legitimately use `window`/`document` in their app code paths. Untangling those is the work of the later filesystem-isolation / decomposition issues, so a clean split is deferred to them rather than forced here (which would mean either broken compilation or premature refactors). Three config files carrying identical libs would add ceremony with no isolation benefit.

## Tests
- New guard test (`src/__tests__/tsconfig-coverage.test.ts`) fails if the worker — or any authored `.ts` — is re-excluded.
- `tsc --noEmit`, ESLint, Prettier, and unit tests (188) all pass.

Closes #46