### PR TITLE
refactor(state): extract ProjectStore from Model (#57)

### DIFF
--- a/src/state/__tests__/project-store.test.ts
+++ b/src/state/__tests__/project-store.test.ts
@@ -1,0 +1,91 @@
+import { ProjectStore } from '../project-store.ts';
+import type { Source } from '../app-state.ts';
+
+function makeFs(files: Record<string, string> = {}) {
+  const written: Record<string, string> = {};
+  return {
+    fs: {
+      readFileSync: vi.fn((path: string) => {
+        if (!(path in files)) throw new Error(`ENOENT ${path}`);
+        return new TextEncoder().encode(files[path]);
+      }),
+      writeFile: vi.fn((path: string, content: string) => {
+        written[path] = content;
+      }),
+    } as unknown as FS,
+    written,
+  };
+}
+
+describe('ProjectStore (#57)', () => {
+  it('reads and replaces the active source content', () => {
+    const store = new ProjectStore(makeFs().fs);
+    const sources: Source[] = [
+      { path: '/a.scad', content: 'A' },
+      { path: '/b.scad', content: 'B' },
+    ];
+    expect(store.activeContent(sources, '/b.scad')).toBe('B');
+    expect(store.activeContent(sources, '/missing')).toBe('');
+
+    const updated = store.withActiveContent(sources, '/a.scad', 'A2');
+    expect(updated.find((s) => s.path === '/a.scad')?.content).toBe('A2');
+    expect(updated.find((s) => s.path === '/b.scad')?.content).toBe('B');
+  });
+
+  it('openFile returns null when the path is already active', () => {
+    const store = new ProjectStore(makeFs().fs);
+    expect(store.openFile([{ path: '/a.scad', content: 'A' }], '/a.scad', '/a.scad')).toBeNull();
+  });
+
+  it('openFile drops the previous active source when it is unmodified vs disk', () => {
+    const store = new ProjectStore(makeFs({ '/a.scad': 'A', '/b.scad': 'B' }).fs);
+    const next = store.openFile([{ path: '/a.scad', content: 'A' }], '/a.scad', '/b.scad');
+    expect(next).not.toBeNull();
+    expect(next!.activePath).toBe('/b.scad');
+    expect(next!.sources.map((s) => s.path)).toEqual(['/b.scad']); // /a.scad dropped, /b.scad added
+    expect(next!.sources[0].content).toBe('B');
+  });
+
+  it('openFile keeps the previous active source when it was modified', () => {
+    const store = new ProjectStore(makeFs({ '/a.scad': 'ON_DISK', '/b.scad': 'B' }).fs);
+    const next = store.openFile([{ path: '/a.scad', content: 'EDITED' }], '/a.scad', '/b.scad');
+    expect(next!.sources.map((s) => s.path)).toEqual(['/a.scad', '/b.scad']);
+  });
+
+  it('openFile does not re-read a source already in the set', () => {
+    const { fs } = makeFs({ '/a.scad': 'A' });
+    const store = new ProjectStore(fs);
+    const sources: Source[] = [
+      { path: '/a.scad', content: 'A' },
+      { path: '/b.scad', content: 'B' },
+    ];
+    const next = store.openFile(sources, '/a.scad', '/b.scad');
+    expect(next!.activePath).toBe('/b.scad');
+    // /b.scad already present, so it is not read from disk.
+    expect(fs.readFileSync).not.toHaveBeenCalledWith('/b.scad');
+  });
+
+  it('newFile picks a unique untitled name', () => {
+    const store = new ProjectStore(makeFs().fs);
+    expect(store.newFile([]).activePath).toBe('/home/untitled.scad');
+    const taken: Source[] = [{ path: '/home/untitled.scad', content: '' }];
+    const next = store.newFile(taken);
+    expect(next.activePath).toBe('/home/untitled-2.scad');
+    expect(next.sources.map((s) => s.path)).toContain('/home/untitled-2.scad');
+  });
+
+  it('addFile writes to the fs and replaces any existing same-path source', () => {
+    const { fs, written } = makeFs();
+    const store = new ProjectStore(fs);
+    const next = store.addFile([{ path: '/home/x.scad', content: 'old' }], '/home/x.scad', 'new');
+    expect(written['/home/x.scad']).toBe('new');
+    expect(next.activePath).toBe('/home/x.scad');
+    expect(next.sources.filter((s) => s.path === '/home/x.scad')).toHaveLength(1);
+    expect(next.sources[0].content).toBe('new');
+  });
+
+  // Note: buildZip (real JSZip -> Blob) is exercised in production via saveProject;
+  // ZIP import/export validation is covered by zip-import.test.ts. JSZip's input
+  // type-check rejects jsdom's Uint8Array, so a buildZip round-trip isn't unit-
+  // testable here without a real browser.
+});

--- a/src/state/model.ts
+++ b/src/state/model.ts
@@ -17,14 +17,7 @@ import {
   readFileAsDataURL,
 } from '../utils.ts';
 import { openLocalFile, saveActiveFile } from '../fs/filesystem.ts';
-import {
-  MAX_PROJECT_FILE_COUNT,
-  MAX_PROJECT_TOTAL_BYTES,
-  normalizeProjectPath,
-  ProjectPathError,
-} from '../fs/project-path.ts';
-
-import JSZip from 'jszip';
+import { ProjectStore } from './project-store.ts';
 import { isExpectedJobCancellation, ProcessStreams } from '../runner/openscad-runner.ts';
 import { is2DFormatExtension } from './formats.ts';
 import { parseOff } from '../io/import_off.ts';
@@ -37,6 +30,9 @@ import {
 } from '../user-facing-errors.ts';
 
 export class Model extends EventTarget {
+  /** Owns project-source logic (lookup, edits, file ops, ZIP import/export). */
+  private readonly projectStore: ProjectStore;
+
   constructor(
     private fs: FS,
     public state: State,
@@ -44,6 +40,7 @@ export class Model extends EventTarget {
     private statePersister?: StatePersister,
   ) {
     super();
+    this.projectStore = new ProjectStore(fs);
   }
 
   // Sequence counters identifying the latest in-flight operation of each kind.
@@ -198,58 +195,39 @@ export class Model extends EventTarget {
   }
 
   openFile(path: string) {
-    // console.log(`openFile: ${path}`);
-    if (
-      this.mutate((s) => {
-        if (s.params.activePath != path) {
-          const readSource = (path: string) => {
-            try {
-              return new TextDecoder('utf-8').decode(this.fs.readFileSync(path));
-            } catch (e) {
-              console.error('Error while reading file:', e);
-              return '';
-            }
-          };
-          // Remove source of previous active path if it's unmodified
-          const activePathContent = readSource(s.params.activePath);
-          s.params.sources = s.params.sources.filter(
-            (src) => src.path !== s.params.activePath || src.content != activePathContent,
-          );
-
-          s.params.activePath = path;
-          if (!s.params.sources.find((src) => src.path === path)) {
-            const content = readSource(path);
-            s.params.sources = [...s.params.sources, { path, content }];
-          }
-          s.lastCheckerRun = undefined;
-          s.output = undefined;
-          s.export = undefined;
-          s.preview = undefined;
-          s.currentRunLogs = undefined;
-          s.error = undefined;
-          s.errorDetails = undefined;
-          s.is2D = undefined;
-        }
-      })
-    ) {
-      this.processSource();
-    }
+    const next = this.projectStore.openFile(
+      this.state.params.sources,
+      this.state.params.activePath,
+      path,
+    );
+    if (!next) return; // already the active file
+    this.mutate((s) => {
+      s.params.sources = next.sources;
+      s.params.activePath = next.activePath;
+      s.lastCheckerRun = undefined;
+      s.output = undefined;
+      s.export = undefined;
+      s.preview = undefined;
+      s.currentRunLogs = undefined;
+      s.error = undefined;
+      s.errorDetails = undefined;
+      s.is2D = undefined;
+    });
+    this.processSource();
   }
 
   get source(): string {
-    return (
-      this.state.params.sources.find((src) => src.path === this.state.params.activePath)?.content ??
-      ''
-    );
+    return this.projectStore.activeContent(this.state.params.sources, this.state.params.activePath);
   }
   set source(source: string) {
     if (
-      this.mutate(
-        (s) =>
-          (s.params.sources = s.params.sources.map((src) =>
-            src.path === s.params.activePath ? { path: src.path, content: source } : src,
-          )),
-      )
+      this.mutate((s) => {
+        s.params.sources = this.projectStore.withActiveContent(
+          s.params.sources,
+          s.params.activePath,
+          source,
+        );
+      })
     ) {
       this.processSource();
     }
@@ -474,19 +452,10 @@ export class Model extends EventTarget {
 
   /** Creates a new empty .scad file in /home/ and activates it. */
   newFile(): void {
-    const base = '/home/untitled';
-    let path = `${base}.scad`;
-    let n = 2;
-    const existing = new Set(this.state.params.sources.map((s) => s.path));
-    while (existing.has(path)) path = `${base}-${n++}.scad`;
-    try {
-      this.fs.writeFile(path, '');
-    } catch {
-      /* fs may not support it yet */
-    }
+    const next = this.projectStore.newFile(this.state.params.sources);
     this.mutate((s) => {
-      s.params.sources = [...s.params.sources, { path, content: '' }];
-      s.params.activePath = path;
+      s.params.sources = next.sources;
+      s.params.activePath = next.activePath;
       s.lastCheckerRun = undefined;
       s.output = undefined;
       s.error = undefined;
@@ -497,56 +466,17 @@ export class Model extends EventTarget {
   /** Extracts a ZIP archive into /home/ and activates the entry .scad. */
   async importProjectZip(zipBuffer: ArrayBuffer): Promise<void> {
     try {
-      const zip = await JSZip.loadAsync(zipBuffer);
-      const entries = Object.entries(zip.files).filter(([, zipObj]) => !zipObj.dir);
-      if (entries.length > MAX_PROJECT_FILE_COUNT) {
-        throw new ProjectPathError(`Archive has too many files (max ${MAX_PROJECT_FILE_COUNT}).`);
-      }
-      // Validate and bound EVERY entry before writing ANY of them, so a malicious
-      // archive is rejected atomically (no partial extraction). The size limit is
-      // an approximate cumulative guard over decoded entry lengths (UTF-16 units);
-      // a single entry is still fully decoded before its length is counted.
-      const files: [string, string][] = [];
-      const seen = new Set<string>();
-      let totalSize = 0;
-      for (const [relPath, zipObj] of entries) {
-        const safePath = normalizeProjectPath(relPath);
-        if (seen.has(safePath)) {
-          throw new ProjectPathError(`Duplicate path in archive: ${safePath}`);
-        }
-        seen.add(safePath);
-        const content = await zipObj.async('string');
-        totalSize += content.length;
-        if (totalSize > MAX_PROJECT_TOTAL_BYTES) {
-          throw new ProjectPathError('Archive exceeds the uncompressed size limit.');
-        }
-        files.push([safePath, content]);
-      }
-      // Paths are validated above; FS write failures (e.g. a missing parent dir in
-      // the worker VFS) are best-effort and must not abort the whole import — the
-      // file content is still surfaced via s.params.sources below.
-      for (const [safePath, content] of files) {
-        try {
-          this.fs.writeFile(`/home/${safePath}`, content);
-        } catch {
-          /* best-effort: source is still loaded into the editor below */
-        }
-      }
-      const entryRel = (files.find(([p]) => p === 'main.scad') ??
-        files.find(([p]) => p.endsWith('.scad')) ??
-        files[0])?.[0];
-      if (entryRel) {
-        const fullEntry = `/home/${entryRel}`;
-        this.mutate((s) => {
-          s.params.sources = files.map(([p, content]) => ({ path: `/home/${p}`, content }));
-          s.params.activePath = fullEntry;
-          s.lastCheckerRun = undefined;
-          s.output = undefined;
-          s.error = undefined;
-          s.errorDetails = undefined;
-        });
-        this.processSource();
-      }
+      const next = await this.projectStore.importZip(zipBuffer);
+      if (!next) return; // archive had no files
+      this.mutate((s) => {
+        s.params.sources = next.sources;
+        s.params.activePath = next.activePath;
+        s.lastCheckerRun = undefined;
+        s.output = undefined;
+        s.error = undefined;
+        s.errorDetails = undefined;
+      });
+      this.processSource();
     } catch (err) {
       this.mutate((s) => {
         this.applyUserFacingError(s, err, 'model');
@@ -558,16 +488,14 @@ export class Model extends EventTarget {
   async openFileViaFSAPI(): Promise<boolean> {
     const result = await openLocalFile();
     if (!result) return false;
-    const path = `/home/${result.name}`;
-    try {
-      this.fs.writeFile(path, result.content);
-    } catch {
-      /* ignore */
-    }
+    const next = this.projectStore.addFile(
+      this.state.params.sources,
+      `/home/${result.name}`,
+      result.content,
+    );
     this.mutate((s) => {
-      const withoutExisting = s.params.sources.filter((src) => src.path !== path);
-      s.params.sources = [...withoutExisting, { path, content: result.content }];
-      s.params.activePath = path;
+      s.params.sources = next.sources;
+      s.params.activePath = next.activePath;
       s.lastCheckerRun = undefined;
       s.output = undefined;
       s.error = undefined;
@@ -592,15 +520,7 @@ export class Model extends EventTarget {
       downloadUrl(URL.createObjectURL(file), file.name);
     } else {
       try {
-        const zip = new JSZip();
-        for (const source of this.state.params.sources) {
-          let path = source.path;
-          if (path.startsWith('/')) {
-            path = path.substring(1);
-          }
-          zip.file(path, await fetchSource(this.fs, source));
-        }
-        const blob = await zip.generateAsync({ type: 'blob' });
+        const blob = await this.projectStore.buildZip(this.state.params.sources);
         const file = new File([blob], 'project.zip');
         downloadUrl(URL.createObjectURL(file), file.name);
       } catch (err) {

--- a/src/state/project-store.ts
+++ b/src/state/project-store.ts
@@ -1,0 +1,146 @@
+import JSZip from 'jszip';
+import { Source } from './app-state.ts';
+import { fetchSource } from '../utils.ts';
+import {
+  MAX_PROJECT_FILE_COUNT,
+  MAX_PROJECT_TOTAL_BYTES,
+  normalizeProjectPath,
+  ProjectPathError,
+} from '../fs/project-path.ts';
+
+/** The project's file set and which one is the active entry point. */
+export interface ProjectSnapshot {
+  sources: Source[];
+  activePath: string;
+}
+
+/**
+ * Owns project-source logic: active-source lookup/edit, new/open/add file, and
+ * ZIP import/export. It reads and writes the project filesystem but never
+ * compiles, renders, downloads, or touches UI/layout state — callers apply the
+ * returned snapshot and drive any follow-up (e.g. recompiling).
+ */
+export class ProjectStore {
+  constructor(private fs: FS) {}
+
+  /** Content of the active source, or '' if absent/not yet loaded. */
+  activeContent(sources: Source[], activePath: string): string {
+    return sources.find((s) => s.path === activePath)?.content ?? '';
+  }
+
+  /** Sources with the active source's content replaced. */
+  withActiveContent(sources: Source[], activePath: string, content: string): Source[] {
+    return sources.map((s) => (s.path === activePath ? { path: s.path, content } : s));
+  }
+
+  private read(path: string): string {
+    try {
+      return new TextDecoder('utf-8').decode(this.fs.readFileSync(path));
+    } catch (e) {
+      console.error('Error while reading file:', e);
+      return '';
+    }
+  }
+
+  /**
+   * Switch the active file to `path`: drop the previous active source if it was
+   * unmodified vs disk, and add `path` (reading its content) if not already
+   * present. Returns null if `path` is already active (no change).
+   */
+  openFile(sources: Source[], activePath: string, path: string): ProjectSnapshot | null {
+    if (activePath === path) return null;
+    const activeContent = this.read(activePath);
+    let next = sources.filter((src) => src.path !== activePath || src.content != activeContent);
+    if (!next.find((src) => src.path === path)) {
+      next = [...next, { path, content: this.read(path) }];
+    }
+    return { sources: next, activePath: path };
+  }
+
+  /** Create a new empty .scad file with a unique /home/untitled* name. */
+  newFile(sources: Source[]): ProjectSnapshot {
+    const base = '/home/untitled';
+    let path = `${base}.scad`;
+    let n = 2;
+    const existing = new Set(sources.map((s) => s.path));
+    while (existing.has(path)) path = `${base}-${n++}.scad`;
+    try {
+      this.fs.writeFile(path, '');
+    } catch {
+      /* fs may not support it yet */
+    }
+    return { sources: [...sources, { path, content: '' }], activePath: path };
+  }
+
+  /** Add (or replace) an externally-opened file and make it active. */
+  addFile(sources: Source[], path: string, content: string): ProjectSnapshot {
+    try {
+      this.fs.writeFile(path, content);
+    } catch {
+      /* ignore */
+    }
+    const withoutExisting = sources.filter((src) => src.path !== path);
+    return { sources: [...withoutExisting, { path, content }], activePath: path };
+  }
+
+  /**
+   * Extract a validated ZIP archive into /home and select an entry .scad.
+   * Validates and bounds every entry before writing any (atomic rejection).
+   * Returns null when the archive contains no files.
+   */
+  async importZip(zipBuffer: ArrayBuffer): Promise<ProjectSnapshot | null> {
+    const zip = await JSZip.loadAsync(zipBuffer);
+    const entries = Object.entries(zip.files).filter(([, zipObj]) => !zipObj.dir);
+    if (entries.length > MAX_PROJECT_FILE_COUNT) {
+      throw new ProjectPathError(`Archive has too many files (max ${MAX_PROJECT_FILE_COUNT}).`);
+    }
+    // The size limit is an approximate cumulative guard over decoded entry
+    // lengths (UTF-16 units); a single entry is still fully decoded before its
+    // length is counted.
+    const files: [string, string][] = [];
+    const seen = new Set<string>();
+    let totalSize = 0;
+    for (const [relPath, zipObj] of entries) {
+      const safePath = normalizeProjectPath(relPath);
+      if (seen.has(safePath)) {
+        throw new ProjectPathError(`Duplicate path in archive: ${safePath}`);
+      }
+      seen.add(safePath);
+      const content = await zipObj.async('string');
+      totalSize += content.length;
+      if (totalSize > MAX_PROJECT_TOTAL_BYTES) {
+        throw new ProjectPathError('Archive exceeds the uncompressed size limit.');
+      }
+      files.push([safePath, content]);
+    }
+    // Paths are validated above; FS write failures (e.g. a missing parent dir in
+    // the worker VFS) are best-effort and must not abort the import — the file
+    // content is still surfaced via the returned sources.
+    for (const [safePath, content] of files) {
+      try {
+        this.fs.writeFile(`/home/${safePath}`, content);
+      } catch {
+        /* best-effort */
+      }
+    }
+    const entryRel = (files.find(([p]) => p === 'main.scad') ??
+      files.find(([p]) => p.endsWith('.scad')) ??
+      files[0])?.[0];
+    if (!entryRel) return null;
+    return {
+      sources: files.map(([p, content]) => ({ path: `/home/${p}`, content })),
+      activePath: `/home/${entryRel}`,
+    };
+  }
+
+  /** Build a project ZIP blob from the current sources (caller downloads it). */
+  async buildZip(sources: Source[]): Promise<Blob> {
+    const zip = new JSZip();
+    for (const source of sources) {
+      let path = source.path;
+      if (path.startsWith('/')) path = path.substring(1);
+      zip.file(path, await fetchSource(this.fs, source));
+    }
+    return zip.generateAsync({ type: 'blob' });
+  }
+}


### PR DESCRIPTION
## What
Extracts project-source logic out of the ~756-line `Model` into a focused **`ProjectStore`** (`src/state/project-store.ts`): active-source lookup/edit (`activeContent`/`withActiveContent`), file ops (`openFile`/`newFile`/`addFile`), and ZIP import/export (`importZip`/`buildZip`). The store reads/writes the project filesystem but **never compiles, renders, downloads, or touches UI/layout state** — `Model` applies the returned `{ sources, activePath }` snapshot and drives any follow-up (UI resets + `processSource`).

`openFile`, `source` get/set, `newFile`, `importProjectZip`, `openFileViaFSAPI`, and `saveProject` now delegate; the now-unused `JSZip` / `project-path` imports are dropped from `Model`.

## Scope note
Limited to the **logic** extraction. The source data still lives in `State.params.sources`/`activePath` (the data-ownership move is the deferred #58), so behavior is unchanged. `ProjectStore` is stateless apart from the injected `fs` — no second source of truth.

## Review
An adversarial review confirmed every delegated method is byte-faithful to the original — including the "drop previous active if unmodified vs disk" filter, the empty-archive no-op (now `null` → Model no-ops), the smaller reset sets, and which methods call `processSource`. Encapsulation is clean (no compile/render/download/UI in the store); no leftover imports or dead code.

## Tests
New `project-store.test.ts` (lookup/edits/open/new/add-file); full unit suite (249) green; full Playwright e2e (22 — file ops, source editing, render) green; tsc/ESLint/Prettier clean.

Closes #57