### PR TITLE
fix(runner): deterministic debounce/supersede scheduling (#48)

### DIFF
--- a/src/__tests__/utils.test.ts
+++ b/src/__tests__/utils.test.ts
@@ -15,7 +15,7 @@ describe('turnIntoDelayableExecution – kill cancels pending timeout (BUG-7)', 
   beforeEach(() => vi.useFakeTimers());
   afterEach(() => vi.useRealTimers());
 
-  it('kill() before timeout prevents job from executing', () => {
+  it('kill() before timeout prevents job from executing and rejects the promise', async () => {
     let executed = false;
     const job = vi.fn(() =>
       AbortablePromise<void>((res) => {
@@ -27,15 +27,130 @@ describe('turnIntoDelayableExecution – kill cancels pending timeout (BUG-7)', 
 
     const delayable = turnIntoDelayableExecution(1000, job);
     const promise = delayable()({ now: false });
+    const outcome = promise.then(
+      () => 'resolved',
+      (e) => (e as Error).message,
+    );
 
     // kill before the 1000ms timeout fires
     promise.kill();
 
     // advance all timers — job must NOT run
-    vi.runAllTimers();
+    await vi.runAllTimersAsync();
 
     expect(executed).toBe(false);
     expect(job).not.toHaveBeenCalled();
+    // The promise must settle (rejected) rather than leak as a pending orphan.
+    expect(await outcome).toBe('Cancelled');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// #48 — deterministic settlement and supersession
+// ---------------------------------------------------------------------------
+
+describe('turnIntoDelayableExecution – settlement & supersession (#48)', () => {
+  beforeEach(() => vi.useFakeTimers());
+  afterEach(() => vi.useRealTimers());
+
+  type JobController = {
+    resolve: (v: string) => void;
+    reject: (e: unknown) => void;
+    wasKilled: () => boolean;
+  };
+
+  function makeJob() {
+    const controllers: JobController[] = [];
+    const job = vi.fn((..._args: unknown[]) => {
+      let resolveFn!: (v: string) => void;
+      let rejectFn!: (e: unknown) => void;
+      let killed = false;
+      const p = AbortablePromise<string>((resolve, reject) => {
+        resolveFn = resolve;
+        rejectFn = reject;
+        return () => {
+          killed = true;
+          reject(new Error('Cancelled'));
+        };
+      });
+      controllers.push({ resolve: resolveFn, reject: rejectFn, wasKilled: () => killed });
+      return p;
+    });
+    return { job, controllers };
+  }
+
+  const outcome = (p: Promise<string>) =>
+    p.then(
+      (v) => `res:${v}`,
+      (e) => `rej:${e instanceof Error ? e.message : String(e)}`,
+    );
+
+  it('rejects a superseded delayed call without ever running its job', async () => {
+    const { job } = makeJob();
+    const delayable = turnIntoDelayableExecution(1000, job);
+
+    const first = outcome(delayable('a')({ now: false }));
+    delayable('b')({ now: false }).catch(() => {}); // supersedes the first before either runs
+
+    expect(await first).toBe('rej:Cancelled');
+    expect(job).not.toHaveBeenCalled(); // still inside the debounce window
+  });
+
+  it('runs only the latest delayed call after the debounce delay', async () => {
+    const { job, controllers } = makeJob();
+    const delayable = turnIntoDelayableExecution(1000, job);
+
+    outcome(delayable('a')({ now: false }));
+    const second = outcome(delayable('b')({ now: false }));
+
+    await vi.advanceTimersByTimeAsync(1000);
+    expect(job).toHaveBeenCalledTimes(1);
+    expect(job).toHaveBeenCalledWith('b');
+
+    controllers[0].resolve('B');
+    expect(await second).toBe('res:B');
+  });
+
+  it('rejects a superseded running call and resolves only the newer one', async () => {
+    const { job, controllers } = makeJob();
+    const delayable = turnIntoDelayableExecution(0, job);
+
+    const first = outcome(delayable('a')({ now: true })); // runs immediately
+    const second = outcome(delayable('b')({ now: true })); // supersedes & kills the first
+
+    expect(controllers[0].wasKilled()).toBe(true);
+    expect(await first).toBe('rej:Cancelled');
+
+    controllers[1].resolve('B');
+    expect(await second).toBe('res:B');
+  });
+
+  it('settles exactly once — a late resolve of a superseded job is ignored', async () => {
+    const { job, controllers } = makeJob();
+    const delayable = turnIntoDelayableExecution(0, job);
+
+    const first = outcome(delayable('a')({ now: true }));
+    delayable('b')({ now: true }).catch(() => {}); // supersede → first rejects Cancelled
+
+    expect(await first).toBe('rej:Cancelled');
+    controllers[0].resolve('late'); // must not flip the already-settled promise
+    expect(await first).toBe('rej:Cancelled');
+  });
+
+  it('keeps a running job cancellable after an earlier job finishes (no clobber race)', async () => {
+    const { job, controllers } = makeJob();
+    const delayable = turnIntoDelayableExecution(0, job);
+
+    delayable('a')({ now: true }).catch(() => {}); // job 0 runs
+    delayable('b')({ now: true }).catch(() => {}); // supersedes/kills job 0; job 1 runs
+    expect(controllers[0].wasKilled()).toBe(true);
+
+    // Let job 0's settlement/finally flush — in the buggy version this nulled the
+    // shared kill signal and left job 1 uncancellable.
+    await vi.advanceTimersByTimeAsync(0);
+
+    delayable('c')({ now: true }).catch(() => {}); // must still be able to supersede/kill job 1
+    expect(controllers[1].wasKilled()).toBe(true);
   });
 });
 

--- a/src/state/model.ts
+++ b/src/state/model.ts
@@ -40,6 +40,15 @@ export class Model extends EventTarget {
     super();
   }
 
+  // Sequence counters identifying the latest in-flight operation of each kind.
+  // checkSyntax/render debounce and supersede one another (turnIntoDelayableExecution),
+  // so a superseded call settles (rejects) while a newer one owns the shared UI
+  // flags — these guards stop the stale call from clobbering the newer call's
+  // previewing/rendering/checkingSyntax state.
+  private _previewSeq = 0;
+  private _renderSeq = 0;
+  private _syntaxSeq = 0;
+
   init() {
     if (
       !this.state.output &&
@@ -288,18 +297,22 @@ export class Model extends EventTarget {
   }
 
   async checkSyntax() {
+    const token = ++this._syntaxSeq;
+    const isCurrent = () => this._syntaxSeq === token;
     this.mutate((s) => (s.checkingSyntax = true));
     try {
       const checkerRun = await checkSyntax({
         activePath: this.state.params.activePath,
         sources: this.state.params.sources,
       })({ now: false });
+      if (!isCurrent()) return; // a newer syntax check superseded this one
       this.mutate((s) => {
         s.lastCheckerRun = checkerRun;
         s.parameterSet = checkerRun?.parameterSet;
         s.checkingSyntax = false;
       });
     } catch (err) {
+      if (!isCurrent()) return; // superseded — the newer check owns checkingSyntax
       if (!isExpectedJobCancellation(err)) {
         if (!isUserFacingOperationError(err)) {
           console.error('Error while checking syntax:', err);
@@ -309,9 +322,11 @@ export class Model extends EventTarget {
         });
       }
     } finally {
-      this.mutate((s) => {
-        if (s.checkingSyntax) s.checkingSyntax = false;
-      });
+      if (isCurrent()) {
+        this.mutate((s) => {
+          if (s.checkingSyntax) s.checkingSyntax = false;
+        });
+      }
     }
   }
 
@@ -566,6 +581,10 @@ export class Model extends EventTarget {
     // console.log(JSON.stringify(this.state, null, 2));
     mountArchives ??= true;
     retryInOtherDim ??= true;
+    // A render and a preview own separate UI flags; track the latest of each so a
+    // superseded call cannot turn off the spinner a newer call is still driving.
+    const token = isPreview ? ++this._previewSeq : ++this._renderSeq;
+    const isCurrent = () => (isPreview ? this._previewSeq : this._renderSeq) === token;
     const setRendering = (s: State, value: boolean) => {
       if (isPreview) {
         s.previewing = value;
@@ -615,6 +634,7 @@ export class Model extends EventTarget {
     };
     try {
       const output = await render(renderArgs)({ now });
+      if (!isCurrent()) return; // a newer render/preview superseded this one
       const displayFile = output.outFile;
       if (output.outFile.name.endsWith('.svg') || output.outFile.name.endsWith('.dxf')) {
         is2D = true;
@@ -656,6 +676,7 @@ export class Model extends EventTarget {
         }
       });
     } catch (err) {
+      if (!isCurrent()) return; // superseded — the newer call owns the spinner state
       this.mutate((s) => {
         setRendering(s, false);
         if (!isExpectedJobCancellation(err)) {

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -30,50 +30,77 @@ export function AbortablePromise<T>(
   return Object.assign(promise, { kill: kill! });
 }
 
-// <T extends unknown[]>(...args: T)
+// Rejection message used when a delayable call is superseded by a newer one or
+// killed before it finishes. Recognized by isExpectedJobCancellation so the UI
+// treats it as benign rather than a real failure.
+export const DELAYABLE_CANCELLED_MESSAGE = 'Cancelled';
+
+/**
+ * Wraps `job` so that rapid calls debounce and supersede one another: at most one
+ * execution is live at a time, and a newer call cancels the previous one whether
+ * it is still waiting out the debounce delay or already running.
+ *
+ * Every returned promise settles exactly once — resolved on success, rejected on
+ * job failure, or rejected with `DELAYABLE_CANCELLED_MESSAGE` when superseded or
+ * killed. Superseded calls are never left pending.
+ */
 export function turnIntoDelayableExecution<T extends unknown[], R>(
   delay: number,
   job: (...args: T) => AbortablePromise<R>,
 ) {
-  let pendingId: number | null;
-  let runningJobKillSignal: (() => void) | null;
+  // Cancels whichever call is currently live (pending-delayed or running).
+  // Identity-checked on cleanup so a finished job cannot clobber a newer one's.
+  let cancelLive: (() => void) | null = null;
+
   return (...args: T) =>
     ({ now }: { now: boolean }) =>
       AbortablePromise<R>((resolve, reject) => {
-        let abortablePromise: AbortablePromise<R> | undefined = undefined;
-        (async () => {
-          const doExecute = async () => {
-            if (runningJobKillSignal) {
-              runningJobKillSignal();
-              runningJobKillSignal = null;
-            }
-            abortablePromise = job(...args);
-            runningJobKillSignal = abortablePromise.kill;
-            try {
-              resolve(await abortablePromise);
-            } catch (e) {
-              reject(e);
-            } finally {
-              runningJobKillSignal = null;
-            }
-          };
-          if (pendingId) {
-            clearTimeout(pendingId);
-            pendingId = null;
+        let settled = false;
+        const settleResolve = (r: R) => {
+          if (!settled) {
+            settled = true;
+            resolve(r);
           }
-          if (now) {
-            doExecute();
-          } else {
-            pendingId = window.setTimeout(doExecute, delay);
-          }
-        })();
-        return () => {
-          if (pendingId) {
-            clearTimeout(pendingId);
-            pendingId = null;
-          }
-          abortablePromise?.kill();
         };
+        const settleReject = (e: unknown) => {
+          if (!settled) {
+            settled = true;
+            reject(e);
+          }
+        };
+
+        // Supersede the previously-live call before starting this one.
+        cancelLive?.();
+
+        let timer: ReturnType<typeof setTimeout> | null = null;
+        let runningJob: AbortablePromise<R> | undefined;
+
+        const cancelThis = () => {
+          if (timer != null) {
+            clearTimeout(timer);
+            timer = null;
+          }
+          runningJob?.kill();
+          settleReject(new Error(DELAYABLE_CANCELLED_MESSAGE));
+        };
+        cancelLive = cancelThis;
+
+        const execute = () => {
+          timer = null;
+          runningJob = job(...args);
+          runningJob.then(settleResolve, settleReject).finally(() => {
+            // Only release the shared signal if this call is still the live one.
+            if (cancelLive === cancelThis) cancelLive = null;
+          });
+        };
+
+        if (now) {
+          execute();
+        } else {
+          timer = setTimeout(execute, delay);
+        }
+
+        return cancelThis;
       });
 }
 


### PR DESCRIPTION
## Problem
`turnIntoDelayableExecution` shared a single pending timer and a single `runningJobKillSignal` across every call of a wrapped operation:
- a superseded **delayed** call had its timer cleared but its promise was **never settled** — an orphaned promise leaked on normal rapid editing;
- killing a delayed call cleared the timer but also left the promise pending forever;
- a finished job's `finally { runningJobKillSignal = null }` could clobber the signal a **newer** job had just stored, leaving the newer job uncancellable (race).

## Fix
Rewrite the primitive so each call owns its own timer and canceller, and every returned promise reaches exactly one terminal state — resolved, failed, or rejected with a cancellation error when superseded/killed. The shared "live canceller" is identity-checked on cleanup so a finished job can't null a newer job's canceller.

Because superseded calls now **settle (reject)** instead of hanging, `Model.render` and `Model.checkSyntax` get per-kind sequence guards so a stale, superseded call cannot turn off the `previewing` / `rendering` / `checkingSyntax` flag that a newer call is still driving. (Previously the model relied on superseded promises never settling — that's the behaviour being made explicit and correct.)

## Tests
- New unit coverage in `utils.test.ts`: superseded-delayed rejects without running its job; only the latest delayed call runs; superseded-running rejects while the newer one resolves; exactly-once settlement; the clobber race (a running job stays cancellable after an earlier one finishes). The existing kill-before-timeout test now also asserts the promise settles.
- Full Playwright e2e suite (21 tests, incl. F5/F6 sequential renders and syntax markers) passes — confirming spinner state is unaffected.
- `tsc`, ESLint, Prettier, unit suite (195) green.

Closes #48