### PR TITLE
refactor(runner): consolidate the compile pipeline (#54)

### DIFF
--- a/src/__tests__/model-checkingSyntax.test.ts
+++ b/src/__tests__/model-checkingSyntax.test.ts
@@ -5,7 +5,6 @@ import { defaultModelColor, defaultSourcePath } from '../state/initial-state.ts'
 vi.mock('../runner/actions.ts', () => ({
   checkSyntax: vi.fn().mockReturnValue(vi.fn().mockRejectedValue(new Error('mock runner failure'))),
   render: vi.fn(),
-  getDefaultCompileArgs: vi.fn().mockReturnValue(['--backend=manifold']),
 }));
 
 describe('Model.checkSyntax', () => {

--- a/src/runner/__tests__/compile-pipeline.test.ts
+++ b/src/runner/__tests__/compile-pipeline.test.ts
@@ -1,42 +1,16 @@
-// T4 — Compile-pipeline tests
+// Compile-pipeline tests
 //
 // Covers:
-//   1. Feature-flag safety: getDefaultCompileArgs() must not include --enable=lazy-union
-//   2. compileWithFallback: success path, no-retry path, and missing-library retry path
-//
-// compileWithFallback calls spawnOpenSCAD from the same module, so we cannot
-// replace spawnOpenSCAD at the module boundary without breaking the internal call chain.
-// Instead, we install a fake Worker in globalThis that immediately posts a
-// synthetic "result" message back to the runner, exercising the full JS-layer
-// path without requiring a real WASM binary.
+//   1. buildOpenScadArgs — the single source of truth for OpenSCAD CLI args,
+//      including feature-flag safety (no implicit --enable=lazy-union).
+//   2. spawnOpenSCAD — the JS-layer request/response loop, exercised via a fake
+//      Worker that posts synthetic result/error messages back to the runner.
 //
 // Full round-trip compilation with real WASM remains intentionally deferred from
-// this JS-layer suite. The Vitest migration removed the old Jest CJS blocker,
-// but the fake-Worker harness still provides the focused coverage used here.
+// this JS-layer suite; the fake-Worker harness provides the focused coverage here.
 
-import { getDefaultCompileArgs } from '../actions.ts';
+import { buildOpenScadArgs } from '../actions.ts';
 import { clearPerfSnapshot, getPerfSnapshot } from '../../perf/runtime-performance.ts';
-
-// ---------------------------------------------------------------------------
-// Mock filesystem.ts — used by compileWithFallback for on-demand library mount
-// ---------------------------------------------------------------------------
-vi.mock('../../fs/filesystem.ts', () => ({
-  mountDemandLibraries: vi.fn().mockResolvedValue([]),
-  extractLibraryNames: vi.fn().mockReturnValue([]),
-  createEditorFS: vi.fn().mockResolvedValue(undefined),
-  preloadEditorLibraries: vi.fn().mockResolvedValue(undefined),
-  symlinkLibraries: vi.fn().mockResolvedValue(undefined),
-  saveActiveFile: vi.fn().mockResolvedValue(false),
-  openLocalFile: vi.fn().mockResolvedValue(null),
-  clearActiveFileHandle: vi.fn(),
-  getParentDir: vi.fn((p: string) => p.split('/').slice(0, -1).join('/') || '/'),
-  join: vi.fn((...args: string[]) => args.join('/')),
-}));
-
-import { compileWithFallback } from '../openscad-runner.ts';
-import { mountDemandLibraries } from '../../fs/filesystem.ts';
-
-const mockMount = mountDemandLibraries as ReturnType<typeof vi.fn>;
 
 // ---------------------------------------------------------------------------
 // Fake Worker that drives the runner message loop
@@ -91,7 +65,6 @@ class FakeWorker {
   terminate() {}
 }
 
-// Install the FakeWorker globally before module code runs
 beforeAll(() => {
   (globalThis as unknown as Record<string, unknown>).Worker = FakeWorker;
 });
@@ -102,52 +75,126 @@ beforeEach(() => {
   clearPerfSnapshot();
 });
 
+// Imported after the FakeWorker is staged so the runner picks it up lazily.
+import { spawnOpenSCAD } from '../openscad-runner.ts';
+
 // ---------------------------------------------------------------------------
-// T4-1 — Feature flags
+// buildOpenScadArgs — single source of truth
 // ---------------------------------------------------------------------------
 
-describe('compile pipeline — feature flags', () => {
-  it('getDefaultCompileArgs returns an array', () => {
-    expect(Array.isArray(getDefaultCompileArgs())).toBe(true);
+describe('buildOpenScadArgs', () => {
+  it('builds the positional path, output, and export format', () => {
+    expect(
+      buildOpenScadArgs({ scadPath: 'm.scad', outFile: 'o.off', exportFormat: 'off' }),
+    ).toEqual(['m.scad', '-o', 'o.off', '--export-format=off']);
   });
 
-  it('includes --backend=manifold', () => {
-    expect(getDefaultCompileArgs()).toContain('--backend=manifold');
+  it('omits --backend when no backend is requested (e.g. syntax pass)', () => {
+    const args = buildOpenScadArgs({
+      scadPath: 'm.scad',
+      outFile: 'o.json',
+      exportFormat: 'param',
+    });
+    expect(args.some((a) => a.startsWith('--backend='))).toBe(false);
   });
 
-  it('does not enable lazy-union', () => {
-    const enableFlags = getDefaultCompileArgs().filter((a: string) => a.startsWith('--enable='));
-    expect(enableFlags).not.toContain('--enable=lazy-union');
+  it('includes the requested backend', () => {
+    const args = buildOpenScadArgs({
+      scadPath: 'm.scad',
+      outFile: 'o.off',
+      exportFormat: 'off',
+      backend: 'manifold',
+    });
+    expect(args).toContain('--backend=manifold');
+  });
+
+  it('does not implicitly enable lazy-union', () => {
+    const args = buildOpenScadArgs({
+      scadPath: 'm.scad',
+      outFile: 'o.off',
+      exportFormat: 'off',
+      backend: 'manifold',
+    });
+    expect(args.filter((a) => a.startsWith('--enable='))).not.toContain('--enable=lazy-union');
+  });
+
+  it('emits -D for vars, --enable for features, and appends extra args', () => {
+    const args = buildOpenScadArgs({
+      scadPath: 'm.scad',
+      outFile: 'o.off',
+      exportFormat: 'off',
+      backend: 'manifold',
+      vars: { n: 3, label: 'hi' },
+      features: ['fast-csg'],
+      extraArgs: ['--quiet'],
+    });
+    expect(args).toContain('-Dn=3');
+    expect(args).toContain('-Dlabel="hi"');
+    expect(args).toContain('--enable=fast-csg');
+    expect(args).toContain('--quiet');
+  });
+
+  it('emits the full render arg list in a stable order', () => {
+    expect(
+      buildOpenScadArgs({
+        scadPath: 'm.scad',
+        outFile: 'o.off',
+        exportFormat: 'off',
+        backend: 'manifold',
+        vars: { n: 3 },
+        features: ['fast-csg'],
+        extraArgs: ['--quiet'],
+      }),
+    ).toEqual([
+      'm.scad',
+      '-o',
+      'o.off',
+      '--backend=manifold',
+      '--export-format=off',
+      '-Dn=3',
+      '--enable=fast-csg',
+      '--quiet',
+    ]);
+  });
+
+  it('throws a parameter-scoped error for an invalid var value', () => {
+    expect(() =>
+      buildOpenScadArgs({
+        scadPath: 'm.scad',
+        outFile: 'o.off',
+        exportFormat: 'off',
+        vars: { bad: NaN },
+      }),
+    ).toThrow(/parameter "bad"/);
   });
 });
 
 // ---------------------------------------------------------------------------
-// T4-2 — compileWithFallback success path
+// spawnOpenSCAD — JS-layer request/response loop
 // ---------------------------------------------------------------------------
 
-describe('compile pipeline — compileWithFallback success', () => {
-  it('resolves with exitCode 0 and does not call mountDemandLibraries', async () => {
+describe('spawnOpenSCAD', () => {
+  it('resolves with the worker exit code on success', async () => {
     _workerSpecs.push({ exitCode: 0 });
-
-    const result = await compileWithFallback(
-      { mountArchives: true, args: ['test.scad', '-o', 'out.off'] },
-      vi.fn(),
-    );
-
+    const result = await spawnOpenSCAD({ mountArchives: true, args: ['m.scad'] }, vi.fn());
     expect(result.exitCode).toBe(0);
-    expect(mockMount).not.toHaveBeenCalled();
   });
 
-  it('returns failure without retry when error is unrelated to missing library', async () => {
-    _workerSpecs.push({ exitCode: 1, stderrLines: ['CGAL error: invalid operation'] });
+  it('preserves an explicit worker error response', async () => {
+    _workerSpecs.push({
+      responseType: 'error',
+      message: 'boom',
+      stderrLines: ['runtime exploded'],
+      perf: { workerJobMillis: 33 },
+    });
 
-    const result = await compileWithFallback(
-      { mountArchives: true, args: ['test.scad', '-o', 'out.off'] },
-      vi.fn(),
+    const result = await spawnOpenSCAD({ mountArchives: true, args: ['m.scad'] }, vi.fn());
+
+    expect(result.error).toBe('boom');
+    expect(result.exitCode).toBeUndefined();
+    expect(getPerfSnapshot().metrics).toContainEqual(
+      expect.objectContaining({ name: 'osc:worker-job-total', duration: 33 }),
     );
-
-    expect(result.exitCode).toBe(1);
-    expect(mockMount).not.toHaveBeenCalled();
   });
 
   it('records worker perf timings from a successful compile response', async () => {
@@ -161,10 +208,7 @@ describe('compile pipeline — compileWithFallback success', () => {
       },
     });
 
-    const result = await compileWithFallback(
-      { mountArchives: true, args: ['test.scad', '-o', 'out.off'] },
-      vi.fn(),
-    );
+    const result = await spawnOpenSCAD({ mountArchives: true, args: ['m.scad'] }, vi.fn());
 
     expect(result.perf?.workerWasmInitMillis).toBe(44);
     const snapshot = getPerfSnapshot();
@@ -172,74 +216,7 @@ describe('compile pipeline — compileWithFallback success', () => {
       expect.objectContaining({ name: 'osc:worker-fs-init', duration: 12 }),
     );
     expect(snapshot.metrics).toContainEqual(
-      expect.objectContaining({ name: 'osc:worker-library-mount', duration: 8 }),
-    );
-    expect(snapshot.metrics).toContainEqual(
       expect.objectContaining({ name: 'osc:worker-wasm-init', duration: 44 }),
     );
-  });
-
-  it('handles explicit worker error responses and preserves the message', async () => {
-    _workerSpecs.push({
-      responseType: 'error',
-      message: 'boom',
-      stderrLines: ['runtime exploded'],
-      perf: { workerJobMillis: 33 },
-    });
-
-    const result = await compileWithFallback(
-      { mountArchives: true, args: ['test.scad', '-o', 'out.off'] },
-      vi.fn(),
-    );
-
-    expect(result.error).toBe('boom');
-    expect(result.exitCode).toBeUndefined();
-    expect(getPerfSnapshot().metrics).toContainEqual(
-      expect.objectContaining({ name: 'osc:worker-job-total', duration: 33 }),
-    );
-  });
-});
-
-// ---------------------------------------------------------------------------
-// T4-3 — compileWithFallback retry path
-// ---------------------------------------------------------------------------
-
-describe('compile pipeline — compileWithFallback retry on missing library', () => {
-  it('mounts the missing library and retries, returning the second result', async () => {
-    _workerSpecs.push({
-      exitCode: 1,
-      stderrLines: ["WARNING: Can't open library 'MCAD/involute_gears.scad'."],
-    });
-    _workerSpecs.push({ exitCode: 0 }); // retry succeeds
-
-    mockMount.mockResolvedValueOnce(['MCAD']);
-
-    const result = await compileWithFallback(
-      { mountArchives: true, args: ['test.scad', '-o', 'out.off'] },
-      vi.fn(),
-    );
-
-    expect(result.exitCode).toBe(0);
-    expect(mockMount).toHaveBeenCalledTimes(1);
-    // Both specs consumed (two Worker calls)
-    expect(_workerSpecs).toHaveLength(0);
-  });
-
-  it('does not retry when mountDemandLibraries returns empty (unknown library)', async () => {
-    _workerSpecs.push({
-      exitCode: 1,
-      stderrLines: ["WARNING: Can't open library 'UnknownLib/foo.scad'."],
-    });
-
-    mockMount.mockResolvedValueOnce([]); // nothing mounted
-
-    const result = await compileWithFallback(
-      { mountArchives: true, args: ['test.scad', '-o', 'out.off'] },
-      vi.fn(),
-    );
-
-    expect(result.exitCode).toBe(1);
-    expect(_workerSpecs).toHaveLength(0); // only one spec pushed, was consumed
-    expect(mockMount).toHaveBeenCalledTimes(1);
   });
 });

--- a/src/runner/__tests__/worker-timeout.test.ts
+++ b/src/runner/__tests__/worker-timeout.test.ts
@@ -8,14 +8,6 @@
 // hangs per-instance: a worker created in "hang" mode answers nothing until it
 // is terminated and a fresh worker is created.
 
-// openscad-runner imports mountDemandLibraries from filesystem.ts; stub the
-// module so the heavy BrowserFS graph is not pulled into the test.
-vi.mock('../../fs/filesystem.ts', () => ({
-  mountDemandLibraries: vi.fn().mockResolvedValue([]),
-  symlinkLibraries: vi.fn().mockResolvedValue(undefined),
-  createEditorFS: vi.fn().mockResolvedValue(undefined),
-}));
-
 // The runner's per-job timeout (kept in sync with SOFT/COMPILE timeout in the runner).
 const TIMEOUT_MS = 30_000;
 

--- a/src/runner/actions.ts
+++ b/src/runner/actions.ts
@@ -28,7 +28,7 @@ export const checkSyntax = turnIntoDelayableExecution(syntaxDelay, (sargs: Synta
     {
       mountArchives: true,
       inputs: sources,
-      args: [activePath, '-o', outFile, '--export-format=param'],
+      args: buildOpenScadArgs({ scadPath: activePath, outFile, exportFormat: 'param' }),
       outputPaths: [outFile],
     },
     (_streams) => {},
@@ -58,7 +58,7 @@ export const checkSyntax = turnIntoDelayableExecution(syntaxDelay, (sargs: Synta
         res({
           ...processMergedOutputs(result.mergedOutputs, {
             shiftSourceLines: {
-              sourcePath: sources[0].path,
+              sourcePath: activePath,
               skipLines: 0,
             },
           }),
@@ -131,15 +131,43 @@ function formatValueAtDepth(value: unknown, depth: number): string {
   }
   throw new Error(`unsupported value type (${value === null ? 'null' : typeof value})`);
 }
+export interface OpenScadArgsRequest {
+  /** Entry-point .scad path passed positionally to OpenSCAD. */
+  scadPath: string;
+  /** Output file path (`-o`). */
+  outFile: string;
+  /** `--export-format` value (e.g. `param`, `off`, `binstl`, `svg`). */
+  exportFormat: string;
+  /** Compute backend; omit for syntax/parameter passes that don't render geometry. */
+  backend?: 'manifold' | 'cgal';
+  /** Customizer variable overrides, emitted as `-D` literals. */
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  vars?: { [name: string]: any };
+  /** Experimental feature flags, emitted as `--enable=`. */
+  features?: string[];
+  /** Extra raw args appended verbatim. */
+  extraArgs?: string[];
+}
+
 /**
- * Returns the fixed compile-time args shared by all render invocations.
- * Exported for testability — the feature-flag test (T5) asserts that
- * no non-default experimental flags (e.g. --enable=lazy-union) are present.
+ * Single source of truth for OpenSCAD command-line arguments. Every compile path
+ * (syntax check, preview, render, export) builds its args here so flag handling
+ * and `-D`/feature-flag formatting stay consistent and individually testable.
  */
-export function getDefaultCompileArgs(): string[] {
-  // The only constant arg is the backend selector. Feature flags (--enable=X) are
-  // user-controlled and come from renderArgs.features[], NOT from a hard-coded list.
-  return [`--backend=manifold`];
+export function buildOpenScadArgs(request: OpenScadArgsRequest): string[] {
+  const args = [request.scadPath, '-o', request.outFile];
+  if (request.backend) args.push(`--backend=${request.backend}`);
+  args.push(`--export-format=${request.exportFormat}`);
+  for (const [k, v] of Object.entries(request.vars ?? {})) {
+    try {
+      args.push(`-D${k}=${formatValue(v)}`);
+    } catch (e) {
+      throw new Error(`Invalid value for parameter "${k}": ${(e as Error).message}`);
+    }
+  }
+  for (const f of request.features ?? []) args.push(`--enable=${f}`);
+  args.push(...(request.extraArgs ?? []));
+  return args;
 }
 
 export const render = turnIntoDelayableExecution(renderDelay, (renderArgs: RenderArgs) => {
@@ -176,22 +204,15 @@ export const render = turnIntoDelayableExecution(renderDelay, (renderArgs: Rende
     .split('/')
     .pop();
   const outFile = `${stem}.${actualRenderFormat}`;
-  const args = [
+  const args = buildOpenScadArgs({
     scadPath,
-    '-o',
     outFile,
-    `--backend=${backend ?? 'manifold'}`,
-    '--export-format=' + (actualRenderFormat == 'stl' ? 'binstl' : actualRenderFormat),
-    ...Object.entries(vars ?? {}).map(([k, v]) => {
-      try {
-        return `-D${k}=${formatValue(v)}`;
-      } catch (e) {
-        throw new Error(`Invalid value for parameter "${k}": ${(e as Error).message}`);
-      }
-    }),
-    ...(features ?? []).map((f) => `--enable=${f}`),
-    ...(extraArgs ?? []),
-  ];
+    exportFormat: actualRenderFormat == 'stl' ? 'binstl' : actualRenderFormat,
+    backend: backend ?? 'manifold',
+    vars,
+    features,
+    extraArgs,
+  });
 
   const job = spawnOpenSCAD(
     {

--- a/src/runner/openscad-runner.ts
+++ b/src/runner/openscad-runner.ts
@@ -2,7 +2,6 @@
 
 import { AbortablePromise } from '../utils.ts';
 import { Source } from '../state/app-state.ts';
-import { mountDemandLibraries } from '../fs/filesystem.ts';
 import { markPerf, measurePerf, recordPerfDuration } from '../perf/runtime-performance.ts';
 import { createOpenSCADWorker } from './worker-bootstrap.ts';
 import {
@@ -264,49 +263,4 @@ export function spawnOpenSCAD(
 
     return () => cancelJobById(id);
   });
-}
-
-// ---------------------------------------------------------------------------
-// F4 — On-demand fallback for missing libraries
-// ---------------------------------------------------------------------------
-
-/**
- * Pattern that matches OpenSCAD's "Can't open library" error in stderr.
- * Example: "Can't open library 'MCAD/involute_gears.scad'."
- */
-const MISSING_LIBRARY_RE = /Can't open library '([^']+)'/;
-
-/**
- * Dispatches a compile job and, if it fails because of a missing library that is
- * known to the registry, mounts that library on-demand and retries once.
- *
- * This covers cases where the static `use <...>` parser in the worker missed a
- * dynamically-constructed library path.
- */
-export async function compileWithFallback(
-  invocation: OpenSCADInvocation,
-  streamsCallback: (ps: ProcessStreams) => void,
-  priority: JobPriority = 'render',
-): Promise<OpenSCADInvocationResults> {
-  let result = await spawnOpenSCAD(invocation, streamsCallback, priority);
-
-  if (result.exitCode !== 0) {
-    // Inspect stderr lines for a missing-library error
-    const stderrText = result.mergedOutputs
-      .filter((o) => 'stderr' in o)
-      .map((o) => (o as { stderr: string }).stderr)
-      .join('\n');
-    const match = stderrText.match(MISSING_LIBRARY_RE);
-    if (match) {
-      const missingPath = match[1]; // e.g. "MCAD/involute_gears.scad"
-      const topLevel = missingPath.split('/')[0];
-      const needed = await mountDemandLibraries([`use <${missingPath}>`]);
-      if (needed.includes(topLevel)) {
-        // Retry once with the library now mounted
-        result = await spawnOpenSCAD(invocation, streamsCallback, priority);
-      }
-    }
-  }
-
-  return result;
 }

--- a/src/state/__tests__/model.test.ts
+++ b/src/state/__tests__/model.test.ts
@@ -25,7 +25,6 @@ vi.mock('../../runner/actions.ts', () => {
       markers: [],
       elapsedMillis: 0,
     }),
-    getDefaultCompileArgs: vi.fn().mockReturnValue(['--backend=manifold']),
   };
 });
 

--- a/src/state/__tests__/source-fetch-race.test.ts
+++ b/src/state/__tests__/source-fetch-race.test.ts
@@ -18,7 +18,6 @@ vi.mock('../../runner/actions.ts', () => {
       markers: [],
       elapsedMillis: 0,
     }),
-    getDefaultCompileArgs: vi.fn().mockReturnValue(['--backend=manifold']),
   };
 });
 vi.mock('../../io/import_off.ts', () => ({ parseOff: vi.fn() }));

--- a/src/state/__tests__/zip-import.test.ts
+++ b/src/state/__tests__/zip-import.test.ts
@@ -17,7 +17,6 @@ vi.mock('../../runner/actions.ts', () => {
       markers: [],
       elapsedMillis: 0,
     }),
-    getDefaultCompileArgs: vi.fn().mockReturnValue(['--backend=manifold']),
   };
 });
 vi.mock('../../io/import_off.ts', () => ({ parseOff: vi.fn() }));


### PR DESCRIPTION
## What
- **One arg builder.** New `buildOpenScadArgs()` is the single source of truth; `checkSyntax` and `render` both build through it. Output is byte-identical (same flags, same order) — verified by review and a full-order `toEqual` test. Removes the test-only `getDefaultCompileArgs()`.
- **Remove the dead fallback.** `compileWithFallback()` had no production callers; deleted along with its now-unused `MISSING_LIBRARY_RE` and `mountDemandLibraries` import. The worker already demand-loads libraries from a static source parse before compiling (and `use`/`include` accept only literal paths), so the post-failure retry covered nothing real.
- **Right source for diagnostics.** `checkSyntax` shifts lines against `activePath`, not `sources[0].path` (inert today with `skipLines: 0`, but correct).

## Review
An adversarial review confirmed byte-identical args (syntax and render), the `sourcePath` change can't regress line attribution, and no real capability is lost. Its SHOULD-FIX items are included: stale `getDefaultCompileArgs` mock keys dropped across 4 test files, a full arg-ordering assertion added, and a now-dead filesystem mock removed from the worker-timeout test.

## Tests
Rewritten compile-pipeline suite (builder + `spawnOpenSCAD`), full unit suite (230) green, plus e2e renders / BOSL2 / NopSCADlib / syntax / customizer all pass — confirming library demand-loading still works without the fallback.

Closes #54