### PR TITLE
chore(ci): unified ok gate + conservative dependabot auto-merge

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -265,16 +265,17 @@ jobs:
           name: perf-baseline-candidate
           path: coverage/perf/
 
-  ci:
+  # Unified gate — the ONLY job required by branch protection. Add every job to
+  # `needs:` here; never add individual jobs to the branch-protection rule.
+  ok:
+    name: ok
     runs-on: ubuntu-24.04
     needs: [build-and-test, publish-artifact, e2e, publish-e2e, performance]
     if: always()
+    timeout-minutes: 5
     steps:
-      - name: All CI checks passed
-        run: |
-          results='${{ toJSON(needs) }}'
-          if echo "$results" | grep -q '"result": "failure"\|"result": "cancelled"'; then
-            echo "One or more required jobs failed or were cancelled."
-            exit 1
-          fi
-          echo "All required jobs succeeded."
+      - name: Fail if any upstream job failed or was cancelled
+        if: contains(needs.*.result, 'failure') || contains(needs.*.result, 'cancelled')
+        run: exit 1
+      - name: Pass
+        run: echo 'All checks passed or were skipped'

--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -1,0 +1,34 @@
+# Conservative Dependabot auto-merge.
+#
+# Enables GitHub auto-merge (which waits for the required "ok" status check, per
+# branch protection) only for the lowest-risk updates:
+#   - any patch update, and
+#   - minor updates to development dependencies.
+# Production minor/major and all major updates are left for manual review.
+name: Dependabot auto-merge
+
+on: pull_request
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  auto-merge:
+    if: github.actor == 'dependabot[bot]'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Fetch update metadata
+        id: meta
+        uses: dependabot/fetch-metadata@v2
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Enable auto-merge for low-risk updates
+        if: >-
+          steps.meta.outputs.update-type == 'version-update:semver-patch' ||
+          (steps.meta.outputs.dependency-type == 'direct:development' &&
+          steps.meta.outputs.update-type == 'version-update:semver-minor')
+        run: gh pr merge --auto --squash "${{ github.event.pull_request.html_url }}"
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## What
- **`ci` → `ok` gate.** Renames the CI aggregator job to `ok` (the standard convention used across the org repos), so a single `ok` status check is the only thing branch protection needs to require. Uses the canonical `if: contains(needs.*.result, 'failure' | 'cancelled')` form.
- **Conservative Dependabot auto-merge.** New `dependabot-auto-merge.yml` enables GitHub auto-merge (which waits for the required `ok` check) for **patch** updates and **dev-dependency minor** updates only. Production minor/major and all majors stay manual.

## Follow-up (applied after this merges)
Branch protection on `main` set to match the convention: require `ok`, strict (up-to-date), enforce for admins, require PR with 0 approvals.