### PR TITLE
fix(pwa): surface SW updates instead of forcing a reload (#53)

### DIFF
--- a/scripts/build-sw.mjs
+++ b/scripts/build-sw.mjs
@@ -36,8 +36,12 @@ try {
     swDest,
     globIgnores: ['**/.*', '**/*.map', 'manifest*.js'],
     maximumFileSizeToCacheInBytes: 200 * 1024 * 1024,
-    clientsClaim: true,
-    skipWaiting: true,
+    // A new worker WAITS instead of taking over the open page: skipWaiting/
+    // clientsClaim would swap the controller mid-session (risking 404s on hashed
+    // chunks removed by the new deploy). The app surfaces an "update available"
+    // signal instead, and the new worker activates on the next load. See #53.
+    clientsClaim: false,
+    skipWaiting: false,
     // Preserve the established runtime-caching rule order to avoid behavior drift.
     runtimeCaching: [
       {

--- a/src/runtime/__tests__/service-worker.test.ts
+++ b/src/runtime/__tests__/service-worker.test.ts
@@ -1,0 +1,104 @@
+// Regression coverage for issue #53: a newly-installed service worker must NOT
+// force a page reload; it surfaces an observable "update available" signal.
+
+vi.mock('../build-env.ts', () => ({ isProductionBuild: () => true }));
+vi.mock('../asset-urls.ts', () => ({ resolveRuntimeAssetUrl: (p: string) => `/${p}` }));
+
+import { registerAppServiceWorker, SW_UPDATE_AVAILABLE_EVENT } from '../service-worker.ts';
+
+type FakeWorker = { state: string; onstatechange: (() => void) | null };
+type FakeRegistration = {
+  scope: string;
+  installing: FakeWorker | null;
+  onupdatefound: (() => void) | null;
+};
+
+describe('registerAppServiceWorker update flow (#53)', () => {
+  let reloadSpy: ReturnType<typeof vi.fn>;
+  const realLocation = window.location;
+
+  beforeEach(() => {
+    reloadSpy = vi.fn();
+    Object.defineProperty(window, 'location', {
+      configurable: true,
+      value: { reload: reloadSpy },
+    });
+  });
+
+  afterEach(() => {
+    Object.defineProperty(window, 'location', { configurable: true, value: realLocation });
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    delete (navigator as any).serviceWorker;
+    vi.restoreAllMocks();
+  });
+
+  it('surfaces an update via callback and event instead of reloading', async () => {
+    const installingWorker: FakeWorker = { state: 'installing', onstatechange: null };
+    const registration: FakeRegistration = {
+      scope: '/',
+      installing: installingWorker,
+      onupdatefound: null,
+    };
+
+    Object.defineProperty(navigator, 'serviceWorker', {
+      configurable: true,
+      value: {
+        register: vi.fn().mockResolvedValue(registration),
+        controller: {}, // an existing controller => this is an update, not first install
+      },
+    });
+
+    const onUpdateAvailable = vi.fn();
+    let eventDetail: unknown = null;
+    const listener = (e: Event) => {
+      eventDetail = (e as CustomEvent).detail;
+    };
+    window.addEventListener(SW_UPDATE_AVAILABLE_EVENT, listener);
+
+    const result = await registerAppServiceWorker({ onUpdateAvailable });
+    expect(result).toBe(registration);
+
+    // Simulate the browser finding and installing a new worker.
+    registration.onupdatefound!();
+    installingWorker.state = 'installed';
+    installingWorker.onstatechange!();
+
+    expect(onUpdateAvailable).toHaveBeenCalledWith(registration);
+    expect(eventDetail).toEqual({ registration });
+    expect(reloadSpy).not.toHaveBeenCalled();
+
+    window.removeEventListener(SW_UPDATE_AVAILABLE_EVENT, listener);
+  });
+
+  it('does not signal an update on first install (no existing controller)', async () => {
+    const installingWorker: FakeWorker = { state: 'installing', onstatechange: null };
+    const registration: FakeRegistration = {
+      scope: '/',
+      installing: installingWorker,
+      onupdatefound: null,
+    };
+
+    Object.defineProperty(navigator, 'serviceWorker', {
+      configurable: true,
+      value: {
+        register: vi.fn().mockResolvedValue(registration),
+        controller: null, // no prior controller => first install, not an update
+      },
+    });
+
+    const onUpdateAvailable = vi.fn();
+    const listener = vi.fn();
+    window.addEventListener(SW_UPDATE_AVAILABLE_EVENT, listener);
+
+    await registerAppServiceWorker({ onUpdateAvailable });
+    registration.onupdatefound!();
+    installingWorker.state = 'installed';
+    installingWorker.onstatechange!();
+
+    expect(onUpdateAvailable).not.toHaveBeenCalled();
+    expect(listener).not.toHaveBeenCalled();
+    expect(reloadSpy).not.toHaveBeenCalled();
+
+    window.removeEventListener(SW_UPDATE_AVAILABLE_EVENT, listener);
+  });
+});

--- a/src/runtime/service-worker.ts
+++ b/src/runtime/service-worker.ts
@@ -1,7 +1,17 @@
 import { isProductionBuild } from './build-env.ts';
 import { resolveRuntimeAssetUrl } from './asset-urls.ts';
 
-export async function registerAppServiceWorker(): Promise<ServiceWorkerRegistration | null> {
+/** Window event dispatched when a new service worker has installed and is waiting. */
+export const SW_UPDATE_AVAILABLE_EVENT = 'osc:sw-update-available';
+
+export interface RegisterServiceWorkerOptions {
+  /** Called when a new worker has installed and an update is ready to apply. */
+  onUpdateAvailable?: (registration: ServiceWorkerRegistration) => void;
+}
+
+export async function registerAppServiceWorker(
+  options: RegisterServiceWorkerOptions = {},
+): Promise<ServiceWorkerRegistration | null> {
   if (
     !isProductionBuild() ||
     import.meta.env.BASE_URL === './' ||
@@ -15,13 +25,19 @@ export async function registerAppServiceWorker(): Promise<ServiceWorkerRegistrat
     console.log('ServiceWorker registration successful with scope: ', registration.scope);
     registration.onupdatefound = () => {
       const installingWorker = registration.installing;
-      if (installingWorker) {
-        installingWorker.onstatechange = () => {
-          if (installingWorker.state === 'installed' && navigator.serviceWorker.controller) {
-            window.location.reload();
-          }
-        };
-      }
+      if (!installingWorker) return;
+      installingWorker.onstatechange = () => {
+        // A new worker installed while an old one still controls the page — an
+        // update is ready. Do NOT force a reload here: that discards unsaved edits
+        // and interrupts an active render. Surface it instead so the UI can offer
+        // a user-controlled reload; the update applies naturally on the next load.
+        if (installingWorker.state === 'installed' && navigator.serviceWorker.controller) {
+          options.onUpdateAvailable?.(registration);
+          window.dispatchEvent(
+            new CustomEvent(SW_UPDATE_AVAILABLE_EVENT, { detail: { registration } }),
+          );
+        }
+      };
     };
     return registration;
   } catch (error) {


### PR DESCRIPTION
## Problem
On finding a new service worker, the app called `window.location.reload()` — discarding unsaved edits and interrupting an in-progress render.

## Fix
- `service-worker.ts` no longer reloads. It dispatches an observable `osc:sw-update-available` window event and invokes an optional `onUpdateAvailable` callback.
- **Crucially**, `build-sw.mjs` now sets `skipWaiting: false` / `clientsClaim: false`. With the old `true`/`true`, removing the reload would let the new worker silently seize the open page mid-session (and 404 on hashed chunks deleted by the new deploy). Now the new worker truly waits and activates on the next natural load — so "applies on next load" is actually true.

## Review
An adversarial review caught the `skipWaiting`/`clientsClaim` half-state (fixed here) and a missing first-install test case (added). The update-available signal currently has no UI consumer; that reload-prompt toast is tracked as a follow-up in **#78** (linked under the epic) rather than left as an unstated gap.

## Tests
`service-worker.test.ts`: update path fires callback+event and does **not** reload; first-install (no controller) fires nothing. `tsc`, ESLint, Prettier, full unit suite green.

Closes #53