### PR TITLE
fix(fs): harden runtime asset fetches (#52)

### DIFF
--- a/src/fs/filesystem.ts
+++ b/src/fs/filesystem.ts
@@ -2,6 +2,7 @@
 
 import { getBrowserFS } from '../runtime/browserfs-runtime.ts';
 import { resolveRuntimeAssetUrl } from '../runtime/asset-urls.ts';
+import { fetchAssetBytes } from '../runtime/fetch-asset.ts';
 import { zipArchives, ZipArchive } from './zip-archives.generated.ts';
 
 // Re-export for consumers that need the type
@@ -64,9 +65,7 @@ export async function createEditorFS({
 }): Promise<FS> {
   const browserFS = getBrowserFS();
   // Fonts are always pre-loaded — needed for any text() call in OpenSCAD
-  const fontsBuf = await fetch(resolveRuntimeAssetUrl('libraries/fonts.zip')).then((r) =>
-    r.arrayBuffer(),
-  );
+  const fontsBuf = await fetchAssetBytes(resolveRuntimeAssetUrl('libraries/fonts.zip'));
   const fontsFS = await createBFSBackend('ZipFS', {
     zipData: browserFS.BFSRequire('buffer').Buffer.from(fontsBuf),
   });
@@ -137,7 +136,7 @@ async function fetchAndMountLibrary(name: string): Promise<void> {
     if (!_rootMFS)
       throw new Error('[filesystem] createEditorFS() must be called before mountDemandLibraries()');
     const browserFS = getBrowserFS();
-    const buf = await fetch(resolveRuntimeAssetUrl(archive.zipPath)).then((r) => r.arrayBuffer());
+    const buf = await fetchAssetBytes(resolveRuntimeAssetUrl(archive.zipPath));
     const zipFS = await createBFSBackend('ZipFS', {
       zipData: browserFS.BFSRequire('buffer').Buffer.from(buf),
     });

--- a/src/runtime/__tests__/fetch-asset.test.ts
+++ b/src/runtime/__tests__/fetch-asset.test.ts
@@ -1,0 +1,76 @@
+import { fetchAssetBytes, AssetFetchError } from '../fetch-asset.ts';
+
+const originalFetch = global.fetch;
+
+afterEach(() => {
+  global.fetch = originalFetch;
+  vi.restoreAllMocks();
+});
+
+function bytes(n: number): ArrayBuffer {
+  return new Uint8Array(n).buffer;
+}
+
+describe('fetchAssetBytes (#52)', () => {
+  it('returns the body bytes for a 200 response', async () => {
+    global.fetch = vi
+      .fn()
+      .mockResolvedValue(
+        new Response(bytes(8), { status: 200, headers: { 'content-length': '8' } }),
+      ) as typeof fetch;
+
+    const buf = await fetchAssetBytes('https://x/asset.zip');
+    expect(buf.byteLength).toBe(8);
+  });
+
+  it('succeeds for a small body with no content-length header', async () => {
+    global.fetch = vi
+      .fn()
+      .mockResolvedValue(new Response(bytes(8), { status: 200 })) as typeof fetch;
+
+    const buf = await fetchAssetBytes('https://x/asset.zip');
+    expect(buf.byteLength).toBe(8);
+  });
+
+  it('throws a structured error on a non-2xx status', async () => {
+    global.fetch = vi
+      .fn()
+      .mockResolvedValue(new Response('<html>Not Found</html>', { status: 404 })) as typeof fetch;
+
+    const err = await fetchAssetBytes('https://x/missing.zip').catch((e) => e);
+    expect(err).toBeInstanceOf(AssetFetchError);
+    expect(err.status).toBe(404);
+    expect(err.url).toBe('https://x/missing.zip');
+    expect(String(err.message)).toContain('404');
+  });
+
+  it('wraps a network failure as an AssetFetchError', async () => {
+    global.fetch = vi.fn().mockRejectedValue(new TypeError('network down')) as typeof fetch;
+
+    const err = await fetchAssetBytes('https://x/asset.zip').catch((e) => e);
+    expect(err).toBeInstanceOf(AssetFetchError);
+    expect(String(err.message)).toContain('network down');
+  });
+
+  it('rejects when content-length exceeds the limit', async () => {
+    global.fetch = vi
+      .fn()
+      .mockResolvedValue(
+        new Response(bytes(4), { status: 200, headers: { 'content-length': '999' } }),
+      ) as typeof fetch;
+
+    await expect(fetchAssetBytes('https://x/big.zip', { maxBytes: 10 })).rejects.toBeInstanceOf(
+      AssetFetchError,
+    );
+  });
+
+  it('rejects when the body exceeds the limit despite no content-length', async () => {
+    global.fetch = vi
+      .fn()
+      .mockResolvedValue(new Response(bytes(100), { status: 200 })) as typeof fetch;
+
+    await expect(fetchAssetBytes('https://x/big.zip', { maxBytes: 10 })).rejects.toBeInstanceOf(
+      AssetFetchError,
+    );
+  });
+});

--- a/src/runtime/fetch-asset.ts
+++ b/src/runtime/fetch-asset.ts
@@ -1,0 +1,75 @@
+// Centralized fetching for first-party runtime assets (fonts and library
+// archives today). Validates HTTP status and bounds the response size, so a 404
+// HTML page or a misbehaving endpoint surfaces as a clear, structured error
+// instead of flowing into a downstream parser (e.g. ZipFS) as a confusing failure.
+
+/** Default cap on a single fetched asset (generous; WASM/library zips are large). */
+export const DEFAULT_MAX_ASSET_BYTES = 256 * 1024 * 1024;
+
+export class AssetFetchError extends Error {
+  constructor(
+    message: string,
+    readonly url: string,
+    readonly status?: number,
+  ) {
+    super(message);
+    this.name = 'AssetFetchError';
+  }
+}
+
+export interface FetchAssetOptions {
+  /** Maximum accepted response size in bytes. Defaults to DEFAULT_MAX_ASSET_BYTES. */
+  maxBytes?: number;
+  /** Abort signal forwarded to fetch. */
+  signal?: AbortSignal;
+}
+
+/**
+ * Fetch a runtime asset as bytes, validating status and size.
+ *
+ * @throws {AssetFetchError} on network failure, non-2xx status, or over-size response.
+ */
+export async function fetchAssetBytes(
+  url: string,
+  options: FetchAssetOptions = {},
+): Promise<ArrayBuffer> {
+  const maxBytes = options.maxBytes ?? DEFAULT_MAX_ASSET_BYTES;
+
+  let response: Response;
+  try {
+    response = await fetch(url, { signal: options.signal });
+  } catch (err) {
+    throw new AssetFetchError(
+      `Failed to fetch asset ${url}: ${err instanceof Error ? err.message : String(err)}`,
+      url,
+    );
+  }
+
+  if (!response.ok) {
+    throw new AssetFetchError(
+      `Failed to fetch asset ${url}: HTTP ${response.status} ${response.statusText}`.trim(),
+      url,
+      response.status,
+    );
+  }
+
+  const declared = Number(response.headers.get('content-length'));
+  if (Number.isFinite(declared) && declared > maxBytes) {
+    throw new AssetFetchError(
+      `Asset ${url} is too large (${declared} bytes, limit ${maxBytes}).`,
+      url,
+      response.status,
+    );
+  }
+
+  const buffer = await response.arrayBuffer();
+  if (buffer.byteLength > maxBytes) {
+    throw new AssetFetchError(
+      `Asset ${url} is too large (${buffer.byteLength} bytes, limit ${maxBytes}).`,
+      url,
+      response.status,
+    );
+  }
+
+  return buffer;
+}


### PR DESCRIPTION
## Problem
Font (`fonts.zip`) and library-archive loads called `fetch(...).then(r => r.arrayBuffer())` with no `response.ok` check, so a 404 HTML response travelled into ZipFS and produced a confusing parse error.

## Fix
New `src/runtime/fetch-asset.ts#fetchAssetBytes()` centralizes first-party asset fetching: validates HTTP status, bounds size (early content-length reject + authoritative post-read byte cap), forwards an abort signal, and throws a structured `AssetFetchError` (with `url`/`status`). The two `filesystem.ts` fetch sites now use it. `external-source.ts` (user URLs, already checks `ok`) and `fragment-state.ts` (in-memory gzip) are correctly out of scope.

## Review
Reviewed: missing/garbage `content-length` does not false-reject (the post-read cap is authoritative); the `ArrayBuffer` return type matches what `Buffer.from` expects (no behavior change); 256 MiB default won't false-positive. Tests cover success (with and without content-length), 404, network error, and both oversize paths.

`tsc`, ESLint, Prettier, full unit suite green.

Closes #52