### PR TITLE
docs(architecture): document layout, boundaries, and decisions (#45)

### DIFF
--- a/README.md
+++ b/README.md
@@ -127,6 +127,11 @@ For publishing OpenSCAD projects into GitHub Pages or another static-site tree, 
 
 Security assumptions, CSP guidance, and external-source loading policy are documented in [docs/SECURITY.md](./docs/SECURITY.md).
 
+## Architecture
+
+The module layout, dependency boundaries, compile lifecycle, and the decision
+records behind the current design live in [docs/architecture/](./docs/architecture/README.md).
+
 ## Contributing
 
 Contributor workflow, verification expectations, and repo conventions are documented in [docs/CONTRIBUTING.md](./docs/CONTRIBUTING.md).

--- a/docs/architecture/README.md
+++ b/docs/architecture/README.md
@@ -1,0 +1,102 @@
+# Architecture overview
+
+OpenSCAD Web is a fully client-side application: a Lit UI shell, a Monaco editor,
+a Three.js viewer, and a persistent Web Worker that runs OpenSCAD compiled to
+WebAssembly against a BrowserFS virtual filesystem. There is no server component.
+
+This document describes how the pieces fit together and the dependency
+boundaries the code is being shaped toward. It reflects the code as it is, and
+calls out where a boundary is intended but not yet fully realized.
+
+## Layers
+
+```mermaid
+flowchart TD
+  subgraph hosts[UI hosts - Lit components]
+    shell[osc-app-shell / embed / customizer shells]
+    editor[osc-editor-panel - Monaco]
+    viewer[osc-viewer-panel]
+    footer[osc-footer]
+  end
+
+  subgraph state[Application state - src/state]
+    model[Model - EventTarget controller]
+    appstate[State / Source / app-state]
+    fragment[fragment-state - URL persistence]
+    urlmode[url-mode]
+  end
+
+  subgraph runner[Compile pipeline - src/runner]
+    actions[actions - checkSyntax / render / buildOpenScadArgs]
+    runnercore[openscad-runner - worker lifecycle, scheduler, timeouts]
+    protocol[worker-protocol]
+    parser[output-parser]
+    worker[[openscad-worker - WASM in a Web Worker]]
+  end
+
+  subgraph core[Host-neutral core]
+    diag[diagnostics]
+    projpath[fs/project-path - path validation]
+    fs[fs/filesystem - BrowserFS]
+  end
+
+  subgraph viewercore[Viewer core - src/components/viewer]
+    three[ThreeScene]
+    off[off-loader]
+  end
+
+  subgraph editorpkg[Editor package - src/language]
+    lang[OpenSCAD language registration]
+    adapter[diagnostic-markers - Diagnostic to Monaco]
+  end
+
+  hosts --> state
+  state --> runner
+  state --> core
+  viewer --> viewercore
+  editor --> editorpkg
+  runner --> core
+  actions --> parser --> diag
+  editor --> diag
+  footer --> diag
+  adapter --> diag
+```
+
+## Module map
+
+| Area             | Path                       | Responsibility                                                                                                                    |
+| ---------------- | -------------------------- | --------------------------------------------------------------------------------------------------------------------------------- |
+| Bootstrap        | `src/index.ts`             | Parse boot mode, init BrowserFS, construct `Model`, mount the shell                                                               |
+| State            | `src/state/`               | `Model` (central `EventTarget` controller), `State`/`Source`, URL persistence, url-mode, deep-mutate                              |
+| Compile pipeline | `src/runner/`              | Worker lifecycle + scheduler + timeouts, arg building, the in-worker WASM driver, the worker protocol, stderr→diagnostics parsing |
+| Diagnostics      | `src/diagnostics.ts`       | Host-neutral `Diagnostic` type + severity helpers                                                                                 |
+| Filesystem       | `src/fs/`                  | BrowserFS canonical mounts, demand-loaded libraries, `project-path` validation                                                    |
+| Runtime          | `src/runtime/`             | Asset URL resolution, bounded asset fetching, service worker, boot config                                                         |
+| Viewer core      | `src/components/viewer/`   | `ThreeScene` (framework-free Three.js wrapper), OFF loader                                                                        |
+| Editor package   | `src/language/`            | Monaco language registration, `Diagnostic`→Monaco marker adapter                                                                  |
+| UI               | `src/components/elements/` | Lit components (shells, editor/viewer/customizer panels, footer)                                                                  |
+| IO               | `src/io/`                  | OFF import, 3MF export, image hashing                                                                                             |
+
+## Dependency boundaries
+
+The cleanup epic is moving the codebase toward a clean separation between a
+host-neutral core and the UI host(s). The current state of each rule:
+
+- **No editor library in domain/runner.** ✅ Enforced by convention today —
+  `src/state` and `src/runner` contain no `monaco-editor` import. Diagnostics
+  flow as the host-neutral `Diagnostic` type; the editor converts to Monaco
+  markers via `src/language/diagnostic-markers.ts` at its boundary.
+- **Untrusted input is validated centrally.** ✅ `fs/project-path` validates and
+  bounds imported archive paths; `runtime/fetch-asset` bounds and status-checks
+  asset fetches; `external-source` enforces the URL policy; `actions.formatValue`
+  validates customizer values before building `-D` args.
+- **Viewer core is framework-free.** ✅ `ThreeScene` has no Lit/`Model`
+  dependency. ⚠️ `osc-viewer-panel` still reaches into the global `Model`; making
+  it a thin adapter over a model-independent `osc-geometry-viewer` is tracked in
+  #60.
+- **Domain is free of direct DOM access.** ⚠️ Not yet — `Model` plays the
+  completion chime via `document`, and `utils` owns browser download/IO helpers.
+  Extracting a web-host adapter is tracked in #59.
+
+See the [ADRs](./adr/) for the decisions behind these boundaries, and
+[compile-lifecycle.md](./compile-lifecycle.md) for how a compile flows end to end.

--- a/docs/architecture/adr/0001-host-neutral-diagnostics.md
+++ b/docs/architecture/adr/0001-host-neutral-diagnostics.md
@@ -1,0 +1,31 @@
+# ADR 0001 — Host-neutral diagnostics
+
+**Status:** Accepted (#55)
+
+## Context
+
+Compiler diagnostics were typed as `monaco.editor.IMarkerData` throughout the
+domain: `State`, the runner action contracts, and `user-facing-errors`. This
+coupled the compiler/diagnostic contracts to the editor library, so any non-editor
+consumer (the footer, error normalization, future hosts) inherited a Monaco
+dependency, and the editor's marker shape leaked into the core.
+
+## Decision
+
+Introduce a host-neutral `Diagnostic` type (`src/diagnostics.ts`):
+`severity: 'error' | 'warning' | 'info'`, a message, a 1-based range, and an
+optional `source`. The output parser, runner contracts, `State`, and
+`user-facing-errors` produce and consume `Diagnostic[]`. The editor converts to
+Monaco markers via a single adapter (`src/language/diagnostic-markers.ts`); the
+footer uses host-neutral severity helpers.
+
+`src/state` and `src/runner` contain no `monaco-editor` import.
+
+## Consequences
+
+- Diagnostics flow as a plain data type; only the editor package knows about
+  Monaco markers.
+- Severity ordering (`error > warning > info`) is preserved by an explicit rank,
+  matching Monaco's previous numeric ordering.
+- The state field is still named `markers` (type `Diagnostic[]`); renaming it to
+  `diagnostics` is deferred as cosmetic.

--- a/docs/architecture/adr/0002-worker-timeout-recovery.md
+++ b/docs/architecture/adr/0002-worker-timeout-recovery.md
@@ -1,0 +1,34 @@
+# ADR 0002 — Worker timeout recovery
+
+**Status:** Accepted (#47)
+
+## Context
+
+The runner used a two-tier timeout: a 30s "soft" timeout rejected the job and
+**cleared** the 60s "hard" timeout, which was the only path that recycled the
+worker. Because `OpenSCADRuntime.callMain()` is a synchronous WASM call, a wedged
+`callMain` could never process the posted cancel message, and the soft path's
+clearing of the hard timeout meant the worker was never recycled. The result: a
+permanently blocked worker, with every subsequent request posted to it.
+
+## Decision
+
+Recover the worker at timeout. A single `COMPILE_TIMEOUT_MS` per job; on timeout
+the runner:
+
+1. terminates the wedged worker and lazily recreates a clean one on the next
+   request;
+2. bumps a `_workerGeneration` counter so late messages from the terminated
+   worker are ignored;
+3. rejects the jobs bound to that generation with a clear error.
+
+Queued-job cancellation (priority supersession, explicit abort) remains a
+distinct, non-terminating path — only a wedged or crashed worker triggers a
+teardown, which the crash handler now shares.
+
+## Consequences
+
+- A hung `callMain` is recovered; the next compile succeeds on a fresh worker.
+- No code path disables the recovery mechanism.
+- A fresh worker pays WASM init again, but the `.wasm` is browser-cached so the
+  cost is small relative to never recovering.

--- a/docs/architecture/adr/0003-deterministic-scheduler.md
+++ b/docs/architecture/adr/0003-deterministic-scheduler.md
@@ -1,0 +1,31 @@
+# ADR 0003 — Deterministic debounce/supersede scheduling
+
+**Status:** Accepted (#48)
+
+## Context
+
+`turnIntoDelayableExecution` shared one pending timer and one running kill signal
+across all invocations of a wrapped operation. A superseded **delayed** call had
+its timer cleared but its promise was never settled — an orphaned promise leaked
+on normal rapid editing. Killing a delayed call left its promise pending too. And
+a finished job's `finally` could null the kill signal a **newer** job had just
+stored, leaving the newer job uncancellable (a race).
+
+## Decision
+
+Rewrite the primitive so each call owns its own timer and canceller, and every
+returned promise reaches exactly one terminal state — resolved, failed, or
+rejected with a cancellation when superseded or killed. The shared "live"
+canceller is identity-checked on cleanup, so a finished job cannot clobber a
+newer call's canceller. A synchronous throw from the job factory rejects the
+promise instead of leaving it pending.
+
+Because superseded calls now settle (reject) instead of hanging, `Model.render`
+and `Model.checkSyntax` gained per-kind sequence guards so a stale call cannot
+turn off a UI flag that a newer call is still driving.
+
+## Consequences
+
+- No orphaned/never-settled promises under interleaved edit/cancel.
+- The cancel-signal clobber race is eliminated.
+- Spinner state is unaffected (validated against the full e2e suite).

--- a/docs/architecture/adr/0004-defer-source-union.md
+++ b/docs/architecture/adr/0004-defer-source-union.md
@@ -1,0 +1,46 @@
+# ADR 0004 — Defer the `Source` discriminated union
+
+**Status:** Deferred (#56)
+
+## Context
+
+`Source` (`{ path; url?; content? }`) allows ambiguous states (both `content` and
+`url` set, or neither; a directory implied only by a trailing `/`). The cleanup
+goal is an explicit discriminated union (text / binary / remote / archive) so no
+ambiguous state is representable, plus a project revision stamped onto compile
+requests/results.
+
+Two facts make this risky to land as one change:
+
+1. **Blast radius** — the `Source` shape (the `sources` field and the `Source`
+   type) is referenced at ~70+ sites across ~15 files (model, runner, worker
+   protocol, url-mode, fragment-state, persistence).
+2. **Serialization backward-compat under live deploy** — `fragment-state`
+   serializes `Source`'s flat shape into shareable model URLs and persisted
+   state. Adding a `kind` discriminator changes that on-the-wire shape. Merges to
+   `main` auto-deploy to the live site, and CI has no legacy-URL backward-compat
+   test, so a subtle regression would ship live and silently break existing
+   shared/bookmarked URLs.
+
+## Decision
+
+Defer the union to a deliberate, decomposed effort rather than a one-shot rewrite:
+
+1. Introduce the `ProjectSource` union plus `toWire`/`fromWire` and
+   `toFragment`/`fromFragment` conversion helpers, keeping both serialized
+   boundaries (worker protocol, URL fragment) in their current flat shapes. Add a
+   **legacy-URL fixture test** that deserializes an old-format fragment — this
+   closes the CI gap before any migration.
+2. Migrate the worker/runner boundary, then `Model`/state, in separate PRs.
+3. Add the project-revision request/result stamping (note: largely overlaps the
+   staleness guards already in place from #47 and #48, so it is contract
+   groundwork rather than a new correctness fix).
+
+`#57` (extract `ProjectStore`) can proceed against the current `Source` type and
+adopt the union later, so it is only softly blocked.
+
+## Consequences
+
+- Ambiguous source states remain representable for now.
+- The migration, when done, must preserve the URL/persistence wire format and
+  prove it with a fixture test.

--- a/docs/architecture/compile-lifecycle.md
+++ b/docs/architecture/compile-lifecycle.md
@@ -1,0 +1,86 @@
+# Compile lifecycle
+
+A "compile" is any OpenSCAD invocation: a syntax/parameter check, a preview
+render, a full render, or an export pass. They all flow through the same
+pipeline and share one persistent Web Worker.
+
+## Request flow
+
+```mermaid
+sequenceDiagram
+  participant M as Model
+  participant A as actions (checkSyntax/render)
+  participant S as scheduler (turnIntoDelayableExecution)
+  participant R as openscad-runner
+  participant W as Web Worker (WASM)
+
+  M->>A: render(args)({ now })
+  A->>S: debounce + supersede
+  Note over S: prior delayed/running call is cancelled<br/>and its promise settled (rejected)
+  S->>A: job() runs after the delay (or immediately if now)
+  A->>R: spawnOpenSCAD(invocation, priority)
+  R->>R: cancel lower-priority pending jobs
+  R->>W: postMessage(CompileRequest, generation g)
+  W->>W: fresh WASM runtime, mount libs, callMain (synchronous)
+  W-->>R: stdout/stderr/result/error (tagged by id)
+  R->>R: drop messages from a stale worker generation
+  R-->>A: OpenSCADInvocationResults
+  A->>M: RenderOutput { outFile, diagnostics, ... }
+  M->>M: apply only if still the current call (per-kind sequence guard)
+```
+
+## Scheduling and supersession
+
+`turnIntoDelayableExecution` (`src/utils.ts`) debounces rapid calls and ensures
+**every** returned promise settles exactly once — resolved, failed, or rejected
+with a cancellation when superseded or killed. Each call owns its own timer and
+canceller; the shared "live" canceller is identity-checked so a finished job
+can't clobber a newer one. See [ADR 0003](./adr/0003-deterministic-scheduler.md).
+
+Priorities (`syntax < preview < render < export`) let a higher-priority request
+discard lower-priority **pending** jobs. Because `callMain` is synchronous, a
+job already executing in the worker cannot be interrupted mid-flight.
+
+## Timeout and worker recovery
+
+```mermaid
+stateDiagram-v2
+  [*] --> Idle
+  Idle --> Busy: postMessage(compile)
+  Busy --> Idle: result / error
+  Busy --> Recycling: COMPILE_TIMEOUT_MS elapsed
+  Recycling --> Idle: terminate worker, bump generation,<br/>reject pending, lazily recreate
+```
+
+A compile that produces no result within `COMPILE_TIMEOUT_MS` means the worker is
+wedged (a synchronous `callMain` cannot be cancelled). The runner terminates the
+worker, bumps a **generation** counter, rejects the pending jobs bound to that
+generation, and lazily creates a clean worker on the next request. The generation
+counter makes late messages from a terminated worker no-ops. See
+[ADR 0002](./adr/0002-worker-timeout-recovery.md).
+
+## Staleness defense (three layers)
+
+A result can arrive after it is no longer wanted (user kept typing, switched
+files, or triggered a higher-priority job). Stale results are dropped at three
+independent layers:
+
+1. **Worker generation** — messages from a terminated worker are ignored
+   (`openscad-runner`).
+2. **Scheduler settlement** — a superseded call's promise rejects rather than
+   resolving with stale output (`turnIntoDelayableExecution`).
+3. **Per-kind sequence guard** — `Model.render`/`checkSyntax` apply a result only
+   if it is still the latest call of that kind, so a stale call can't clobber the
+   `previewing`/`rendering`/`checkingSyntax` flags a newer call owns.
+
+A project-level revision stamped onto requests/results (a cleaner single
+mechanism) is deferred with the typed-contracts work; see
+[ADR 0004](./adr/0004-defer-source-union.md).
+
+## Arguments and diagnostics
+
+`buildOpenScadArgs` (`src/runner/actions.ts`) is the single source of truth for
+the OpenSCAD command line; every compile path builds through it.
+`output-parser` turns OpenSCAD's stderr into host-neutral `Diagnostic`s; the
+editor renders them via the Monaco adapter. See
+[ADR 0001](./adr/0001-host-neutral-diagnostics.md).

--- a/docs/architecture/security-boundaries.md
+++ b/docs/architecture/security-boundaries.md
@@ -1,0 +1,37 @@
+# Security boundaries
+
+OpenSCAD Web runs entirely in the browser, so the trust boundary is between the
+app and the **untrusted inputs** it ingests: imported archives, fetched models,
+URL/persistence fragments, and customizer values. The app also runs OpenSCAD in a
+sandboxed Web Worker against a virtual filesystem, never the host filesystem.
+
+## Untrusted input validation
+
+| Input                                | Control                                                                                                                                    | Location                                       |
+| ------------------------------------ | ------------------------------------------------------------------------------------------------------------------------------------------ | ---------------------------------------------- |
+| Imported ZIP entries                 | Canonical path validation (reject `..`, absolute/drive/UNC, control chars, duplicates) + atomic rejection + file-count / total-size bounds | `fs/project-path.ts`, `Model.importProjectZip` |
+| Runtime assets (fonts, library zips) | HTTP status check + size bound + structured errors                                                                                         | `runtime/fetch-asset.ts`                       |
+| External model URLs                  | Same-origin-relative / allow-listed HTTPS policy + size bound + trust prompt                                                               | `external-source.ts`, `state/url-mode.ts`      |
+| Customizer values                    | Type validation (string / finite number / boolean / bounded nested arrays) before building `-D` args                                       | `runner/actions.formatValue`                   |
+| URL fragment / persisted state       | Field-level validation on deserialize                                                                                                      | `state/fragment-state.ts`                      |
+
+## Virtual filesystem
+
+OpenSCAD runs in a Web Worker against BrowserFS — an in-memory / IndexedDB
+virtual filesystem under `/home`, with read-only ZipFS mounts for fonts and
+demand-loaded libraries. Imported files are confined to the project root by
+`project-path` normalization; there is no access to the host filesystem.
+
+## PWA updates
+
+A new service worker **waits** (`skipWaiting`/`clientsClaim` are off) rather than
+seizing the open page mid-session. The app surfaces an `osc:sw-update-available`
+event instead of force-reloading, so an update never discards unsaved edits; it
+applies on the next load. See #53 and follow-up #78.
+
+## Notes for future hosts
+
+The audit-driven boundaries above are designed so a non-browser host would reuse
+the same validators rather than re-implement them. Remaining browser-specific
+coupling in the domain (DOM access in `Model`/`utils`) is tracked for extraction
+into a web-host adapter (#59).


### PR DESCRIPTION
## What
New `docs/architecture/` (linked from the README):
- **README.md** — overview, a Mermaid dependency graph, a module map, and the current state of each dependency boundary (what's enforced vs. tracked for follow-up).
- **compile-lifecycle.md** — the request flow (Mermaid sequence + state diagrams), debounce/supersede scheduling, `COMPILE_TIMEOUT_MS` + worker-generation recovery, and the three staleness-defense layers.
- **security-boundaries.md** — the untrusted-input validation table, the virtual filesystem, and PWA update behavior.
- **adr/0001–0004** — host-neutral diagnostics, worker timeout recovery, deterministic scheduler, and the deferred `Source` union (with the auto-deploy/backward-compat rationale).

Docs reflect the code **as it is**, flagging boundaries that are intended but not yet realized (viewer→Model in #60, DOM-in-domain in #59).

## Review
A fact-check pass verified every claim against the code (module map, the monaco-free domain, the compile lifecycle + priorities + generation counter, the security controls, the `skipWaiting/clientsClaim=off` and `deploy.yml` claims, and all internal links). Its three findings are fixed: the SW event name (`osc:sw-update-available`), the `Source` blast-radius wording, and a Mermaid `<br/>` line break.

Docs-only; no code changed.

Closes #45