### PR TITLE
refactor(ui): command layer for shortcuts + suspend inactive viewer (#64)

### DIFF
--- a/src/commands/__tests__/app-commands.test.ts
+++ b/src/commands/__tests__/app-commands.test.ts
@@ -1,0 +1,51 @@
+import { createAppCommands, matchKeybinding } from '../app-commands.ts';
+import type { Model } from '../../state/model.ts';
+
+function makeModelStub() {
+  return {
+    render: vi.fn(),
+    export: vi.fn(),
+    saveProject: vi.fn(),
+  };
+}
+
+const ev = (key: string, ctrlKey = false, metaKey = false) => ({ key, ctrlKey, metaKey });
+
+describe('app commands (#64)', () => {
+  it('maps F5/F6/F7 to the right command without modifiers', () => {
+    const cmds = createAppCommands(makeModelStub() as unknown as Model);
+    expect(matchKeybinding(cmds, ev('F5'))?.id).toBe('render.preview');
+    expect(matchKeybinding(cmds, ev('F6'))?.id).toBe('render.full');
+    expect(matchKeybinding(cmds, ev('F7'))?.id).toBe('export');
+  });
+
+  it('requires Ctrl/Cmd for the save command', () => {
+    const cmds = createAppCommands(makeModelStub() as unknown as Model);
+    expect(matchKeybinding(cmds, ev('s'))).toBeUndefined();
+    expect(matchKeybinding(cmds, ev('s', true))?.id).toBe('project.save');
+    expect(matchKeybinding(cmds, ev('s', false, true))?.id).toBe('project.save');
+  });
+
+  it('returns undefined for an unbound key', () => {
+    const cmds = createAppCommands(makeModelStub() as unknown as Model);
+    expect(matchKeybinding(cmds, ev('F9'))).toBeUndefined();
+    expect(matchKeybinding(cmds, ev('a', true))).toBeUndefined();
+  });
+
+  it('commands invoke the matching Model action', () => {
+    const model = makeModelStub();
+    const cmds = createAppCommands(model as unknown as Model);
+
+    matchKeybinding(cmds, ev('F5'))?.run();
+    expect(model.render).toHaveBeenCalledWith({ isPreview: true, now: true });
+
+    matchKeybinding(cmds, ev('F6'))?.run();
+    expect(model.render).toHaveBeenCalledWith({ isPreview: false, now: true });
+
+    matchKeybinding(cmds, ev('F7'))?.run();
+    expect(model.export).toHaveBeenCalled();
+
+    matchKeybinding(cmds, ev('s', true))?.run();
+    expect(model.saveProject).toHaveBeenCalled();
+  });
+});

--- a/src/commands/app-commands.ts
+++ b/src/commands/app-commands.ts
@@ -1,0 +1,58 @@
+// Named application commands, decoupled from their keyboard bindings. The UI
+// invokes commands by intent; hosts (the app shell today) map shortcuts onto
+// them. This keeps key handling out of the components that perform the actions.
+import type { Model } from '../state/model.ts';
+
+export interface CommandKeybinding {
+  /** KeyboardEvent.key value, e.g. 'F5' or 's'. */
+  key: string;
+  /** Require Ctrl (or Cmd on macOS). */
+  ctrlOrMeta?: boolean;
+}
+
+export interface AppCommand {
+  id: string;
+  title: string;
+  keybinding?: CommandKeybinding;
+  run: () => void;
+}
+
+export function createAppCommands(model: Model): AppCommand[] {
+  return [
+    {
+      id: 'render.preview',
+      title: 'Preview',
+      keybinding: { key: 'F5' },
+      run: () => model.render({ isPreview: true, now: true }),
+    },
+    {
+      id: 'render.full',
+      title: 'Render',
+      keybinding: { key: 'F6' },
+      run: () => model.render({ isPreview: false, now: true }),
+    },
+    {
+      id: 'export',
+      title: 'Export',
+      keybinding: { key: 'F7' },
+      run: () => model.export(),
+    },
+    {
+      id: 'project.save',
+      title: 'Save project',
+      keybinding: { key: 's', ctrlOrMeta: true },
+      run: () => model.saveProject(),
+    },
+  ];
+}
+
+/** Find the command whose keybinding matches the event, if any. */
+export function matchKeybinding(
+  commands: AppCommand[],
+  e: { key: string; ctrlKey: boolean; metaKey: boolean },
+): AppCommand | undefined {
+  return commands.find((c) => {
+    if (!c.keybinding || c.keybinding.key !== e.key) return false;
+    return c.keybinding.ctrlOrMeta ? e.ctrlKey || e.metaKey : true;
+  });
+}

--- a/src/components/elements/osc-app-shell.ts
+++ b/src/components/elements/osc-app-shell.ts
@@ -2,6 +2,11 @@
 import { LitElement, html } from 'lit';
 import { customElement, state } from 'lit/decorators.js';
 import { getModel } from '../../state/model-context.ts';
+import {
+  createAppCommands,
+  matchKeybinding,
+  type AppCommand,
+} from '../../commands/app-commands.ts';
 import type { State } from '../../state/app-state.ts';
 import type { Model } from '../../state/model.ts';
 import './osc-panel-switcher.ts';
@@ -19,6 +24,7 @@ export class OscAppShell extends LitElement {
 
   @state() private _st: State | null = null;
   private _model!: Model;
+  private _commands: AppCommand[] = [];
   private _onState = (e: Event) => {
     this._st = (e as CustomEvent<State>).detail;
   };
@@ -26,10 +32,11 @@ export class OscAppShell extends LitElement {
   override connectedCallback() {
     super.connectedCallback();
     this._model = getModel();
+    this._commands = createAppCommands(this._model);
     this._model.addEventListener('state', this._onState);
     this._st = this._model.state;
 
-    // Global keyboard shortcuts
+    // Map global keyboard shortcuts onto named commands.
     window.addEventListener('keydown', this._handleKeyDown);
   }
 
@@ -40,18 +47,10 @@ export class OscAppShell extends LitElement {
   }
 
   private _handleKeyDown = (e: KeyboardEvent) => {
-    if (e.key === 'F5') {
+    const command = matchKeybinding(this._commands, e);
+    if (command) {
       e.preventDefault();
-      this._model.render({ isPreview: true, now: true });
-    } else if (e.key === 'F6') {
-      e.preventDefault();
-      this._model.render({ isPreview: false, now: true });
-    } else if (e.key === 'F7') {
-      e.preventDefault();
-      this._model.export();
-    } else if (e.key === 's' && (e.ctrlKey || e.metaKey)) {
-      e.preventDefault();
-      this._model.saveProject();
+      command.run();
     }
   };
 
@@ -141,6 +140,7 @@ export class OscAppShell extends LitElement {
             ? html`
                 <osc-viewer-panel
                   id="panel-viewer"
+                  ?active=${true}
                   style="flex:1 1 ${pct};max-width:${pct};min-width:0;overflow:hidden;"
                 ></osc-viewer-panel>
               `
@@ -179,6 +179,7 @@ export class OscAppShell extends LitElement {
             role="tabpanel"
             aria-label="Viewer panel"
             class="absolute-fill"
+            ?active=${focus === 'viewer'}
             style="z-index:${zOf('viewer')};"
             ?inert=${focus !== 'viewer'}
             aria-hidden=${focus !== 'viewer' ? 'true' : 'false'}

--- a/src/components/elements/osc-geometry-viewer.ts
+++ b/src/components/elements/osc-geometry-viewer.ts
@@ -27,6 +27,8 @@ export class OscGeometryViewer extends LitElement {
   @property({ attribute: false }) offText: string | null = null;
   @property() color = DEFAULT_COLOR;
   @property({ type: Boolean }) showAxes = true;
+  /** When false, the scene is suspended (no rendering) until reactivated. */
+  @property({ type: Boolean }) active = true;
   /** Initial camera; applied on mount only — the user drives it afterward. */
   @property({ attribute: false }) camera: CameraState | null = null;
 
@@ -59,12 +61,14 @@ export class OscGeometryViewer extends LitElement {
     });
     this._ro.observe(container);
 
+    if (!this.active) scene.setActive(false);
     if (this.offText) this._loadGeometry(this.offText);
   }
 
   override updated(changed: PropertyValues) {
     const scene = this._scene;
     if (!scene) return;
+    if (changed.has('active')) scene.setActive(this.active);
     if (changed.has('showAxes')) scene.setAxesVisible(this.showAxes);
     if (changed.has('color') && this.color) scene.setModelColor(this.color);
     if (changed.has('offText') && this.offText && this.offText !== this._loadedOffText) {

--- a/src/components/elements/osc-viewer-panel.ts
+++ b/src/components/elements/osc-viewer-panel.ts
@@ -1,6 +1,6 @@
 // Portions of this file are Copyright 2021 Google LLC, and licensed under GPL2+. See COPYING.
 import { LitElement, html } from 'lit';
-import { customElement, state } from 'lit/decorators.js';
+import { customElement, property, state } from 'lit/decorators.js';
 import { getModel } from '../../state/model-context.ts';
 import { blurHashToImage, imageToThumbhash, thumbHashToImage } from '../../io/image_hashes.ts';
 import { getViewerOutputMode } from './viewer-output-mode.ts';
@@ -21,6 +21,8 @@ export class OscViewerPanel extends LitElement {
     return this;
   }
 
+  /** Whether this panel is the active surface; forwarded to suspend the viewer. */
+  @property({ type: Boolean }) active = true;
   @state() private _st: State | null = null;
   @state() private _offText: string | null = null;
   private _model!: Model;
@@ -153,6 +155,7 @@ export class OscViewerPanel extends LitElement {
               .offText=${this._offText}
               color=${st?.view.color ?? DEFAULT_COLOR}
               ?showAxes=${!!st?.view.showAxes}
+              ?active=${this.active}
               .camera=${(st?.view.camera ?? null) as CameraState | null}
               @camera-change=${(e: CustomEvent<CameraState>) =>
                 this._model.mutate((s) => {

--- a/src/components/viewer/ThreeScene.ts
+++ b/src/components/viewer/ThreeScene.ts
@@ -41,6 +41,7 @@ export class ThreeScene {
   readonly controls: OrbitControls;
   private animationId: number | null = null;
   private needsRender = false;
+  private paused = false;
   private modelMesh: THREE.Mesh | null = null;
   private axesObject: THREE.LineSegments | null = null;
   private cameraDebounceTimer: ReturnType<typeof setTimeout> | null = null;
@@ -119,7 +120,23 @@ export class ThreeScene {
     this.requestRender();
   }
 
+  /**
+   * Suspend or resume rendering. While inactive, `requestRender` is a no-op (so
+   * geometry/camera changes don't spin the loop for an off-screen viewer);
+   * resuming renders the current state once. `renderOnce` still works while
+   * suspended so a thumbnail can be captured.
+   */
+  setActive(active: boolean): void {
+    this.paused = !active;
+    if (active) {
+      this.requestRender();
+    } else {
+      this.stop();
+    }
+  }
+
   requestRender(): void {
+    if (this.paused) return; // suspended — will render on resume
     this.needsRender = true;
     if (this.animationId === null) {
       this.animationId = requestAnimationFrame(this.tick);


### PR DESCRIPTION
## What
- **Command layer.** `src/commands/app-commands.ts` defines named commands (`render.preview`/`render.full`/`export`/`project.save`) with their keybindings as data. `osc-app-shell` resolves a keydown to a command via `matchKeybinding` and runs it — F5/F6/F7/Ctrl+S behave exactly as before, but key handling is decoupled from the actions.
- **Suspend the inactive viewer.** An `active` flag flows `osc-app-shell` → `osc-viewer-panel` → `osc-geometry-viewer` → `ThreeScene.setActive()`. While inactive, `requestRender` is a no-op (no loop spin for an off-screen viewer) but `renderOnce` still captures; reactivation renders the current state. The shell sets `active` per layout (multi-pane: always; single-panel: only the focused panel).

The `active` flag defaults true and the default layout is multi-pane, so the viewer is always active on the e2e-covered path — unchanged. The suspend only affects single-panel mode.

## Review
An adversarial review traced all five suspend scenarios and confirmed the logic is **sound**: `setActive` clears `paused` before `requestRender` (resume renders, no stuck-blank); geometry loaded while suspended is in the graph and shown on resume; `firstUpdated`'s `start()`→`setActive(false)` leaves no leaked rAF; multi-pane is behaviorally identical; and `matchKeybinding` preserves the exact old shortcut behavior with no leak. All findings were NITs explicitly marked no-fix.

## Tests
New `app-commands.test.ts` (keybinding matching + command dispatch); full e2e suite (22, multi-pane viewer render/F5/F6) green; 242 unit tests, tsc, ESLint, Prettier green.

Closes #64