### PR TITLE
fix(viewer): on-demand rendering, full disposal, context-loss (#61)

### DIFF
--- a/src/components/elements/osc-viewer-panel.ts
+++ b/src/components/elements/osc-viewer-panel.ts
@@ -131,6 +131,7 @@ export class OscViewerPanel extends LitElement {
     if (!scene) return;
     try {
       const text = await file.text();
+      if (this._scene !== scene) return; // viewer torn down / scene replaced during await
       const data = parseOff(text);
       const geometry = offToBufferGeometry(data);
       const color = this._st?.view.color ?? '#f9d72c';
@@ -138,8 +139,11 @@ export class OscViewerPanel extends LitElement {
 
       if (this._container) this._container.dataset.geometryLoaded = 'true';
 
-      const dataUrl = scene.renderer.domElement.toDataURL('image/png', 0.5);
+      // Render the new geometry before capturing so the thumbnail isn't stale.
+      scene.renderOnce();
+      const dataUrl = scene.renderer.domElement.toDataURL('image/png');
       const hash = await imageToThumbhash(dataUrl);
+      if (this._scene !== scene) return; // torn down during hashing
       this._model.mutate((s) => {
         s.preview = { thumbhash: hash };
       });

--- a/src/components/viewer/ThreeScene.ts
+++ b/src/components/viewer/ThreeScene.ts
@@ -9,6 +9,13 @@ export type { CameraState };
 
 const BACKGROUND_COLOR = new THREE.Color(0x1e1e1e);
 
+/** Cap device-pixel-ratio so high-DPI displays don't blow up fill cost / memory. */
+export const MAX_PIXEL_RATIO = 2;
+export function cappedPixelRatio(devicePixelRatio: number, max = MAX_PIXEL_RATIO): number {
+  if (!Number.isFinite(devicePixelRatio) || devicePixelRatio <= 0) return 1;
+  return Math.min(devicePixelRatio, max);
+}
+
 export interface NamedPosition {
   name: string;
   position: [number, number, number];
@@ -33,17 +40,36 @@ export class ThreeScene {
   readonly scene: THREE.Scene;
   readonly controls: OrbitControls;
   private animationId: number | null = null;
+  private needsRender = false;
   private modelMesh: THREE.Mesh | null = null;
   private axesObject: THREE.LineSegments | null = null;
+  private cameraDebounceTimer: ReturnType<typeof setTimeout> | null = null;
+  private readonly onContextLostHandler: (e: Event) => void;
+  private readonly onContextRestoredHandler: () => void;
 
   // Callback fired (debounced) when the user moves the camera.
   onCameraChange: ((state: CameraState) => void) | null = null;
+  // Fired when the WebGL context is lost (recoverable; a restore re-renders).
+  onContextLost: (() => void) | null = null;
 
   constructor(container: HTMLElement) {
     this.renderer = new THREE.WebGLRenderer({ antialias: true, alpha: false });
-    this.renderer.setPixelRatio(window.devicePixelRatio);
+    this.renderer.setPixelRatio(cappedPixelRatio(window.devicePixelRatio));
     this.renderer.setSize(container.clientWidth, container.clientHeight);
     container.appendChild(this.renderer.domElement);
+
+    // Recover gracefully from a lost WebGL context instead of going silently blank.
+    this.onContextLostHandler = (e: Event) => {
+      e.preventDefault(); // allow the browser to restore the context
+      this.stop();
+      this.onContextLost?.();
+    };
+    this.onContextRestoredHandler = () => this.requestRender();
+    this.renderer.domElement.addEventListener('webglcontextlost', this.onContextLostHandler);
+    this.renderer.domElement.addEventListener(
+      'webglcontextrestored',
+      this.onContextRestoredHandler,
+    );
 
     this.camera = new THREE.PerspectiveCamera(
       45,
@@ -71,14 +97,15 @@ export class ThreeScene {
     this.controls.enableDamping = true;
     this.controls.dampingFactor = 0.05;
 
-    // Forward camera changes to caller (debounced 200 ms).
-    let debounceTimer: ReturnType<typeof setTimeout> | null = null;
     this.controls.addEventListener('change', () => {
+      // Any control-driven change needs a frame...
+      this.requestRender();
+      // ...and is forwarded to the caller (debounced 200 ms).
       if (!this.onCameraChange) return;
-      if (debounceTimer) clearTimeout(debounceTimer);
-      debounceTimer = setTimeout(() => {
+      if (this.cameraDebounceTimer) clearTimeout(this.cameraDebounceTimer);
+      this.cameraDebounceTimer = setTimeout(() => {
         this.onCameraChange?.(this.getCameraState());
-        debounceTimer = null;
+        this.cameraDebounceTimer = null;
       }, 200);
     });
   }
@@ -87,14 +114,36 @@ export class ThreeScene {
   // Lifecycle
   // ---------------------------------------------------------------------------
 
+  /** Render on demand: schedule a single frame, plus a damping settle loop. */
   start(): void {
-    const animate = () => {
-      this.animationId = requestAnimationFrame(animate);
-      this.controls.update();
-      this.renderer.render(this.scene, this.camera);
-    };
-    animate();
+    this.requestRender();
   }
+
+  requestRender(): void {
+    this.needsRender = true;
+    if (this.animationId === null) {
+      this.animationId = requestAnimationFrame(this.tick);
+    }
+  }
+
+  /** Render exactly one frame now (e.g. before capturing the canvas). */
+  renderOnce(): void {
+    this.renderer.render(this.scene, this.camera);
+    this.needsRender = false;
+  }
+
+  private tick = (): void => {
+    // OrbitControls damping keeps moving the camera for a few frames after input;
+    // update() returns true while it's still settling.
+    const damping = this.controls.update();
+    this.renderer.render(this.scene, this.camera);
+    this.needsRender = false;
+    if (damping || this.needsRender) {
+      this.animationId = requestAnimationFrame(this.tick);
+    } else {
+      this.animationId = null; // settled — stop until the next requestRender()
+    }
+  };
 
   stop(): void {
     if (this.animationId !== null) {
@@ -108,11 +157,37 @@ export class ThreeScene {
     this.camera.aspect = width / height;
     this.camera.updateProjectionMatrix();
     this.renderer.setSize(width, height);
+    this.requestRender();
   }
 
   dispose(): void {
     this.stop();
+    if (this.cameraDebounceTimer) {
+      clearTimeout(this.cameraDebounceTimer);
+      this.cameraDebounceTimer = null;
+    }
+    this.renderer.domElement.removeEventListener('webglcontextlost', this.onContextLostHandler);
+    this.renderer.domElement.removeEventListener(
+      'webglcontextrestored',
+      this.onContextRestoredHandler,
+    );
+    if (this.modelMesh) {
+      this.scene.remove(this.modelMesh);
+      this.modelMesh.geometry.dispose();
+      (this.modelMesh.material as THREE.Material).dispose();
+      this.modelMesh = null;
+    }
+    if (this.axesObject) {
+      this.scene.remove(this.axesObject);
+      this.axesObject.geometry.dispose();
+      (this.axesObject.material as THREE.Material).dispose();
+      this.axesObject = null;
+    }
     this.controls.dispose();
+    // renderer.dispose() frees programs/render-lists but not the GL context itself;
+    // force it so repeated viewer teardowns (e.g. 3D<->SVG toggles) don't accumulate
+    // live WebGL contexts toward the browser's per-page limit.
+    this.renderer.forceContextLoss();
     this.renderer.dispose();
     this.renderer.domElement.remove();
   }
@@ -142,6 +217,7 @@ export class ThreeScene {
     this.modelMesh = new THREE.Mesh(geometry, material);
     this.scene.add(this.modelMesh);
     this.fitCameraToMesh(this.modelMesh);
+    this.requestRender();
   }
 
   private fitCameraToMesh(mesh: THREE.Mesh): void {
@@ -178,6 +254,7 @@ export class ThreeScene {
     this.camera.zoom = saved.zoom;
     this.camera.updateProjectionMatrix();
     this.controls.update();
+    this.requestRender();
   }
 
   setCameraPosition(name: string): void {
@@ -193,6 +270,7 @@ export class ThreeScene {
     this.camera.zoom = 1;
     this.camera.updateProjectionMatrix();
     this.controls.update();
+    this.requestRender();
   }
 
   // ---------------------------------------------------------------------------
@@ -245,6 +323,7 @@ export class ThreeScene {
     } else if (this.axesObject) {
       this.scene.remove(this.axesObject);
     }
+    this.requestRender();
   }
 
   // ---------------------------------------------------------------------------
@@ -256,6 +335,7 @@ export class ThreeScene {
       const mat = this.modelMesh.material as THREE.MeshPhongMaterial;
       // Don't override per-vertex colors from a multi-material model.
       if (!mat.vertexColors) mat.color.set(color);
+      this.requestRender();
     }
   }
 }

--- a/src/components/viewer/__tests__/three-scene-helpers.test.ts
+++ b/src/components/viewer/__tests__/three-scene-helpers.test.ts
@@ -1,0 +1,20 @@
+import { cappedPixelRatio, MAX_PIXEL_RATIO } from '../ThreeScene.ts';
+
+describe('cappedPixelRatio (#61)', () => {
+  it('caps high device-pixel-ratios at the maximum', () => {
+    expect(cappedPixelRatio(3)).toBe(MAX_PIXEL_RATIO);
+    expect(cappedPixelRatio(4, 2)).toBe(2);
+  });
+
+  it('passes through ratios at or below the cap', () => {
+    expect(cappedPixelRatio(1)).toBe(1);
+    expect(cappedPixelRatio(1.5)).toBe(1.5);
+    expect(cappedPixelRatio(2)).toBe(2);
+  });
+
+  it('falls back to 1 for invalid ratios', () => {
+    expect(cappedPixelRatio(0)).toBe(1);
+    expect(cappedPixelRatio(-2)).toBe(1);
+    expect(cappedPixelRatio(NaN)).toBe(1);
+  });
+});

--- a/tests/e2e.spec.ts
+++ b/tests/e2e.spec.ts
@@ -788,6 +788,32 @@ test.describe('conformance — geometry primitives', () => {
     });
     expect(loaded).toBe(true);
   });
+
+  test('a non-empty preview thumbnail is produced from the rendered canvas', async ({ page }) => {
+    // The preview thumbhash is computed from the rendered canvas (renderOnce ->
+    // toDataURL). Its presence proves the capture path produced pixels; a render
+    // that threw or a missing canvas would leave it unset.
+    await loadSrc(page, 'cube([20, 20, 20]);');
+    await waitForViewer(page);
+    const thumbhash = await page.evaluate(async () => {
+      for (let i = 0; i < 50; i++) {
+        const shell = document.querySelector('osc-app-shell') as
+          | (Element & { _st?: unknown })
+          | null;
+        const state =
+          shell && '_st' in shell ? (shell._st as Record<string, unknown> | undefined) : null;
+        const preview =
+          state && typeof state === 'object' && 'preview' in state
+            ? (state.preview as Record<string, unknown> | undefined)
+            : undefined;
+        if (preview?.thumbhash != null) return JSON.stringify(preview.thumbhash);
+        await new Promise((r) => setTimeout(r, 100));
+      }
+      return null;
+    });
+    expect(thumbhash).not.toBeNull();
+    expect(thumbhash).not.toBe('""');
+  });
 });
 
 test.describe('e2e — keyboard shortcuts', () => {


### PR DESCRIPTION
## What
A correctness/resource pass on the Three.js viewer:
- **On-demand rendering** — `requestRender()`/`tick()` replace the perpetual `requestAnimationFrame` loop; frames are drawn only when geometry/camera/axes/color/size change, with a short damping settle loop. No more continuous CPU/GPU when idle.
- **`renderOnce()` before capture** — the preview thumbnail reflects the newly-loaded geometry instead of a stale frame.
- **Full disposal** — `dispose()` now frees mesh + axes geometry/material, clears the camera debounce timer, removes the context-loss listeners, and calls `forceContextLoss()` so repeated teardowns (e.g. 3D↔SVG toggles) don't accumulate live WebGL contexts toward the browser's per-page limit.
- **Capped DPR** — `cappedPixelRatio` (≤2), unit-tested.
- **WebGL context-loss/restored** handling (recoverable; restore re-renders).
- **Panel teardown guards** — the async geometry load/hash re-checks `this._scene` after each await.

## Review
An adversarial review traced the loop against three.js r184 source and confirmed: damping settles correctly (render-then-check, no dropped final frame), no rAF double-schedule or lost `requestRender`, dispose is complete + double-dispose safe, and the panel guards have no remaining race. Its two SHOULD-FIX items are included — `forceContextLoss()` (a real GL-context leak) and explicit `requestRender()` in `setCameraPosition`/`applyCameraState` (robustness vs. relying on OrbitControls' implicit `change` event).

## Tests
`cappedPixelRatio` unit test; a new e2e asserting a non-empty preview thumbnail is produced from the rendered canvas; full e2e suite (viewer render, F5/F6, camera) green; 238 unit tests, tsc, ESLint, Prettier green. (ThreeScene needs WebGL so its loop is e2e-validated, not unit-testable in jsdom.)

Closes #61