### PR TITLE
refactor: host-neutral diagnostics, remove Monaco from domain (#55)

### DIFF
--- a/src/__tests__/diagnostics.test.ts
+++ b/src/__tests__/diagnostics.test.ts
@@ -1,0 +1,61 @@
+import * as monaco from 'monaco-editor/esm/vs/editor/editor.api';
+import {
+  countDiagnostics,
+  maxDiagnosticSeverity,
+  hasErrorDiagnostic,
+  type Diagnostic,
+} from '../diagnostics.ts';
+import { toMonacoMarkers } from '../language/diagnostic-markers.ts';
+
+function diag(severity: Diagnostic['severity'], line = 1): Diagnostic {
+  return {
+    severity,
+    message: `${severity} at ${line}`,
+    startLineNumber: line,
+    startColumn: 1,
+    endLineNumber: line,
+    endColumn: 10,
+  };
+}
+
+describe('diagnostics helpers (#55)', () => {
+  it('counts diagnostics by severity', () => {
+    const counts = countDiagnostics([diag('error'), diag('error'), diag('warning'), diag('info')]);
+    expect(counts).toEqual({ error: 2, warning: 1, info: 1 });
+  });
+
+  it('reports the most severe level present', () => {
+    expect(maxDiagnosticSeverity([diag('info'), diag('warning')])).toBe('warning');
+    expect(maxDiagnosticSeverity([diag('warning'), diag('error'), diag('info')])).toBe('error');
+    expect(maxDiagnosticSeverity([])).toBeNull();
+  });
+
+  it('detects an error diagnostic', () => {
+    expect(hasErrorDiagnostic([diag('warning'), diag('info')])).toBe(false);
+    expect(hasErrorDiagnostic([diag('warning'), diag('error')])).toBe(true);
+  });
+});
+
+describe('toMonacoMarkers adapter (#55)', () => {
+  it('maps host-neutral severities to Monaco MarkerSeverity and preserves the range', () => {
+    const markers = toMonacoMarkers([diag('error', 3), diag('warning', 5), diag('info', 7)]);
+
+    expect(markers.map((m) => m.severity)).toEqual([
+      monaco.MarkerSeverity.Error,
+      monaco.MarkerSeverity.Warning,
+      monaco.MarkerSeverity.Info,
+    ]);
+    expect(markers[0]).toMatchObject({
+      message: 'error at 3',
+      startLineNumber: 3,
+      startColumn: 1,
+      endLineNumber: 3,
+      endColumn: 10,
+    });
+  });
+
+  it('round-trips the optional source field', () => {
+    const [marker] = toMonacoMarkers([{ ...diag('warning'), source: 'openscad' }]);
+    expect(marker.source).toBe('openscad');
+  });
+});

--- a/src/__tests__/user-facing-errors.test.ts
+++ b/src/__tests__/user-facing-errors.test.ts
@@ -1,5 +1,3 @@
-import * as monaco from 'monaco-editor/esm/vs/editor/editor.api';
-
 import {
   createOperationFailure,
   formatExternalLoadError,
@@ -49,7 +47,7 @@ describe('user-facing error helpers', () => {
           endLineNumber: 1,
           endColumn: 100,
           message: 'syntax error',
-          severity: monaco.MarkerSeverity.Error,
+          severity: 'error' as const,
         },
       ],
     });

--- a/src/components/elements/osc-editor-panel.ts
+++ b/src/components/elements/osc-editor-panel.ts
@@ -10,6 +10,7 @@ import { getParentDir, join } from '../../fs/filesystem.ts';
 import { defaultSourcePath, getBlankProjectState } from '../../state/initial-state.ts';
 import { buildUrlForStateParams } from '../../state/fragment-state.ts';
 import { registerOpenSCADLanguage } from '../../language/openscad-register-language.ts';
+import { toMonacoMarkers } from '../../language/diagnostic-markers.ts';
 import { markPerf, measurePerf } from '../../perf/runtime-performance.ts';
 import type { State } from '../../state/app-state.ts';
 import type { Model } from '../../state/model.ts';
