### PR TITLE
security(model): validate and bound imported ZIP archives (#50)

### DIFF
--- a/src/fs/__tests__/project-path.test.ts
+++ b/src/fs/__tests__/project-path.test.ts
@@ -1,0 +1,50 @@
+import { normalizeProjectPath, ProjectPathError } from '../project-path.ts';
+
+describe('normalizeProjectPath (#50)', () => {
+  it('accepts and normalizes plain relative paths', () => {
+    expect(normalizeProjectPath('main.scad')).toBe('main.scad');
+    expect(normalizeProjectPath('lib/util.scad')).toBe('lib/util.scad');
+  });
+
+  it('collapses "." segments and redundant slashes', () => {
+    expect(normalizeProjectPath('./a/./b.scad')).toBe('a/b.scad');
+    expect(normalizeProjectPath('a//b///c.scad')).toBe('a/b/c.scad');
+  });
+
+  it('converts backslashes to forward slashes', () => {
+    expect(normalizeProjectPath('lib\\sub\\file.scad')).toBe('lib/sub/file.scad');
+  });
+
+  it('rejects parent-directory traversal', () => {
+    expect(() => normalizeProjectPath('../evil.scad')).toThrow(ProjectPathError);
+    expect(() => normalizeProjectPath('a/../../evil.scad')).toThrow(ProjectPathError);
+    expect(() => normalizeProjectPath('lib\\..\\..\\evil.scad')).toThrow(ProjectPathError);
+  });
+
+  it('rejects absolute, drive-letter, and UNC paths', () => {
+    expect(() => normalizeProjectPath('/etc/passwd')).toThrow(ProjectPathError);
+    expect(() => normalizeProjectPath('C:\\Windows\\system32')).toThrow(ProjectPathError);
+    // UNC: backslashes become slashes first, so it reads as an absolute path.
+    expect(() => normalizeProjectPath('\\\\server\\share\\f.scad')).toThrow(ProjectPathError);
+  });
+
+  it('keeps literal dotted segments (... ) as harmless filenames, not traversal', () => {
+    expect(normalizeProjectPath('.../f.scad')).toBe('.../f.scad');
+    expect(normalizeProjectPath('a/.../b.scad')).toBe('a/.../b.scad');
+  });
+
+  it('rejects NUL and control characters', () => {
+    expect(() => normalizeProjectPath('a\x00b.scad')).toThrow(ProjectPathError);
+    expect(() => normalizeProjectPath('a\nb.scad')).toThrow(ProjectPathError);
+  });
+
+  it('rejects empty paths and paths that resolve to nothing', () => {
+    expect(() => normalizeProjectPath('')).toThrow(ProjectPathError);
+    expect(() => normalizeProjectPath('.')).toThrow(ProjectPathError);
+    expect(() => normalizeProjectPath('./')).toThrow(ProjectPathError);
+  });
+
+  it('rejects over-long paths', () => {
+    expect(() => normalizeProjectPath('a/'.repeat(600) + 'f.scad')).toThrow(ProjectPathError);
+  });
+});

--- a/src/fs/project-path.ts
+++ b/src/fs/project-path.ts
@@ -1,0 +1,68 @@
+// Canonical validation for project-relative paths coming from untrusted sources
+// (imported archives, fetched manifests, host-supplied file lists). Centralized
+// so every entry point applies the same rules and writes stay within the project
+// root.
+
+/** Maximum length of a single relative path. */
+export const MAX_PROJECT_PATH_LENGTH = 1024;
+/** Maximum number of files accepted from one imported archive. */
+export const MAX_PROJECT_FILE_COUNT = 2000;
+/** Maximum total uncompressed bytes accepted from one imported archive (64 MiB). */
+export const MAX_PROJECT_TOTAL_BYTES = 64 * 1024 * 1024;
+
+export class ProjectPathError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = 'ProjectPathError';
+  }
+}
+
+/**
+ * Normalize an untrusted relative path to a safe, project-relative form.
+ *
+ * Converts backslashes to forward slashes, collapses `.` segments and redundant
+ * slashes, and rejects anything that could escape the project root or smuggle in
+ * control characters: absolute paths, drive letters, `..` traversal, NUL/control
+ * characters, and over-long paths.
+ *
+ * @returns the normalized relative path (e.g. `sub/dir/file.scad`)
+ * @throws {ProjectPathError} if the path is unsafe.
+ */
+export function normalizeProjectPath(rawPath: string): string {
+  if (typeof rawPath !== 'string' || rawPath.length === 0) {
+    throw new ProjectPathError('Empty path.');
+  }
+  if (rawPath.length > MAX_PROJECT_PATH_LENGTH) {
+    throw new ProjectPathError(`Path exceeds ${MAX_PROJECT_PATH_LENGTH} characters.`);
+  }
+
+  const path = rawPath.replace(/\\/g, '/');
+
+  for (let i = 0; i < path.length; i++) {
+    if (path.charCodeAt(i) < 0x20 || path.charCodeAt(i) === 0x7f) {
+      throw new ProjectPathError('Path contains control characters.');
+    }
+  }
+
+  if (path.startsWith('/')) {
+    throw new ProjectPathError(`Absolute paths are not allowed: ${rawPath}`);
+  }
+  if (/^[a-zA-Z]:/.test(path)) {
+    throw new ProjectPathError(`Drive-letter paths are not allowed: ${rawPath}`);
+  }
+
+  const segments: string[] = [];
+  for (const segment of path.split('/')) {
+    if (segment === '' || segment === '.') continue;
+    if (segment === '..') {
+      throw new ProjectPathError(`Path traversal is not allowed: ${rawPath}`);
+    }
+    segments.push(segment);
+  }
+
+  if (segments.length === 0) {
+    throw new ProjectPathError(`Path resolves to nothing: ${rawPath}`);
+  }
+
+  return segments.join('/');
+}

