### PR TITLE
fix(runner): validate customizer values before building -D args (#51)

### DIFF
--- a/src/__tests__/user-facing-errors.test.ts
+++ b/src/__tests__/user-facing-errors.test.ts
@@ -13,6 +13,20 @@ describe('user-facing error helpers', () => {
     );
   });
 
+  it('normalizes a recycled-worker timeout to the stopped-responding message', () => {
+    expect(
+      normalizeOperationFailure(new Error('Worker recycled after timeout'), 'render').message,
+    ).toBe('Render failed because the compile worker stopped responding. Try again.');
+  });
+
+  it('surfaces an invalid customizer parameter value as the headline message', () => {
+    const message = normalizeOperationFailure(
+      new Error('Invalid value for parameter "x": non-finite number (NaN)'),
+      'render',
+    ).message;
+    expect(message).toBe('Invalid value for parameter "x": non-finite number (NaN)');
+  });
+
   it('normalizes OOM messages for export operations', () => {
     expect(normalizeOperationFailure(new Error('Out of memory'), 'export').message).toBe(
       'Export ran out of memory in the browser. Try simplifying the model.',

--- a/src/__tests__/utils.test.ts
+++ b/src/__tests__/utils.test.ts
@@ -137,6 +137,37 @@ describe('turnIntoDelayableExecution – settlement & supersession (#48)', () =>
     expect(await first).toBe('rej:Cancelled');
   });
 
+  it('rejects (does not hang) when a delayed job throws synchronously', async () => {
+    const job = vi.fn((_x: string): AbortablePromise<string> => {
+      throw new Error('bad args');
+    });
+    const delayable = turnIntoDelayableExecution(1000, job);
+    const result = outcome(delayable('x')({ now: false }));
+
+    await vi.advanceTimersByTimeAsync(1000);
+    expect(await result).toBe('rej:bad args');
+  });
+
+  it('rejects an immediate (now:true) job that throws synchronously, and recovers after', async () => {
+    let throwNext = true;
+    const job = vi.fn((arg: string): AbortablePromise<string> => {
+      if (throwNext) throw new Error('boom');
+      return AbortablePromise<string>((resolve) => {
+        resolve(`ok:${arg}`);
+        return () => {};
+      });
+    });
+    const delayable = turnIntoDelayableExecution(0, job);
+
+    const first = outcome(delayable('a')({ now: true }));
+    expect(await first).toBe('rej:boom');
+
+    // A sync throw must have freed the live signal so a later call still settles.
+    throwNext = false;
+    const second = outcome(delayable('b')({ now: true }));
+    expect(await second).toBe('res:ok:b');
+  });
+
   it('keeps a running job cancellable after an earlier job finishes (no clobber race)', async () => {
     const { job, controllers } = makeJob();
     const delayable = turnIntoDelayableExecution(0, job);

--- a/src/runner/actions.ts
+++ b/src/runner/actions.ts
@@ -97,16 +97,39 @@ export type RenderArgs = {
   backend?: 'manifold' | 'cgal';
 };
 
-// eslint-disable-next-line @typescript-eslint/no-explicit-any
-export function formatValue(value: any): string {
+/** Maximum array-nesting depth accepted for a customizer value. */
+const MAX_VALUE_DEPTH = 16;
+
+/**
+ * Render an OpenSCAD customizer value into a `-D` literal. Only the value shapes
+ * OpenSCAD parameters can hold are accepted — string, finite number, boolean, and
+ * (bounded) nested arrays of those. Anything else (NaN/Infinity, objects,
+ * functions, null/undefined, over-deep arrays) throws, so malformed values surface
+ * as a clear error instead of producing garbage like `-Dx=[object Object]`.
+ */
+export function formatValue(value: unknown): string {
+  return formatValueAtDepth(value, 0);
+}
+
+function formatValueAtDepth(value: unknown, depth: number): string {
+  if (depth > MAX_VALUE_DEPTH) {
+    throw new Error('array nesting is too deep');
+  }
   if (typeof value === 'string') {
     const escaped = value.replace(/\\/g, '\\\\').replace(/"/g, '\\"');
     return `"${escaped}"`;
-  } else if (value instanceof Array) {
-    return `[${value.map(formatValue).join(', ')}]`;
-  } else {
+  }
+  if (typeof value === 'number') {
+    if (!Number.isFinite(value)) throw new Error(`non-finite number (${value})`);
     return `${value}`;
   }
+  if (typeof value === 'boolean') {
+    return value ? 'true' : 'false';
+  }
+  if (Array.isArray(value)) {
+    return `[${value.map((v) => formatValueAtDepth(v, depth + 1)).join(', ')}]`;
+  }
+  throw new Error(`unsupported value type (${value === null ? 'null' : typeof value})`);
 }
 /**
  * Returns the fixed compile-time args shared by all render invocations.
@@ -159,7 +182,13 @@ export const render = turnIntoDelayableExecution(renderDelay, (renderArgs: Rende
     outFile,
     `--backend=${backend ?? 'manifold'}`,
     '--export-format=' + (actualRenderFormat == 'stl' ? 'binstl' : actualRenderFormat),
-    ...Object.entries(vars ?? {}).flatMap(([k, v]) => [`-D${k}=${formatValue(v)}`]),
+    ...Object.entries(vars ?? {}).map(([k, v]) => {
+      try {
+        return `-D${k}=${formatValue(v)}`;
+      } catch (e) {
+        throw new Error(`Invalid value for parameter "${k}": ${(e as Error).message}`);
+      }
+    }),
     ...(features ?? []).map((f) => `--enable=${f}`),
     ...(extraArgs ?? []),
   ];

--- a/src/state/__tests__/url-mode.test.ts
+++ b/src/state/__tests__/url-mode.test.ts
@@ -176,6 +176,34 @@ describe('formatValue — string escaping', () => {
     expect(formatValue(['a', 'b'])).toBe('["a", "b"]');
     expect(formatValue([1, [2, 3]])).toBe('[1, [2, 3]]');
   });
+
+  it('rejects non-finite numbers', () => {
+    expect(() => formatValue(NaN)).toThrow();
+    expect(() => formatValue(Infinity)).toThrow();
+    expect(() => formatValue(-Infinity)).toThrow();
+  });
+
+  it('rejects objects, null, undefined, and functions', () => {
+    expect(() => formatValue({})).toThrow();
+    expect(() => formatValue(null)).toThrow();
+    expect(() => formatValue(undefined)).toThrow();
+    expect(() => formatValue(() => {})).toThrow();
+  });
+
+  it('rejects an invalid value nested inside an array', () => {
+    expect(() => formatValue([1, NaN, 3])).toThrow();
+    expect(() => formatValue([1, {}])).toThrow();
+  });
+
+  it('rejects excessively deep array nesting at the boundary', () => {
+    const nest = (levels: number) => {
+      let v: unknown = 1;
+      for (let i = 0; i < levels; i++) v = [v];
+      return v;
+    };
+    expect(() => formatValue(nest(16))).not.toThrow();
+    expect(() => formatValue(nest(17))).toThrow();
+  });
 });
 
 // ---------------------------------------------------------------------------

--- a/src/user-facing-errors.ts
+++ b/src/user-facing-errors.ts
@@ -148,7 +148,7 @@ export function normalizeOperationFailure(
 
   if (
     lower.includes('worker crashed') ||
-    lower.includes('worker recycled after hard timeout') ||
+    lower.includes('worker recycled') ||
     lower.includes('stopped responding')
   ) {
     return {
@@ -162,6 +162,12 @@ export function normalizeOperationFailure(
       message: `${label} finished without producing an output file.`,
       details,
     };
+  }
+
+  // Invalid customizer parameter value: the thrown message already names the
+  // parameter and the reason, so surface it directly as the headline.
+  if (lower.includes('invalid value for parameter')) {
+    return { message: details, details };
   }
 
   return {

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -87,11 +87,20 @@ export function turnIntoDelayableExecution<T extends unknown[], R>(
 
         const execute = () => {
           timer = null;
-          runningJob = job(...args);
-          runningJob.then(settleResolve, settleReject).finally(() => {
+          const release = () => {
             // Only release the shared signal if this call is still the live one.
             if (cancelLive === cancelThis) cancelLive = null;
-          });
+          };
+          try {
+            runningJob = job(...args);
+          } catch (e) {
+            // A job factory that throws synchronously (e.g. invalid args) must
+            // still settle this promise — never leave it pending.
+            settleReject(e);
+            release();
+            return;
+          }
+          runningJob.then(settleResolve, settleReject).finally(release);
         };
 
         if (now) {


### PR DESCRIPTION
## Problem
`formatValue()` stringified any value via template interpolation (catch-all `` `${value}` ``), so objects became `"[object Object]"` and `NaN` / `Infinity` / `undefined` flowed unchecked into `-D` compile arguments.

## Fix
- `formatValue` accepts only the shapes an OpenSCAD customizer parameter can hold — string, **finite** number, boolean, and bounded nested arrays — and throws on anything else (NaN/Infinity, object, null/undefined, function, over-deep arrays).
- The render arg builder wraps each value with its parameter name, and `normalizeOperationFailure` surfaces `Invalid value for parameter "x": ...` as the headline.
- Hardened `turnIntoDelayableExecution` so a job that throws **synchronously** (an invalid value in a *delayed* render) rejects the promise instead of leaving it pending.
- Fixed a stale `worker recycled after hard timeout` string (the worker-timeout change renamed it) so recycled-worker errors map to the right message.

## Review
An adversarial review pass confirmed: no previously-valid value is now rejected; number formatting is locale-independent; the sync-throw handling can't double-settle and frees the live signal correctly; the error reaches the user without leaving the spinner stuck. All findings were NITs — the headline-message improvement and the flagged test gaps (depth boundary, `now:true` throw, reuse-after-throw) are included here.

## Tests
`formatValue` rejection + depth-boundary cases, the delayed/immediate sync-throw + recovery in `utils.test.ts`, and the new error-normalizer branches. `tsc`, ESLint, Prettier, full unit suite (221) green.

Closes #51