### PR TITLE
fix(runner): recover a wedged OpenSCAD worker on timeout (#47)

### DIFF
--- a/src/runner/__tests__/worker-timeout.test.ts
+++ b/src/runner/__tests__/worker-timeout.test.ts
@@ -1,0 +1,138 @@
+// Regression coverage for issue #47: a hung OpenSCAD worker must be recovered.
+//
+// callMain() is a synchronous WASM call. If it wedges, the worker can process no
+// further messages, so the runner must terminate and recreate it on timeout
+// rather than leaving every subsequent compile blocked on a dead worker.
+//
+// A real stuck worker never responds to ANY message, so the FakeWorker here
+// hangs per-instance: a worker created in "hang" mode answers nothing until it
+// is terminated and a fresh worker is created.
+
+// openscad-runner imports mountDemandLibraries from filesystem.ts; stub the
+// module so the heavy BrowserFS graph is not pulled into the test.
+vi.mock('../../fs/filesystem.ts', () => ({
+  mountDemandLibraries: vi.fn().mockResolvedValue([]),
+  symlinkLibraries: vi.fn().mockResolvedValue(undefined),
+  createEditorFS: vi.fn().mockResolvedValue(undefined),
+}));
+
+// The runner's per-job timeout (kept in sync with SOFT/COMPILE timeout in the runner).
+const TIMEOUT_MS = 30_000;
+
+type WorkerResponseMessage = {
+  type: 'result';
+  id: string;
+  exitCode: number;
+  outputs: [string, Uint8Array][];
+  mergedOutputs: unknown[];
+  elapsedMillis: number;
+};
+
+const createdWorkers: FakeWorker[] = [];
+let nextWorkerHangs = false;
+
+class FakeWorker {
+  onmessage: ((e: MessageEvent) => void) | null = null;
+  onerror: ((e: ErrorEvent) => void) | null = null;
+  readonly hangs: boolean;
+  terminated = false;
+
+  constructor() {
+    this.hangs = nextWorkerHangs;
+    createdWorkers.push(this);
+  }
+
+  postMessage(msg: { type: string; id: string }) {
+    if (msg.type !== 'compile') return;
+    if (this.hangs) return; // a wedged worker never answers any message
+    const response: WorkerResponseMessage = {
+      type: 'result',
+      id: msg.id,
+      exitCode: 0,
+      outputs: [],
+      mergedOutputs: [],
+      elapsedMillis: 0,
+    };
+    setTimeout(() => this.onmessage?.({ data: response } as MessageEvent), 0);
+  }
+
+  terminate() {
+    this.terminated = true;
+  }
+}
+
+beforeAll(() => {
+  (globalThis as unknown as Record<string, unknown>).Worker = FakeWorker;
+});
+
+let spawnOpenSCAD: typeof import('../openscad-runner.ts').spawnOpenSCAD;
+
+beforeEach(async () => {
+  vi.resetModules();
+  vi.useFakeTimers();
+  createdWorkers.length = 0;
+  nextWorkerHangs = false;
+  ({ spawnOpenSCAD } = await import('../openscad-runner.ts'));
+});
+
+afterEach(() => {
+  vi.useRealTimers();
+});
+
+describe('worker timeout recovery (#47)', () => {
+  it('terminates a wedged worker on timeout and recovers on the next compile', async () => {
+    nextWorkerHangs = true;
+    const hung = spawnOpenSCAD({ mountArchives: false, args: ['a.scad'] }, () => {});
+    const hungOutcome = hung.then(
+      () => 'resolved',
+      (e) => e as Error,
+    );
+
+    await vi.advanceTimersByTimeAsync(TIMEOUT_MS + 100);
+
+    const err = await hungOutcome;
+    expect(err).toBeInstanceOf(Error);
+    expect(String(err)).toMatch(/timed out/i);
+
+    // The wedged worker must have been terminated (not left running).
+    expect(createdWorkers[0].terminated).toBe(true);
+
+    // The next compile must run on a fresh worker and succeed.
+    nextWorkerHangs = false;
+    const next = spawnOpenSCAD({ mountArchives: false, args: ['b.scad'] }, () => {});
+    await vi.advanceTimersByTimeAsync(10);
+    const result = await next;
+
+    expect(result.exitCode).toBe(0);
+    expect(createdWorkers).toHaveLength(2); // a clean worker was created lazily
+    expect(createdWorkers[1].terminated).toBe(false);
+  });
+
+  it('ignores a late response from a terminated worker generation', async () => {
+    nextWorkerHangs = true;
+    const hung = spawnOpenSCAD({ mountArchives: false, args: ['a.scad'] }, () => {});
+    const hungOutcome = hung.then(
+      () => 'resolved',
+      (e) => e as Error,
+    );
+    await vi.advanceTimersByTimeAsync(TIMEOUT_MS + 100);
+    await hungOutcome;
+
+    const oldWorker = createdWorkers[0];
+    expect(oldWorker.terminated).toBe(true);
+
+    // A message arriving late from the terminated worker must be ignored, not throw.
+    expect(() =>
+      oldWorker.onmessage?.({
+        data: {
+          type: 'result',
+          id: '1',
+          exitCode: 0,
+          outputs: [],
+          mergedOutputs: [],
+          elapsedMillis: 0,
+        },
+      } as MessageEvent),
+    ).not.toThrow();
+  });
+});

--- a/src/runner/openscad-runner.ts
+++ b/src/runner/openscad-runner.ts
@@ -69,30 +69,52 @@ type PendingJob = {
   streamsCallback: (ps: ProcessStreams) => void;
   priority: number;
   startTime: number;
-  softTimeoutHandle: ReturnType<typeof setTimeout> | null;
-  hardTimeoutHandle: ReturnType<typeof setTimeout> | null;
+  timeoutHandle: ReturnType<typeof setTimeout> | null;
 };
 
 const _pending = new Map<string, PendingJob>();
 let _nextId = 0;
 let _worker: Worker | null = null;
+// Identifies the current worker. Bumped whenever the worker is torn down so that
+// late messages from a terminated worker cannot resolve or affect newer jobs.
+let _workerGeneration = 0;
 let _firstCompileRequested = false;
 let _firstCompileCompleted = false;
 
-// Timeout thresholds
-const SOFT_TIMEOUT_MS = 30_000;
-const HARD_TIMEOUT_MS = 60_000;
+// A compile that has not produced a result within this window means the worker
+// is wedged (callMain is synchronous and cannot be interrupted), so the worker
+// is terminated and recreated rather than left blocking all future work.
+const COMPILE_TIMEOUT_MS = 30_000;
 
 function getWorker(): Worker {
   if (!_worker) {
+    const generation = _workerGeneration;
     _worker = createOpenSCADWorker();
-    _worker.onmessage = handleWorkerMessage;
+    _worker.onmessage = (e: MessageEvent<WorkerResponse>) => handleWorkerMessage(e, generation);
     _worker.onerror = handleWorkerError;
   }
   return _worker;
 }
 
-function handleWorkerMessage(e: MessageEvent<WorkerResponse>): void {
+// Terminate the current worker and reject every job bound to it. The next
+// request lazily creates a clean worker (getWorker). This is the recovery path
+// for a wedged or crashed worker.
+function recycleWorker(reason: string): void {
+  if (_worker) {
+    _worker.terminate();
+    _worker = null;
+  }
+  _workerGeneration++;
+  for (const [, job] of _pending) {
+    clearJobTimers(job);
+    job.reject(new Error(reason));
+  }
+  _pending.clear();
+}
+
+function handleWorkerMessage(e: MessageEvent<WorkerResponse>, generation: number): void {
+  // Ignore messages from a worker generation that has since been terminated.
+  if (generation !== _workerGeneration) return;
   const msg = e.data;
   const job = _pending.get(msg.id);
   if (!job) return; // stale response — job was cancelled or timed out
@@ -132,18 +154,11 @@ function handleWorkerMessage(e: MessageEvent<WorkerResponse>): void {
 
 function handleWorkerError(e: ErrorEvent): void {
   console.error('OpenSCAD worker crashed:', e.message);
-  // Reject all pending jobs and reset the worker
-  for (const [, job] of _pending) {
-    clearJobTimers(job);
-    job.reject(new Error('Worker crashed: ' + e.message));
-  }
-  _pending.clear();
-  _worker = null; // will be recreated on next request
+  recycleWorker('Worker crashed: ' + e.message);
 }
 
 function clearJobTimers(job: PendingJob): void {
-  if (job.softTimeoutHandle != null) clearTimeout(job.softTimeoutHandle);
-  if (job.hardTimeoutHandle != null) clearTimeout(job.hardTimeoutHandle);
+  if (job.timeoutHandle != null) clearTimeout(job.timeoutHandle);
 }
 
 function recordCompilePerf(job: PendingJob, perf?: CompilePerfStats): void {
@@ -213,41 +228,23 @@ export function spawnOpenSCAD(
       streamsCallback,
       priority: incomingPriority,
       startTime: performance.now(),
-      softTimeoutHandle: null,
-      hardTimeoutHandle: null,
+      timeoutHandle: null,
     };
 
-    // Soft timeout: reject promise, discard late response.
-    // Must also clear the hard-timeout timer — if we don't, the hard-timeout
-    // fires later and recycles the worker even though this job is already gone,
-    // interrupting any unrelated compile that started in the meantime.
-    job.softTimeoutHandle = setTimeout(() => {
-      if (_pending.has(id)) {
-        _pending.delete(id);
-        clearTimeout(job.hardTimeoutHandle ?? undefined);
-        job.hardTimeoutHandle = null;
-        _worker?.postMessage({ type: 'cancel', id } satisfies CancelRequest);
-        reject(new Error(`Compile timed out after ${SOFT_TIMEOUT_MS / 1000}s`));
-      }
-    }, SOFT_TIMEOUT_MS);
-
-    // Hard timeout: recycle worker if it remains blocked.
-    // Guard on _pending.has(id): the job may have been resolved, cancelled, or
-    // soft-timed-out already — in that case we must NOT recycle the worker.
-    job.hardTimeoutHandle = setTimeout(() => {
-      if (!_pending.has(id)) return; // job already finished — nothing to do
-      if (_worker) {
-        console.warn('[runner] Hard timeout reached — recycling worker');
-        _worker.terminate();
-        _worker = null;
-      }
-      // Clear any residual jobs
-      for (const [, j] of _pending) {
-        clearJobTimers(j);
-        j.reject(new Error('Worker recycled after hard timeout'));
-      }
-      _pending.clear();
-    }, HARD_TIMEOUT_MS);
+    // Timeout: the worker has produced no result in time. Because callMain is a
+    // synchronous WASM call, a wedged worker can process neither this job nor any
+    // queued or future request — so reject this job and recycle the worker so the
+    // next request runs on a clean one. recycleWorker() rejects the remaining
+    // pending jobs (which are stuck behind this one on the same worker).
+    job.timeoutHandle = setTimeout(() => {
+      const stuck = _pending.get(id);
+      if (!stuck) return; // already resolved, cancelled, or superseded
+      clearJobTimers(stuck);
+      _pending.delete(id);
+      reject(new Error(`Compile timed out after ${COMPILE_TIMEOUT_MS / 1000}s`));
+      console.warn(`[runner] Compile ${id} timed out after ${COMPILE_TIMEOUT_MS / 1000}s`);
+      recycleWorker('Worker recycled after timeout');
+    }, COMPILE_TIMEOUT_MS);
 
     _pending.set(id, job);
 


### PR DESCRIPTION
## Problem
The runner's soft timeout deleted the job from `_pending` **and** cleared the hard-timeout handle. The hard timeout's recycle is guarded on `_pending.has(id)`, so once the soft path removed the job, the recycle never fired. A genuinely hung synchronous `callMain` left the worker permanently blocked, and every subsequent request was posted to that dead worker.

## Fix
Replace the two-tier soft/hard timeout with a single timeout that **recovers** the worker:
- terminate the wedged worker and lazily recreate a clean one on the next request;
- bump a `_workerGeneration` id so late messages from a terminated worker are ignored;
- reject the jobs bound to that generation with a clear error.

Queued-job cancellation (`cancelJobById`, used for priority supersession and explicit aborts) stays a distinct, non-terminating path — only an unrecoverable wedged/crashed worker triggers a teardown. The worker-crash handler now routes through the same `recycleWorker` recovery.

## Tests
New `src/runner/__tests__/worker-timeout.test.ts` (fails before, passes after):
- a worker that hangs on every message is terminated on timeout, and the next compile succeeds on a fresh worker;
- a late response from a terminated worker generation is ignored.

`tsc`, ESLint, Prettier, and the full unit suite (190) pass.

Closes #47