--- a/src/state/__tests__/zip-import.test.ts
+++ b/src/state/__tests__/zip-import.test.ts
@@ -1,0 +1,174 @@
+// Regression coverage for issue #50: importProjectZip must reject archive
+// entries that would escape /home, and import well-formed archives normally.
+
+import { Model } from '../model.ts';
+import { State } from '../app-state.ts';
+import { defaultSourcePath, defaultModelColor } from '../initial-state.ts';
+import { MAX_PROJECT_FILE_COUNT, MAX_PROJECT_TOTAL_BYTES } from '../../fs/project-path.ts';
+
+vi.mock('../../runner/actions.ts', () => {
+  const makeDelayable = (resolvedValue: unknown) =>
+    vi.fn().mockReturnValue(vi.fn().mockResolvedValue(resolvedValue));
+  return {
+    checkSyntax: makeDelayable({ logText: '', markers: [], parameterSet: undefined }),
+    render: makeDelayable({
+      outFile: new File([''], 't.off'),
+      logText: '',
+      markers: [],
+      elapsedMillis: 0,
+    }),
+    getDefaultCompileArgs: vi.fn().mockReturnValue(['--backend=manifold']),
+  };
+});
+vi.mock('../../io/import_off.ts', () => ({ parseOff: vi.fn() }));
+
+// Control archive contents deterministically without depending on JSZip's own
+// name handling.
+vi.mock('jszip', () => ({ default: { loadAsync: vi.fn() } }));
+import JSZip from 'jszip';
+const mockLoadAsync = (JSZip as unknown as { loadAsync: ReturnType<typeof vi.fn> }).loadAsync;
+
+function fakeZip(entries: Record<string, string>) {
+  const files: Record<string, { dir: boolean; async: () => Promise<string> }> = {};
+  for (const [name, content] of Object.entries(entries)) {
+    files[name] = { dir: false, async: () => Promise.resolve(content) };
+  }
+  return { files };
+}
+
+function makeMockFs() {
+  return {
+    readFileSync: vi.fn(() => new Uint8Array(0)),
+    writeFile: vi.fn(),
+    isFile: vi.fn(() => false),
+  };
+}
+
+function baseState(): State {
+  return {
+    params: {
+      activePath: defaultSourcePath,
+      sources: [{ path: defaultSourcePath, content: 'cube(1);' }],
+      features: [],
+      exportFormat2D: 'svg',
+      exportFormat3D: 'stl',
+      autoCompile: false,
+    },
+    view: {
+      layout: {
+        mode: 'multi',
+        editor: true,
+        viewer: true,
+        customizer: false,
+      } as State['view']['layout'],
+      color: defaultModelColor,
+      showAxes: true,
+      lineNumbers: false,
+    },
+  };
+}
+
+describe('importProjectZip validation (#50)', () => {
+  let model: Model;
+  let mockFs: ReturnType<typeof makeMockFs>;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    Object.defineProperty(global, 'URL', {
+      value: { createObjectURL: vi.fn(() => 'blob:x'), revokeObjectURL: vi.fn() },
+      writable: true,
+      configurable: true,
+    });
+    mockFs = makeMockFs();
+    model = new Model(mockFs as unknown as FS, baseState(), undefined, undefined);
+  });
+
+  it('imports a well-formed archive into /home', async () => {
+    mockLoadAsync.mockResolvedValue(fakeZip({ 'main.scad': 'cube(2);', 'lib/util.scad': 'x' }));
+
+    await model.importProjectZip(new ArrayBuffer(0));
+
+    expect(mockFs.writeFile).toHaveBeenCalledWith('/home/main.scad', 'cube(2);');
+    expect(mockFs.writeFile).toHaveBeenCalledWith('/home/lib/util.scad', 'x');
+    expect(model.state.params.activePath).toBe('/home/main.scad');
+    expect(model.state.error).toBeUndefined();
+  });
+
+  it('rejects a traversal entry and writes nothing outside the project root', async () => {
+    mockLoadAsync.mockResolvedValue(fakeZip({ '../../evil.scad': 'pwned' }));
+
+    await model.importProjectZip(new ArrayBuffer(0));
+
+    // No write may reference a traversal path...
+    for (const call of mockFs.writeFile.mock.calls) {
+      expect(String(call[0])).not.toContain('..');
+    }
+    // ...the whole import is rejected with a surfaced error.
+    expect(model.state.error).toBeTruthy();
+  });
+
+  it('rejects an absolute-path entry', async () => {
+    mockLoadAsync.mockResolvedValue(fakeZip({ '/etc/passwd': 'x' }));
+
+    await model.importProjectZip(new ArrayBuffer(0));
+
+    expect(mockFs.writeFile).not.toHaveBeenCalled();
+    expect(model.state.error).toBeTruthy();
+  });
+
+  it('rejects the whole archive atomically when any entry is unsafe', async () => {
+    // A valid file alongside a traversal entry: nothing should be written.
+    mockLoadAsync.mockResolvedValue(fakeZip({ 'main.scad': 'cube(1);', '../evil.scad': 'pwned' }));
+
+    await model.importProjectZip(new ArrayBuffer(0));
+
+    expect(mockFs.writeFile).not.toHaveBeenCalled();
+    expect(model.state.error).toBeTruthy();
+  });
+
+  it('rejects duplicate normalized paths', async () => {
+    mockLoadAsync.mockResolvedValue(fakeZip({ 'main.scad': 'a', './main.scad': 'b' }));
+
+    await model.importProjectZip(new ArrayBuffer(0));
+
+    expect(mockFs.writeFile).not.toHaveBeenCalled();
+    expect(model.state.error).toBeTruthy();
+  });
+
+  it('rejects an archive with too many files', async () => {
+    const entries: Record<string, string> = {};
+    for (let i = 0; i <= MAX_PROJECT_FILE_COUNT; i++) entries[`f${i}.scad`] = 'x';
+    mockLoadAsync.mockResolvedValue(fakeZip(entries));
+
+    await model.importProjectZip(new ArrayBuffer(0));
+
+    expect(mockFs.writeFile).not.toHaveBeenCalled();
+    expect(model.state.error).toBeTruthy();
+  });
+
+  it('rejects an archive that exceeds the uncompressed size limit', async () => {
+    mockLoadAsync.mockResolvedValue(
+      fakeZip({ 'big.scad': 'x'.repeat(MAX_PROJECT_TOTAL_BYTES + 1) }),
+    );
+
+    await model.importProjectZip(new ArrayBuffer(0));
+
+    expect(mockFs.writeFile).not.toHaveBeenCalled();
+    expect(model.state.error).toBeTruthy();
+  });
+
+  it('tolerates a writeFile failure and still loads the sources', async () => {
+    mockLoadAsync.mockResolvedValue(fakeZip({ 'main.scad': 'cube(3);', 'lib/util.scad': 'y' }));
+    mockFs.writeFile.mockImplementation((p: string) => {
+      if (p.includes('/lib/')) throw new Error('ENOENT'); // missing parent dir in the VFS
+    });
+
+    await model.importProjectZip(new ArrayBuffer(0));
+
+    expect(model.state.params.sources.map((s) => s.path)).toEqual([
+      '/home/main.scad',
+      '/home/lib/util.scad',
+    ]);
+    expect(model.state.error).toBeUndefined();
+  });
+});

