### PR TITLE
fix(model): write fetched source to the file it was requested for (#49)

### DIFF
--- a/src/state/__tests__/source-fetch-race.test.ts
+++ b/src/state/__tests__/source-fetch-race.test.ts
@@ -1,0 +1,126 @@
+// Regression coverage for issue #49: an in-flight source fetch must write its
+// content back to the file it was fetched for — never whichever file happens to
+// be active when the fetch resolves.
+
+import { Model } from '../model.ts';
+import { State } from '../app-state.ts';
+import { defaultModelColor } from '../initial-state.ts';
+
+// Avoid touching the real runner (Worker/WASM) and heavy IO.
+vi.mock('../../runner/actions.ts', () => {
+  const makeDelayable = (resolvedValue: unknown) =>
+    vi.fn().mockReturnValue(vi.fn().mockResolvedValue(resolvedValue));
+  return {
+    checkSyntax: makeDelayable({ logText: '', markers: [], parameterSet: undefined }),
+    render: makeDelayable({
+      outFile: new File([''], 't.off'),
+      logText: '',
+      markers: [],
+      elapsedMillis: 0,
+    }),
+    getDefaultCompileArgs: vi.fn().mockReturnValue(['--backend=manifold']),
+  };
+});
+vi.mock('../../io/import_off.ts', () => ({ parseOff: vi.fn() }));
+
+// Controllable fetchSource; everything else in utils stays real.
+vi.mock('../../utils.ts', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('../../utils.ts')>();
+  return { ...actual, fetchSource: vi.fn() };
+});
+
+import { fetchSource } from '../../utils.ts';
+
+const mockFetchSource = fetchSource as ReturnType<typeof vi.fn>;
+
+type FetchController = { resolve: (data: Uint8Array) => void; reject: (e: unknown) => void };
+
+function makeMockFs() {
+  return {
+    readFileSync: vi.fn(() => new Uint8Array(0)),
+    writeFile: vi.fn(),
+    isFile: vi.fn(() => false),
+  };
+}
+
+function stateWithUrlSources(): State {
+  return {
+    params: {
+      activePath: '/a.scad',
+      sources: [
+        { path: '/a.scad', url: 'a.scad' },
+        { path: '/b.scad', url: 'b.scad' },
+      ],
+      features: [],
+      exportFormat2D: 'svg',
+      exportFormat3D: 'stl',
+      autoCompile: false, // keep the test focused on the fetch write-back
+    },
+    view: {
+      layout: {
+        mode: 'multi',
+        editor: true,
+        viewer: true,
+        customizer: false,
+      } as State['view']['layout'],
+      color: defaultModelColor,
+      showAxes: true,
+      lineNumbers: false,
+    },
+  };
+}
+
+async function flush(n = 4) {
+  for (let i = 0; i < n; i++) await new Promise<void>((r) => setTimeout(r, 0));
+}
+
+describe('source fetch write-back race (#49)', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    Object.defineProperty(global, 'URL', {
+      value: { createObjectURL: vi.fn(() => 'blob:x'), revokeObjectURL: vi.fn() },
+      writable: true,
+      configurable: true,
+    });
+  });
+
+  it('writes fetched content to the originally requested file after the active file changes', async () => {
+    const controllers = new Map<string, FetchController>();
+    mockFetchSource.mockImplementation(
+      (_fs: unknown, src: { path: string }) =>
+        new Promise<Uint8Array>((resolve, reject) => {
+          controllers.set(src.path, { resolve, reject });
+        }),
+    );
+
+    const model = new Model(
+      makeMockFs() as unknown as FS,
+      stateWithUrlSources(),
+      undefined,
+      undefined,
+    );
+
+    // Start fetching /a.scad (the active file).
+    model.init();
+    await flush();
+    expect(controllers.has('/a.scad')).toBe(true);
+
+    // Switch to /b.scad while /a.scad's fetch is still in flight.
+    model.openFile('/b.scad');
+    await flush();
+    expect(model.state.params.activePath).toBe('/b.scad');
+
+    // /a.scad's fetch now resolves.
+    controllers.get('/a.scad')!.resolve(new TextEncoder().encode('A_CONTENT'));
+    await flush();
+
+    const sources = model.state.params.sources;
+    const a = sources.find((s) => s.path === '/a.scad');
+    const b = sources.find((s) => s.path === '/b.scad');
+
+    // Content landed in /a.scad...
+    expect(a?.content).toBe('A_CONTENT');
+    // ...and NOT in the now-active /b.scad.
+    expect(b?.content ?? null).not.toBe('A_CONTENT');
+  });
+});

--- a/src/state/model.ts
+++ b/src/state/model.ts
@@ -256,23 +256,40 @@ export class Model extends EventTarget {
   } = {}) {
     const src = this.state.params.sources.find((src) => src.path === this.state.params.activePath);
     if (src && src.content == null) {
+      const requestedPath = src.path;
+      const { url } = src;
       try {
-        const { path } = src;
-        const { url } = src;
         const content = new TextDecoder().decode(
-          await fetchSource(this.fs, { path, url }, { baseUrl: window.location.href }),
+          await fetchSource(
+            this.fs,
+            { path: requestedPath, url },
+            { baseUrl: window.location.href },
+          ),
         );
+        // The active file may have changed while the fetch was in flight. Write
+        // the content back to the source it was actually fetched for — never
+        // whichever file is active now — and only if that source still needs it.
+        let written = false;
         this.mutate((s) => {
-          s.params.sources = s.params.sources.map((src) =>
-            src.path === s.params.activePath ? { ...src, content } : src,
+          const target = s.params.sources.find((cur) => cur.path === requestedPath);
+          if (!target || target.content != null) return; // source removed or already filled
+          s.params.sources = s.params.sources.map((cur) =>
+            cur.path === requestedPath ? { ...cur, content } : cur,
           );
           s.error = undefined;
           s.errorDetails = undefined;
+          written = true;
         });
+        // If the user has since switched away, a newer processSource owns the
+        // active file's compilation — don't drive a render for the file they left.
+        if (!written || requestedPath !== this.state.params.activePath) return;
       } catch (err) {
-        this.mutate((s) => {
-          this.applyUserFacingError(s, err, 'source');
-        });
+        // Only surface the error if this fetch is still for the active file.
+        if (requestedPath === this.state.params.activePath) {
+          this.mutate((s) => {
+            this.applyUserFacingError(s, err, 'source');
+          });
+        }
         return;
       }
     }


### PR DESCRIPTION
## Problem
`Model.processSource()` captured the source path before `await fetchSource(...)`, but the write-back keyed on the **current** `activePath`:
```ts
src.path === s.params.activePath ? { ...src, content } : src
```
If the user switched active files while the fetch was in flight, file A's fetched content was written into file B — a data-integrity race.

## Fix
- Write the content back to the **originally requested path**, never the now-active one.
- Skip the write if that source was removed or already filled (stale fetch).
- Only surface a fetch error if the file is still active.
- Don't drive a render/check for a file the user has navigated away from — a newer `processSource` owns the active file.

## Tests
New `source-fetch-race.test.ts` starts a fetch for `/a.scad`, switches to `/b.scad` mid-flight, resolves the fetch, and asserts the content lands in `/a.scad` (not `/b.scad`). Fails before, passes after. Existing model tests, `tsc`, ESLint, Prettier, and the URL/path-loading e2e tests all pass.

Closes #49