@@ -46,7 +47,11 @@ export class OscEditorPanel extends LitElement {
       const checkerRun = st.lastCheckerRun;
       const editorModel = this._editor.getModel();
       if (editorModel && checkerRun) {
-        this._monaco.editor.setModelMarkers(editorModel, 'openscad', checkerRun.markers);
+        this._monaco.editor.setModelMarkers(
+          editorModel,
+          'openscad',
+          toMonacoMarkers(checkerRun.markers),
+        );
       }
 
       // If path changed, update the editor model
@@ -185,7 +190,11 @@ export class OscEditorPanel extends LitElement {
     const checkerRun = st.lastCheckerRun;
     const editorModelInstance = editor.getModel();
     if (editorModelInstance && checkerRun) {
-      monaco.editor.setModelMarkers(editorModelInstance, 'openscad', checkerRun.markers);
+      monaco.editor.setModelMarkers(
+        editorModelInstance,
+        'openscad',
+        toMonacoMarkers(checkerRun.markers),
+      );
     }
 
     // ResizeObserver to keep Monaco sized correctly

--- a/src/components/elements/osc-footer.ts
+++ b/src/components/elements/osc-footer.ts
@@ -1,7 +1,7 @@
 // Portions of this file are Copyright 2021 Google LLC, and licensed under GPL2+. See COPYING.
 import { LitElement, html, css } from 'lit';
 import { customElement, state } from 'lit/decorators.js';
-import * as monaco from 'monaco-editor/esm/vs/editor/editor.api';
+import { countDiagnostics, maxDiagnosticSeverity } from '../../diagnostics.ts';
 import { getModel } from '../../state/model-context.ts';
 import type { State } from '../../state/app-state.ts';
 import type { Model } from '../../state/model.ts';
@@ -159,13 +159,11 @@ export class OscFooter extends LitElement {
 
     const busy = st.rendering || st.previewing || st.checkingSyntax || st.exporting;
     const markers = st.lastCheckerRun?.markers ?? [];
-    const errCount = markers.filter((m) => m.severity === monaco.MarkerSeverity.Error).length;
-    const warnCount = markers.filter((m) => m.severity === monaco.MarkerSeverity.Warning).length;
-    const infoCount = markers.filter((m) => m.severity === monaco.MarkerSeverity.Info).length;
-    const maxSev =
-      markers.length === 0
-        ? undefined
-        : markers.reduce((a, b) => (a.severity > b.severity ? a : b)).severity;
+    const counts = countDiagnostics(markers);
+    const errCount = counts.error;
+    const warnCount = counts.warning;
+    const infoCount = counts.info;
+    const maxSev = maxDiagnosticSeverity(markers) ?? undefined;
     const hasDiagnostics = !!(
       st.lastCheckerRun ||
       st.output ||
@@ -237,9 +235,9 @@ export class OscFooter extends LitElement {
         ${hasDiagnostics
           ? html`
               <button
-                class="foot-btn ${maxSev === monaco.MarkerSeverity.Error
+                class="foot-btn ${maxSev === 'error'
                   ? 'danger'
-                  : maxSev === monaco.MarkerSeverity.Warning
+                  : maxSev === 'warning'
                     ? 'warning'
                     : ''}"
                 title="Toggle log output"

--- a/src/diagnostics.ts
+++ b/src/diagnostics.ts
@@ -1,0 +1,38 @@
+// Host-neutral compile diagnostics. Domain and runner code produce and consume
+// these; each host (the Monaco editor today, others later) converts them to its
+// own representation at its boundary, so the core never depends on an editor API.
+
+export type DiagnosticSeverity = 'error' | 'warning' | 'info';
+
+export interface Diagnostic {
+  severity: DiagnosticSeverity;
+  message: string;
+  // 1-based line/column range (compatible with common editor marker APIs).
+  startLineNumber: number;
+  startColumn: number;
+  endLineNumber: number;
+  endColumn: number;
+  /** Optional source/tool that produced the diagnostic. */
+  source?: string;
+}
+
+const SEVERITY_RANK: Record<DiagnosticSeverity, number> = { info: 0, warning: 1, error: 2 };
+
+export function countDiagnostics(diagnostics: Diagnostic[]): Record<DiagnosticSeverity, number> {
+  const counts: Record<DiagnosticSeverity, number> = { error: 0, warning: 0, info: 0 };
+  for (const d of diagnostics) counts[d.severity]++;
+  return counts;
+}
+
+/** The most severe level present, or null if there are no diagnostics. */
+export function maxDiagnosticSeverity(diagnostics: Diagnostic[]): DiagnosticSeverity | null {
+  let max: DiagnosticSeverity | null = null;
+  for (const d of diagnostics) {
+    if (max === null || SEVERITY_RANK[d.severity] > SEVERITY_RANK[max]) max = d.severity;
+  }
+  return max;
+}
+
+export function hasErrorDiagnostic(diagnostics: Diagnostic[]): boolean {
+  return diagnostics.some((d) => d.severity === 'error');
+}

--- a/src/language/diagnostic-markers.ts
+++ b/src/language/diagnostic-markers.ts
@@ -1,0 +1,23 @@
+// Adapter from host-neutral Diagnostics to Monaco editor markers. This is the
+// only place the editor's marker representation meets the core diagnostics, so
+// Monaco stays out of domain and runner code.
+import * as monaco from 'monaco-editor/esm/vs/editor/editor.api';
+import type { Diagnostic, DiagnosticSeverity } from '../diagnostics.ts';
+
+const MONACO_SEVERITY: Record<DiagnosticSeverity, monaco.MarkerSeverity> = {
+  error: monaco.MarkerSeverity.Error,
+  warning: monaco.MarkerSeverity.Warning,
+  info: monaco.MarkerSeverity.Info,
+};
+
+export function toMonacoMarkers(diagnostics: Diagnostic[]): monaco.editor.IMarkerData[] {
+  return diagnostics.map((d) => ({
+    severity: MONACO_SEVERITY[d.severity],
+    message: d.message,
+    startLineNumber: d.startLineNumber,
+    startColumn: d.startColumn,
+    endLineNumber: d.endLineNumber,
+    endColumn: d.endColumn,
+    source: d.source,
+  }));
+}

--- a/src/runner/actions.ts
+++ b/src/runner/actions.ts
@@ -1,6 +1,6 @@
 // Portions of this file are Copyright 2021 Google LLC, and licensed under GPL2+. See COPYING.
 
-import * as monaco from 'monaco-editor/esm/vs/editor/editor.api';
+import type { Diagnostic } from '../diagnostics.ts';
 import { ProcessStreams, isExpectedJobCancellation, spawnOpenSCAD } from './openscad-runner.ts';
 import { processMergedOutputs } from './output-parser.ts';
 import { AbortablePromise, turnIntoDelayableExecution } from '../utils.ts';
@@ -17,7 +17,7 @@ type SyntaxCheckArgs = {
 };
 type SyntaxCheckOutput = {
   logText: string;
-  markers: monaco.editor.IMarkerData[];
+  markers: Diagnostic[];
   parameterSet?: ParameterSet;
 };
 export const checkSyntax = turnIntoDelayableExecution(syntaxDelay, (sargs: SyntaxCheckArgs) => {
@@ -79,7 +79,7 @@ const renderDelay = 1000;
 export type RenderOutput = {
   outFile: File;
   logText: string;
-  markers: monaco.editor.IMarkerData[];
+  markers: Diagnostic[];
   elapsedMillis: number;
 };
 

--- a/src/runner/output-parser.ts
+++ b/src/runner/output-parser.ts
@@ -1,5 +1,5 @@
-import * as monaco from 'monaco-editor/esm/vs/editor/editor.api';
 import { MergedOutputs } from './openscad-runner';
+import type { Diagnostic } from '../diagnostics.ts';
 
 const ignoredLogs = new Set(['Could not initialize localization.']);
 
@@ -31,10 +31,10 @@ export function joinMergedOutputs(mergedOutputs: MergedOutputs, _opts: MergedOut
 export function parseMergedOutputs(
   mergedOutputs: MergedOutputs,
   opts: MergedOutputsOptions,
-): monaco.editor.IMarkerData[] {
+): Diagnostic[] {
   let unmatchedLines = [];
 
-  const markers = [];
+  const markers: Diagnostic[] = [];
   let warningCount = 0,
     errorCount = 0;
   const addError = (error: string, file: string, line: number) => {
@@ -44,7 +44,7 @@ export function parseMergedOutputs(
       endLineNumber: Number(line),
       endColumn: 1000,
       message: error,
-      severity: monaco.MarkerSeverity.Error,
+      severity: 'error',
     });
   };
   const shiftSourceName = opts.shiftSourceLines && opts.shiftSourceLines.sourcePath;
@@ -84,7 +84,7 @@ export function parseMergedOutputs(
           endLineNumber: getLine(file, line),
           endColumn: 1000,
           message: warning,
-          severity: monaco.MarkerSeverity.Warning,
+          severity: 'warning',
         });
         continue;
       }

--- a/src/state/__tests__/model.test.ts
+++ b/src/state/__tests__/model.test.ts
@@ -5,7 +5,6 @@
 import { Model } from '../model.ts';
 import { State } from '../app-state.ts';
 import { defaultSourcePath, defaultModelColor } from '../initial-state.ts';
-import * as monaco from 'monaco-editor/esm/vs/editor/editor.api';
 import { createOperationFailure } from '../../user-facing-errors.ts';
 
 // ---------------------------------------------------------------------------
@@ -361,7 +360,7 @@ describe('Model — expected cancellation handling', () => {
               endLineNumber: 1,
               endColumn: 100,
               message: 'syntax error',
-              severity: monaco.MarkerSeverity.Error,
+              severity: 'error' as const,
             },
           ],
         }),

--- a/src/state/app-state.ts
+++ b/src/state/app-state.ts
@@ -1,6 +1,6 @@
 // Portions of this file are Copyright 2021 Google LLC, and licensed under GPL2+. See COPYING.
 
-import * as monaco from 'monaco-editor/esm/vs/editor/editor.api';
+import type { Diagnostic } from '../diagnostics.ts';
 import { ParameterSet } from './customizer-types.ts';
 import { VALID_EXPORT_FORMATS_2D, VALID_EXPORT_FORMATS_3D } from './formats.ts';
 
@@ -73,7 +73,7 @@ export interface State {
 
   lastCheckerRun?: {
     logText: string;
-    markers: monaco.editor.IMarkerData[];
+    markers: Diagnostic[];
   };
   rendering?: boolean;
   previewing?: boolean;

--- a/src/user-facing-errors.ts
+++ b/src/user-facing-errors.ts
@@ -1,4 +1,4 @@
-import * as monaco from 'monaco-editor/esm/vs/editor/editor.api';
+import { hasErrorDiagnostic, type Diagnostic } from './diagnostics.ts';
 
 export type UserFacingOperation = 'preview' | 'render' | 'export' | 'syntax' | 'source' | 'model';
 
@@ -6,7 +6,7 @@ export type UserFacingError = {
   message: string;
   details?: string;
   logText?: string;
-  markers?: monaco.editor.IMarkerData[];
+  markers?: Diagnostic[];
 };
 
 export class UserFacingOperationError extends Error {
@@ -88,14 +88,12 @@ export function createOperationFailure(
     markers,
     logText,
   }: {
-    markers?: monaco.editor.IMarkerData[];
+    markers?: Diagnostic[];
     logText?: string;
   } = {},
 ): UserFacingOperationError {
   const details = getErrorText(error);
-  const hasSyntaxErrors = (markers ?? []).some(
-    (marker) => marker.severity === monaco.MarkerSeverity.Error,
-  );
+  const hasSyntaxErrors = hasErrorDiagnostic(markers ?? []);
 
   if (hasSyntaxErrors) {
     return new UserFacingOperationError({


### PR DESCRIPTION
## What
Domain state and runner contracts typed diagnostics as `monaco.editor.IMarkerData`, coupling them to the editor library.

- New `src/diagnostics.ts` — host-neutral `Diagnostic` (severity `'error'|'warning'|'info'`, message, 1-based range, optional source) + helpers (`countDiagnostics`, `maxDiagnosticSeverity`, `hasErrorDiagnostic`).
- The output parser, runner action contracts (`SyntaxCheckOutput`/`RenderOutput`), app `State`, and `user-facing-errors` now produce/consume `Diagnostic[]`.
- New `src/language/diagnostic-markers.ts#toMonacoMarkers` is the **only** domain→Monaco bridge, used by the editor panel. The footer uses the host-neutral severity helpers.
- **`grep monaco-editor src/state src/runner` is now empty.**

## Review
An adversarial review verified the acceptance (domain is monaco-free; adapter is the sole bridge), behavior preservation (severity ranking matches Monaco's Error>Warning>Info; footer counts, error-banner `hasErrorDiagnostic`, and rendered markers unchanged), and completeness (all `.markers` consumers updated or shape-agnostic). Its NIT — a `source`-field round-trip test — is included. The `markers` field keeps its name (type is now `Diagnostic[]`); a rename to `diagnostics` is noted as optional future polish.

## Tests
`diagnostics.test.ts` (helpers + adapter incl. source round-trip); full unit suite green; e2e syntax-marker/error-banner + render pass.

Closes #55