--- a/src/state/model.ts
+++ b/src/state/model.ts
@@ -17,6 +17,12 @@ import {
   readFileAsDataURL,
 } from '../utils.ts';
 import { openLocalFile, saveActiveFile } from '../fs/filesystem.ts';
+import {
+  MAX_PROJECT_FILE_COUNT,
+  MAX_PROJECT_TOTAL_BYTES,
+  normalizeProjectPath,
+  ProjectPathError,
+} from '../fs/project-path.ts';
 
 import JSZip from 'jszip';
 import { isExpectedJobCancellation, ProcessStreams } from '../runner/openscad-runner.ts';
@@ -492,17 +498,38 @@ export class Model extends EventTarget {
   async importProjectZip(zipBuffer: ArrayBuffer): Promise<void> {
     try {
       const zip = await JSZip.loadAsync(zipBuffer);
-      const files: [string, string][] = [];
-      for (const [relPath, zipObj] of Object.entries(zip.files)) {
-        if (!zipObj.dir) {
-          files.push([relPath, await zipObj.async('string')]);
-        }
+      const entries = Object.entries(zip.files).filter(([, zipObj]) => !zipObj.dir);
+      if (entries.length > MAX_PROJECT_FILE_COUNT) {
+        throw new ProjectPathError(`Archive has too many files (max ${MAX_PROJECT_FILE_COUNT}).`);
       }
-      for (const [relPath, content] of files) {
+      // Validate and bound EVERY entry before writing ANY of them, so a malicious
+      // archive is rejected atomically (no partial extraction). The size limit is
+      // an approximate cumulative guard over decoded entry lengths (UTF-16 units);
+      // a single entry is still fully decoded before its length is counted.
+      const files: [string, string][] = [];
+      const seen = new Set<string>();
+      let totalSize = 0;
+      for (const [relPath, zipObj] of entries) {
+        const safePath = normalizeProjectPath(relPath);
+        if (seen.has(safePath)) {
+          throw new ProjectPathError(`Duplicate path in archive: ${safePath}`);
+        }
+        seen.add(safePath);
+        const content = await zipObj.async('string');
+        totalSize += content.length;
+        if (totalSize > MAX_PROJECT_TOTAL_BYTES) {
+          throw new ProjectPathError('Archive exceeds the uncompressed size limit.');
+        }
+        files.push([safePath, content]);
+      }
+      // Paths are validated above; FS write failures (e.g. a missing parent dir in
+      // the worker VFS) are best-effort and must not abort the whole import — the
+      // file content is still surfaced via s.params.sources below.
+      for (const [safePath, content] of files) {
         try {
-          this.fs.writeFile(`/home/${relPath}`, content);
+          this.fs.writeFile(`/home/${safePath}`, content);
         } catch {
-          /* ignore */
+          /* best-effort: source is still loaded into the editor below */
         }
       }
       const entryRel = (files.find(([p]) => p === 'main.scad') ??


### PR DESCRIPTION
## Problem
`importProjectZip()` wrote each archive entry to `/home/${relPath}` with no sanitization — no rejection of `..`, absolute/backslash/UNC paths, NUL bytes, duplicates, or normalized escapes, and no limit on file count or total uncompressed size. A crafted archive could write outside the project root in the virtual filesystem or exhaust memory.

## Fix
- New `src/fs/project-path.ts` — a reusable `normalizeProjectPath()` that converts `\`→`/`, collapses `.`/redundant slashes, and rejects absolute, drive-letter, UNC, `..`-traversal, control-character, and over-long paths.
- `importProjectZip` validates **every** entry before writing **any** (atomic rejection), rejects duplicate normalized paths, and bounds `MAX_PROJECT_FILE_COUNT` / `MAX_PROJECT_TOTAL_BYTES`.
- FS write failures stay best-effort (a missing parent dir in the worker VFS no longer aborts the whole import — the source is still loaded into the editor).

## Review
An adversarial review pass found a regression (dropped tolerant write) and test gaps; both fixed here — the tolerant-write behavior is now restored and covered, and tests assert atomic rejection, the count/size bounds, and duplicate rejection. No path-escape vector was found in the validator (UNC/drive/percent-encoding/Unicode all confined).

## Tests
`project-path.test.ts` (validator incl. UNC, `...`) + `zip-import.test.ts` (well-formed import, traversal/absolute/duplicate/atomic rejection, count & size limits, tolerant write). `tsc`, ESLint, Prettier, full unit suite (213) green.

Closes #50