### PR TITLE
refactor(viewer): extract model-independent osc-geometry-viewer (#60)

### DIFF
--- a/src/components/elements/osc-geometry-viewer.ts
+++ b/src/components/elements/osc-geometry-viewer.ts
@@ -1,0 +1,176 @@
+// A model-independent 3D geometry viewer. It owns the Three.js scene lifecycle
+// and renders OFF geometry passed as plain text, with camera-preset controls.
+// It has no dependency on the application Model/State — inputs come in as
+// properties and changes go out as events, so it can be reused in isolation.
+//
+// Inputs (properties): offText, color, showAxes, camera (applied on mount only).
+// Events: `camera-change` (CameraState), `geometry-loaded` ({ thumbhash }),
+// `context-lost`, `viewer-error` (the load error). The host listens to whichever
+// it needs; in this app `osc-viewer-panel` consumes camera-change/geometry-loaded.
+import { LitElement, html, type PropertyValues } from 'lit';
+import { customElement, property, state } from 'lit/decorators.js';
+import { ThreeScene, NAMED_POSITIONS, type CameraState } from '../viewer/ThreeScene.ts';
+import { offToBufferGeometry } from '../viewer/off-loader.ts';
+import { parseOff } from '../../io/import_off.ts';
+import { imageToThumbhash } from '../../io/image_hashes.ts';
+
+const DEFAULT_COLOR = '#f9d72c';
+
+@customElement('osc-geometry-viewer')
+export class OscGeometryViewer extends LitElement {
+  // Light DOM so Three.js can size the canvas and data-testid stays queryable.
+  protected override createRenderRoot() {
+    return this;
+  }
+
+  /** OFF geometry as text. Setting it (re)loads the mesh. */
+  @property({ attribute: false }) offText: string | null = null;
+  @property() color = DEFAULT_COLOR;
+  @property({ type: Boolean }) showAxes = true;
+  /** Initial camera; applied on mount only — the user drives it afterward. */
+  @property({ attribute: false }) camera: CameraState | null = null;
+
+  @state() private _toastMessage: string | null = null;
+
+  private _scene: ThreeScene | null = null;
+  private _ro: ResizeObserver | null = null;
+  private _container: HTMLDivElement | null = null;
+  private _loadedOffText: string | null = null;
+  private _toastTimer: ReturnType<typeof setTimeout> | null = null;
+
+  override firstUpdated() {
+    const container = this.querySelector('[data-testid="viewer-canvas"]') as HTMLDivElement | null;
+    if (!container) return;
+    this._container = container;
+
+    const scene = new ThreeScene(container);
+    this._scene = scene;
+    if (this.camera) scene.applyCameraState(this.camera);
+    scene.setAxesVisible(this.showAxes);
+    scene.onCameraChange = (cam) =>
+      this.dispatchEvent(new CustomEvent<CameraState>('camera-change', { detail: cam }));
+    scene.onContextLost = () => this.dispatchEvent(new CustomEvent('context-lost'));
+    scene.start();
+
+    this._ro = new ResizeObserver((entries) => {
+      for (const entry of entries) {
+        scene.resize(entry.contentRect.width, entry.contentRect.height);
+      }
+    });
+    this._ro.observe(container);
+
+    if (this.offText) this._loadGeometry(this.offText);
+  }
+
+  override updated(changed: PropertyValues) {
+    const scene = this._scene;
+    if (!scene) return;
+    if (changed.has('showAxes')) scene.setAxesVisible(this.showAxes);
+    if (changed.has('color') && this.color) scene.setModelColor(this.color);
+    if (changed.has('offText') && this.offText && this.offText !== this._loadedOffText) {
+      this._loadGeometry(this.offText);
+    }
+    // `camera` is intentionally NOT re-applied on change: it is an initial value
+    // only; echoing the model's camera back while the user is interacting would
+    // fight their input.
+  }
+
+  override disconnectedCallback() {
+    super.disconnectedCallback();
+    this._ro?.disconnect();
+    this._ro = null;
+    this._scene?.dispose();
+    this._scene = null;
+    this._container = null;
+    if (this._toastTimer) clearTimeout(this._toastTimer);
+  }
+
+  private async _loadGeometry(offText: string) {
+    const scene = this._scene;
+    if (!scene) return;
+    this._loadedOffText = offText;
+    try {
+      const geometry = offToBufferGeometry(parseOff(offText));
+      scene.loadGeometry(geometry, this.color);
+      if (this._container) this._container.dataset.geometryLoaded = 'true';
+
+      // Render the new geometry before capturing so the thumbnail isn't stale.
+      scene.renderOnce();
+      const dataUrl = scene.renderer.domElement.toDataURL('image/png');
+      const thumbhash = await imageToThumbhash(dataUrl);
+      if (this._scene !== scene) return; // torn down during hashing
+      this.dispatchEvent(new CustomEvent('geometry-loaded', { detail: { thumbhash } }));
+    } catch (err) {
+      console.error('Error loading OFF geometry:', err);
+      this.dispatchEvent(new CustomEvent('viewer-error', { detail: err }));
+    }
+  }
+
+  private _showToast(msg: string) {
+    this._toastMessage = msg;
+    if (this._toastTimer) clearTimeout(this._toastTimer);
+    this._toastTimer = setTimeout(() => {
+      this._toastMessage = null;
+    }, 1500);
+  }
+
+  override render() {
+    return html`
+      <style>
+        osc-geometry-viewer {
+          display: block;
+          position: relative;
+          flex: 1;
+          width: 100%;
+          height: 100%;
+        }
+        osc-geometry-viewer .osc-toast {
+          position: absolute;
+          top: 8px;
+          right: 8px;
+          background: rgba(0, 0, 0, 0.65);
+          color: #fff;
+          padding: 4px 12px;
+          border-radius: 4px;
+          font-size: 0.8rem;
+          pointer-events: none;
+          z-index: 10;
+          transition: opacity 0.3s;
+        }
+      </style>
+      <div
+        data-testid="viewer-canvas"
+        role="img"
+        aria-label="3D preview viewport"
+        style="flex:1;position:relative;width:100%;height:100%;"
+      ></div>
+      ${this._toastMessage ? html`<div class="osc-toast">${this._toastMessage}</div>` : ''}
+      <div
+        aria-label="Viewer camera presets"
+        style="position:absolute;bottom:8px;right:8px;display:flex;flex-direction:column;gap:2px;z-index:2;"
+      >
+        ${NAMED_POSITIONS.map(
+          ({ name }) => html`
+            <button
+              title="${name} view"
+              aria-label=${`Set ${name} view`}
+              @click=${() => {
+                this._scene?.setCameraPosition(name);
+                this._showToast(`${name} view`);
+              }}
+              style="font-size:0.65rem;padding:2px 6px;cursor:pointer;opacity:0.75;background:rgba(0,0,0,0.5);color:#fff;border:none;border-radius:3px;"
+            >
+              ${name}
+            </button>
+          `,
+        )}
+      </div>
+    `;
+  }
+}
+
+declare global {
+  interface HTMLElementTagNameMap {
+    'osc-geometry-viewer': OscGeometryViewer;
+  }
+}

--- a/src/components/elements/osc-viewer-panel.ts
+++ b/src/components/elements/osc-viewer-panel.ts
@@ -3,54 +3,36 @@ import { LitElement, html } from 'lit';
 import { customElement, state } from 'lit/decorators.js';
 import { getModel } from '../../state/model-context.ts';
 import { blurHashToImage, imageToThumbhash, thumbHashToImage } from '../../io/image_hashes.ts';
-import { ThreeScene, NAMED_POSITIONS } from '../viewer/ThreeScene.ts';
-import { offToBufferGeometry } from '../viewer/off-loader.ts';
-import { parseOff } from '../../io/import_off.ts';
 import { getViewerOutputMode } from './viewer-output-mode.ts';
+import './osc-geometry-viewer.ts';
+import type { CameraState } from '../viewer/ThreeScene.ts';
 import type { State } from '../../state/app-state.ts';
 import type { Model } from '../../state/model.ts';
 
-// Uses light DOM so data-testid is accessible and Three.js can manage the canvas size.
+const DEFAULT_COLOR = '#f9d72c';
 
+// Adapter between the application Model/State and the model-independent
+// <osc-geometry-viewer>: it picks the output surface (3D / SVG / DXF), feeds the
+// geometry viewer its inputs, and forwards camera/preview changes back to Model.
+// Uses light DOM so data-testid is accessible and child sizing works.
 @customElement('osc-viewer-panel')
 export class OscViewerPanel extends LitElement {
-  // Light DOM — no shadow root
   protected override createRenderRoot() {
     return this;
   }
 
   @state() private _st: State | null = null;
-  @state() private _toastMessage: string | null = null;
+  @state() private _offText: string | null = null;
   private _model!: Model;
-  private _scene: ThreeScene | null = null;
-  private _ro: ResizeObserver | null = null;
-  private _container: HTMLDivElement | null = null;
   private _lastOutFile: File | undefined;
-  private _toastTimer: ReturnType<typeof setTimeout> | null = null;
   private _lastSvgPreviewUrl: string | null = null;
 
   private _onState = (e: Event) => {
     const st = (e as CustomEvent<State>).detail;
-    const prev = this._st;
     this._st = st;
-
-    // Axes change
-    if (prev?.view.showAxes !== st.view.showAxes) {
-      this._scene?.setAxesVisible(!!st.view.showAxes);
-    }
-    // Color change
-    if (prev?.view.color !== st.view.color && st.view.color) {
-      this._scene?.setModelColor(st.view.color);
-    }
-    // Output change
     if (st.output?.outFile !== this._lastOutFile) {
       this._lastOutFile = st.output?.outFile;
-      const outputMode = getViewerOutputMode(st.output?.outFile?.name);
-      if (outputMode === 'three' && st.output?.outFile) {
-        this._loadGeometry(st.output.outFile);
-      } else if (outputMode === 'svg' && st.output?.outFileURL) {
-        this._loadSvgPreview(st.output.outFileURL);
-      }
+      this._syncOutput(st);
     }
   };
 
@@ -59,96 +41,34 @@ export class OscViewerPanel extends LitElement {
     this._model = getModel();
     this._model.addEventListener('state', this._onState);
     this._st = this._model.state;
+    this._lastOutFile = this._st.output?.outFile;
+    this._syncOutput(this._st);
   }
 
   override disconnectedCallback() {
     super.disconnectedCallback();
     this._model?.removeEventListener('state', this._onState);
-    this._teardownScene();
-    if (this._toastTimer) clearTimeout(this._toastTimer);
   }
 
-  override updated() {
-    const nextContainer = this.querySelector(
-      '[data-testid="viewer-canvas"]',
-    ) as HTMLDivElement | null;
-    if (!nextContainer) {
-      if (
-        getViewerOutputMode(this._st?.output?.outFile?.name) === 'svg' &&
-        this._st?.output?.outFileURL
-      ) {
-        this._loadSvgPreview(this._st.output.outFileURL);
-      }
-      this._teardownScene();
-      return;
-    }
-
-    if (this._scene && this._container === nextContainer) {
-      return;
-    }
-
-    this._teardownScene();
-    this._container = nextContainer;
-
-    const scene = new ThreeScene(nextContainer);
-    this._scene = scene;
-
-    const st = this._st ?? this._model.state;
-    if (st.view.camera) scene.applyCameraState(st.view.camera);
-    scene.onCameraChange = (cam) => {
-      this._model.mutate((s) => {
-        s.view.camera = cam;
-      });
-    };
-    scene.setAxesVisible(!!st.view.showAxes);
-    scene.start();
-
-    this._ro = new ResizeObserver((entries) => {
-      for (const entry of entries) {
-        const { width, height } = entry.contentRect;
-        scene.resize(width, height);
-      }
-    });
-    this._ro.observe(this._container);
-
-    // Load any geometry that was already output when this panel mounted
-    if (getViewerOutputMode(st.output?.outFile?.name) === 'three' && st.output?.outFile) {
-      this._lastOutFile = st.output.outFile;
-      this._loadGeometry(st.output.outFile);
+  private _syncOutput(st: State) {
+    const mode = getViewerOutputMode(st.output?.outFile?.name);
+    if (mode === 'three' && st.output?.outFile) {
+      this._readOffText(st.output.outFile);
+    } else if (mode === 'svg' && st.output?.outFileURL) {
+      this._offText = null;
+      this._loadSvgPreview(st.output.outFileURL);
+    } else {
+      this._offText = null;
     }
   }
 
-  private _teardownScene() {
-    this._ro?.disconnect();
-    this._ro = null;
-    this._scene?.dispose();
-    this._scene = null;
-    this._container = null;
-  }
-
-  private async _loadGeometry(file: File) {
-    const scene = this._scene;
-    if (!scene) return;
+  private async _readOffText(file: File) {
     try {
       const text = await file.text();
-      if (this._scene !== scene) return; // viewer torn down / scene replaced during await
-      const data = parseOff(text);
-      const geometry = offToBufferGeometry(data);
-      const color = this._st?.view.color ?? '#f9d72c';
-      scene.loadGeometry(geometry, color);
-
-      if (this._container) this._container.dataset.geometryLoaded = 'true';
-
-      // Render the new geometry before capturing so the thumbnail isn't stale.
-      scene.renderOnce();
-      const dataUrl = scene.renderer.domElement.toDataURL('image/png');
-      const hash = await imageToThumbhash(dataUrl);
-      if (this._scene !== scene) return; // torn down during hashing
-      this._model.mutate((s) => {
-        s.preview = { thumbhash: hash };
-      });
+      if (this._lastOutFile !== file) return; // a newer output superseded this one
+      this._offText = text;
     } catch (err) {
-      console.error('Error loading OFF geometry:', err);
+      console.error('Error reading OFF geometry:', err);
     }
   }
 
@@ -163,14 +83,6 @@ export class OscViewerPanel extends LitElement {
     } catch (err) {
       console.error('Error loading SVG preview:', err);
     }
-  }
-
-  private _showToast(msg: string) {
-    this._toastMessage = msg;
-    if (this._toastTimer) clearTimeout(this._toastTimer);
-    this._toastTimer = setTimeout(() => {
-      this._toastMessage = null;
-    }, 1500);
   }
 
   override render() {
@@ -205,19 +117,6 @@ export class OscViewerPanel extends LitElement {
             opacity: 0.4;
           }
         }
-        .osc-toast {
-          position: absolute;
-          top: 8px;
-          right: 8px;
-          background: rgba(0, 0, 0, 0.65);
-          color: #fff;
-          padding: 4px 12px;
-          border-radius: 4px;
-          font-size: 0.8rem;
-          pointer-events: none;
-          z-index: 10;
-          transition: opacity 0.3s;
-        }
         .svg-preview,
         .dxf-placeholder {
           width: 100%;
@@ -250,12 +149,20 @@ export class OscViewerPanel extends LitElement {
         : ''}
       ${shows3DViewer
         ? html`
-            <div
-              data-testid="viewer-canvas"
-              role="img"
-              aria-label="3D preview viewport"
-              style="flex:1;position:relative;width:100%;height:100%;"
-            ></div>
+            <osc-geometry-viewer
+              .offText=${this._offText}
+              color=${st?.view.color ?? DEFAULT_COLOR}
+              ?showAxes=${!!st?.view.showAxes}
+              .camera=${(st?.view.camera ?? null) as CameraState | null}
+              @camera-change=${(e: CustomEvent<CameraState>) =>
+                this._model.mutate((s) => {
+                  s.view.camera = e.detail;
+                })}
+              @geometry-loaded=${(e: CustomEvent<{ thumbhash: string }>) =>
+                this._model.mutate((s) => {
+                  s.preview = { thumbhash: e.detail.thumbhash };
+                })}
+            ></osc-geometry-viewer>
           `
         : outputMode === 'svg'
           ? html`
@@ -271,33 +178,6 @@ export class OscViewerPanel extends LitElement {
                 DXF exported. Click Download to open it in your CAD tool.
               </div>
             `}
-      ${shows3DViewer && this._toastMessage
-        ? html`<div class="osc-toast">${this._toastMessage}</div>`
-        : ''}
-      ${shows3DViewer
-        ? html`
-            <div
-              aria-label="Viewer camera presets"
-              style="position:absolute;bottom:8px;right:8px;display:flex;flex-direction:column;gap:2px;z-index:2;"
-            >
-              ${NAMED_POSITIONS.map(
-                ({ name }) => html`
-                  <button
-                    title="${name} view"
-                    aria-label=${`Set ${name} view`}
-                    @click=${() => {
-                      this._scene?.setCameraPosition(name);
-                      this._showToast(`${name} view`);
-                    }}
-                    style="font-size:0.65rem;padding:2px 6px;cursor:pointer;opacity:0.75;background:rgba(0,0,0,0.5);color:#fff;border:none;border-radius:3px;"
-                  >
-                    ${name}
-                  </button>
-                `,
-              )}
-            </div>
-          `
-        : ''}
     `;
   }
 }


### PR DESCRIPTION
## What
`osc-viewer-panel` mixed Model/State integration with the Three.js scene lifecycle, OFF loading, camera presets, thumbnail capture, and toasts.

- **New `osc-geometry-viewer`** — a reusable component with **no `Model`/`State` dependency**. It owns the `ThreeScene`, renders OFF geometry from an `offText` property, exposes `color`/`showAxes`/`camera` inputs, renders the camera-preset overlay + toast, and emits `camera-change` / `geometry-loaded` / `context-lost` / `viewer-error` events.
- **`osc-viewer-panel`** is now a thin adapter: it reads Model/State, picks the output surface (3D / SVG / DXF), feeds the geometry viewer its inputs, and forwards camera/preview changes back to `Model`.

## Review
An adversarial review traced every lifecycle path against the old single-component version and confirmed **no behavior regression**: the camera doesn't echo back mid-interaction (applied on mount only, ignored on prop change); output-mode toggles dispose/recreate the scene and restore the persisted camera + geometry; first-load doesn't double- or miss-render (`_loadedOffText` set before the await); the capture/teardown guard holds; and the compiling placeholder, SVG hashing, DXF placeholder, toast, presets, `data-testid` hooks and aria labels are all preserved. Its two NITs were non-blocking (the extra events are the component's documented public API; `setModelColor` already no-ops without a mesh) — the events are now documented.

## Tests
Full e2e suite (22, incl. viewer render / geometryLoaded / F5/F6 / thumbnail / camera) green; 238 unit tests, tsc, ESLint, Prettier green.

Closes #60