### PR TITLE
refactor(state): scope persistence to durable state, debounced (#58)

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -99,14 +99,14 @@ window.addEventListener('load', async () => {
       const data = JSON.parse(
         new TextDecoder('utf-8').decode(bfs.readFileSync('/home/state.json')),
       );
-      const { view, params } = data;
-      persistedState = { view, params };
+      const { view, params, preview } = data;
+      persistedState = { view, params, preview };
     } catch (e) {
       console.log('Failed to read the persisted state from local storage.', e);
     }
     statePersister = {
-      set: async ({ view, params }) => {
-        bfs.writeFile('/home/state.json', JSON.stringify({ view, params }));
+      set: async ({ view, params, preview }) => {
+        bfs.writeFile('/home/state.json', JSON.stringify({ view, params, preview }));
       },
     };
   } else {

--- a/src/state/__tests__/scoped-persistence.test.ts
+++ b/src/state/__tests__/scoped-persistence.test.ts
@@ -1,0 +1,134 @@
+// Regression coverage for issue #58: persistence is scoped to the durable slice
+// (params/view/preview), debounced, and serialized. Transient mutations
+// (rendering flags, logs, errors, output) must not trigger writes.
+
+import { Model } from '../model.ts';
+import { State } from '../app-state.ts';
+import { defaultSourcePath, defaultModelColor } from '../initial-state.ts';
+
+vi.mock('../../runner/actions.ts', () => {
+  const makeDelayable = (resolved: unknown) =>
+    vi.fn().mockReturnValue(vi.fn().mockResolvedValue(resolved));
+  return {
+    checkSyntax: makeDelayable({ logText: '', markers: [], parameterSet: undefined }),
+    render: makeDelayable({
+      outFile: new File([''], 't.off'),
+      logText: '',
+      markers: [],
+      elapsedMillis: 0,
+    }),
+  };
+});
+vi.mock('../../io/import_off.ts', () => ({ parseOff: vi.fn() }));
+
+function makeFs() {
+  return {
+    readFileSync: vi.fn(() => new Uint8Array(0)),
+    writeFile: vi.fn(),
+    isFile: vi.fn(() => false),
+  } as unknown as FS;
+}
+
+function baseState(): State {
+  return {
+    params: {
+      activePath: defaultSourcePath,
+      sources: [{ path: defaultSourcePath, content: 'cube(1);' }],
+      features: [],
+      exportFormat2D: 'svg',
+      exportFormat3D: 'stl',
+    },
+    view: {
+      layout: {
+        mode: 'multi',
+        editor: true,
+        viewer: true,
+        customizer: false,
+      } as State['view']['layout'],
+      color: defaultModelColor,
+      showAxes: true,
+      lineNumbers: false,
+    },
+  };
+}
+
+describe('scoped persistence (#58)', () => {
+  beforeEach(() => vi.useFakeTimers());
+  afterEach(() => vi.useRealTimers());
+
+  function makeModel() {
+    const persister = { set: vi.fn().mockResolvedValue(undefined) };
+    const model = new Model(makeFs(), baseState(), undefined, persister);
+    return { model, persister };
+  }
+
+  it('does not persist on a transient-only mutation', async () => {
+    const { model, persister } = makeModel();
+    model.mutate((s) => {
+      s.rendering = true;
+      s.currentRunLogs = [['stdout', 'working']];
+    });
+    await vi.advanceTimersByTimeAsync(1000);
+    expect(persister.set).not.toHaveBeenCalled();
+  });
+
+  it('persists a durable mutation after the debounce', async () => {
+    const { model, persister } = makeModel();
+    model.mutate((s) => (s.view.showAxes = false));
+    expect(persister.set).not.toHaveBeenCalled(); // debounced
+    await vi.advanceTimersByTimeAsync(600);
+    expect(persister.set).toHaveBeenCalledTimes(1);
+  });
+
+  it('coalesces rapid durable mutations into a single write of the latest state', async () => {
+    const { model, persister } = makeModel();
+    model.mutate((s) => (s.view.color = '#111111'));
+    model.mutate((s) => (s.view.color = '#222222'));
+    model.mutate((s) => (s.view.color = '#333333'));
+    await vi.advanceTimersByTimeAsync(600);
+    expect(persister.set).toHaveBeenCalledTimes(1);
+    expect(persister.set.mock.calls[0][0].view.color).toBe('#333333');
+  });
+
+  it('does not re-persist when only transient state changes after a durable write', async () => {
+    const { model, persister } = makeModel();
+    model.mutate((s) => (s.view.showAxes = false));
+    await vi.advanceTimersByTimeAsync(600);
+    expect(persister.set).toHaveBeenCalledTimes(1);
+
+    model.mutate((s) => (s.previewing = true));
+    model.mutate((s) => (s.error = 'boom'));
+    await vi.advanceTimersByTimeAsync(1000);
+    expect(persister.set).toHaveBeenCalledTimes(1); // no extra write
+  });
+
+  it('swallows persister errors without throwing', async () => {
+    const { model, persister } = makeModel();
+    persister.set.mockRejectedValueOnce(new Error('disk full'));
+    model.mutate((s) => (s.view.showAxes = false));
+    await expect(vi.advanceTimersByTimeAsync(600)).resolves.not.toThrow();
+  });
+
+  it('serializes overlapping writes: a change during an in-flight write is persisted after', async () => {
+    const resolvers: Array<() => void> = [];
+    const set = vi.fn().mockImplementation(() => new Promise<void>((r) => resolvers.push(r)));
+    const model = new Model(makeFs(), baseState(), undefined, { set });
+
+    // Write A starts and stays in-flight (its promise is unresolved).
+    model.mutate((s) => (s.view.color = '#aaaaaa'));
+    await vi.advanceTimersByTimeAsync(600);
+    expect(set).toHaveBeenCalledTimes(1);
+    expect(set.mock.calls[0][0].view.color).toBe('#aaaaaa');
+
+    // Change B arrives while A is in-flight — must not start a second write yet.
+    model.mutate((s) => (s.view.color = '#bbbbbb'));
+    await vi.advanceTimersByTimeAsync(600);
+    expect(set).toHaveBeenCalledTimes(1);
+
+    // Resolve A → the coalesced follow-up writes the latest (B).
+    resolvers[0]();
+    await vi.advanceTimersByTimeAsync(0);
+    expect(set).toHaveBeenCalledTimes(2);
+    expect(set.mock.calls[1][0].view.color).toBe('#bbbbbb');
+  });
+});

--- a/src/state/model.ts
+++ b/src/state/model.ts
@@ -29,6 +29,19 @@ import {
   UserFacingOperation,
 } from '../user-facing-errors.ts';
 
+/** Debounce window for durable-state persistence (coalesces rapid edits/drags). */
+const PERSIST_DEBOUNCE_MS = 500;
+/** Cap so persistence still flushes during sustained activity (e.g. log streaming). */
+const PERSIST_MAX_WAIT_MS = 2000;
+
+/** The durable slice of State that is persisted (matches the fragment encoder). */
+type PersistedSlice = Pick<State, 'params' | 'view' | 'preview'>;
+const durableSlice = (state: State): PersistedSlice => ({
+  params: state.params,
+  view: state.view,
+  preview: state.preview,
+});
+
 export class Model extends EventTarget {
   /** Owns project-source logic (lookup, edits, file ops, ZIP import/export). */
   private readonly projectStore: ProjectStore;
@@ -41,6 +54,7 @@ export class Model extends EventTarget {
   ) {
     super();
     this.projectStore = new ProjectStore(fs);
+    this._lastPersistedJson = JSON.stringify(durableSlice(state));
   }
 
   // Sequence counters identifying the latest in-flight operation of each kind.
@@ -51,6 +65,18 @@ export class Model extends EventTarget {
   private _previewSeq = 0;
   private _renderSeq = 0;
   private _syntaxSeq = 0;
+
+  // Scoped persistence: only the durable slice (params/view/preview) is written,
+  // so transient mutations (rendering flags, logs, errors, output URLs) don't
+  // cause writes. Writes are debounced and serialized. deep-mutate only re-bumps
+  // the top-level State identity (nested objects mutate in place), so durable
+  // changes are detected by comparing a JSON signature of the slice — computed
+  // once per debounce window, not per mutation.
+  private _lastPersistedJson: string;
+  private _persistTimer: ReturnType<typeof setTimeout> | null = null;
+  private _persistDeadline: number | null = null;
+  private _persistInFlight = false;
+  private _persistPending = false;
 
   init() {
     if (
@@ -66,9 +92,55 @@ export class Model extends EventTarget {
 
   private setState(state: State) {
     this.state = state;
-    this.statePersister?.set(state);
+    this.schedulePersist();
     this.setStateCallback?.(state);
     this.dispatchEvent(new CustomEvent<State>('state', { detail: state }));
+  }
+
+  /**
+   * Debounce a persistence check; the actual durable-change test runs at flush.
+   * A max-wait deadline ensures the timer still fires under sustained activity
+   * (e.g. a render streaming logs) rather than being pushed back indefinitely.
+   */
+  private schedulePersist() {
+    if (!this.statePersister) return;
+    const now = Date.now();
+    if (this._persistDeadline == null) this._persistDeadline = now + PERSIST_MAX_WAIT_MS;
+    const delay = Math.max(0, Math.min(PERSIST_DEBOUNCE_MS, this._persistDeadline - now));
+    if (this._persistTimer) clearTimeout(this._persistTimer);
+    this._persistTimer = setTimeout(() => {
+      this._persistTimer = null;
+      this._persistDeadline = null;
+      void this.flushPersist();
+    }, delay);
+  }
+
+  /**
+   * Persist the durable slice, but only if it actually changed (so transient-only
+   * mutations write nothing). Serialized so writes can't overlap or reorder; the
+   * latest state is coalesced into a single follow-up write, and errors are logged.
+   */
+  private async flushPersist() {
+    if (!this.statePersister) return;
+    if (this._persistInFlight) {
+      this._persistPending = true; // re-check & persist the latest once the current write finishes
+      return;
+    }
+    const json = JSON.stringify(durableSlice(this.state));
+    if (json === this._lastPersistedJson) return; // durable state unchanged — skip the write
+    this._persistInFlight = true;
+    try {
+      await this.statePersister.set(this.state);
+      this._lastPersistedJson = json; // record only on success so a failed write retries
+    } catch (e) {
+      console.error('Failed to persist state:', e);
+    } finally {
+      this._persistInFlight = false;
+      if (this._persistPending) {
+        this._persistPending = false;
+        void this.flushPersist();
+      }
+    }
   }
 
   mutate(f: (state: State) => void) {


### PR DESCRIPTION
## What
`Model.setState` called `statePersister.set(state)` on **every** mutation, so transient changes (rendering flags, logs, errors, output blob URLs) triggered a re-serialize + URL/localStorage write — even though only `{params, view, preview}` is persisted — and the call was unawaited/uncaught.

- Persist **only when the durable slice changed**: `deep-mutate` re-bumps only the top-level `State` identity (nested objects mutate in place), so durable changes are detected by a JSON signature of `{params, view, preview}` — computed once per debounce window, not per mutation.
- Writes are **debounced** (500 ms) with a **max-wait cap** (2 s) so they still flush under sustained activity (a render streaming logs won't push the timer back indefinitely), **serialized** (no overlapping/reordered writes; the latest is coalesced into one follow-up), and **errors are caught**.
- The standalone/localStorage persister now also stores `preview`, so its persisted set matches the signature (no redundant per-render writes in standalone mode).

## Scope note
Limited to the **persistence behavior** — the issue's acceptance criteria. The structural split of `State` into separate store objects is deferred; it's intertwined with the `Model` decomposition (#59) and not required for these guarantees.

## Review
An adversarial review confirmed the signature exactly matches the encoder, the in-flight coalescing is correct (no lost writes), and the boot baseline avoids spurious/missing initial writes. Its four findings are all addressed here: standalone `preview` divergence (fixed), record-on-success-only retry (fixed), max-wait starvation cap (added), and a test for the in-flight overlap path (added).

## Tests
New `scoped-persistence.test.ts` — transient mutations write nothing, durable writes are debounced + coalesced, errors swallowed, and the in-flight overlap path. Full unit suite (255) + e2e (boot/load/customizer/F5) green; tsc/ESLint/Prettier clean.

Closes #58