### PR TITLE
refactor(state): route Model side effects through a HostAdapter (slice of #59)

### DIFF
--- a/src/state/__tests__/web-host-adapter.test.ts
+++ b/src/state/__tests__/web-host-adapter.test.ts
@@ -1,0 +1,109 @@
+// Issue #59 (slice): Model routes browser side effects through a HostAdapter
+// instead of touching the DOM/window directly.
+
+import { Model } from '../model.ts';
+import { State } from '../app-state.ts';
+import { WebHostAdapter, type HostAdapter } from '../web-host-adapter.ts';
+import { defaultSourcePath, defaultModelColor } from '../initial-state.ts';
+
+vi.mock('../../runner/actions.ts', () => {
+  const makeDelayable = (resolved: unknown) =>
+    vi.fn().mockReturnValue(vi.fn().mockResolvedValue(resolved));
+  return {
+    checkSyntax: makeDelayable({ logText: '', markers: [], parameterSet: undefined }),
+    render: makeDelayable({
+      outFile: new File(['off-bytes'], 'out.off'),
+      logText: '',
+      markers: [],
+      elapsedMillis: 1,
+    }),
+  };
+});
+vi.mock('../../io/import_off.ts', () => ({ parseOff: vi.fn() }));
+
+function makeFs() {
+  return {
+    readFileSync: vi.fn(() => new Uint8Array(0)),
+    writeFile: vi.fn(),
+    isFile: vi.fn(() => false),
+  } as unknown as FS;
+}
+
+function baseState(): State {
+  return {
+    params: {
+      activePath: defaultSourcePath,
+      sources: [{ path: defaultSourcePath, content: 'cube(1);' }],
+      features: [],
+      exportFormat2D: 'svg',
+      exportFormat3D: 'stl',
+      autoCompile: false,
+    },
+    view: {
+      layout: {
+        mode: 'multi',
+        editor: true,
+        viewer: true,
+        customizer: false,
+      } as State['view']['layout'],
+      color: defaultModelColor,
+      showAxes: true,
+      lineNumbers: false,
+    },
+  };
+}
+
+function mockHost(): HostAdapter & { [K in keyof HostAdapter]: ReturnType<typeof vi.fn> } {
+  return {
+    createObjectURL: vi.fn(() => 'blob:fake'),
+    revokeObjectURL: vi.fn(),
+    download: vi.fn(),
+    playCompletionChime: vi.fn(),
+    baseUrl: vi.fn(() => 'http://localhost/'),
+  };
+}
+
+describe('WebHostAdapter', () => {
+  it('exposes the host operations without throwing in a DOM environment', () => {
+    const host = new WebHostAdapter();
+    const url = host.createObjectURL(new Blob(['x']));
+    expect(typeof url).toBe('string');
+    expect(() => host.revokeObjectURL(url)).not.toThrow();
+    expect(() => host.playCompletionChime()).not.toThrow(); // no #complete-sound element -> no-op
+    expect(typeof host.baseUrl()).toBe('string');
+  });
+});
+
+describe('Model routes side effects through the host (#59)', () => {
+  it('plays the completion chime on a full render, not a preview', async () => {
+    const host = mockHost();
+    const model = new Model(makeFs(), baseState(), undefined, undefined, host);
+
+    await model.render({ isPreview: false, now: true });
+    expect(host.playCompletionChime).toHaveBeenCalledTimes(1);
+    expect(host.createObjectURL).toHaveBeenCalled();
+
+    host.playCompletionChime.mockClear();
+    await model.render({ isPreview: true, now: true });
+    expect(host.playCompletionChime).not.toHaveBeenCalled();
+  });
+
+  it('downloads via the host when re-exporting an existing OFF output', async () => {
+    const host = mockHost();
+    const state = baseState();
+    state.is2D = false;
+    state.params.exportFormat3D = 'off';
+    state.output = {
+      isPreview: false,
+      outFile: new File(['off'], 'model.off'),
+      outFileURL: 'blob:existing',
+      elapsedMillis: 1,
+      formattedElapsedMillis: '1ms',
+      formattedOutFileSize: '3 bytes',
+    } as State['output'];
+    const model = new Model(makeFs(), state, undefined, undefined, host);
+
+    await model.export();
+    expect(host.download).toHaveBeenCalledWith('blob:existing', 'model.off');
+  });
+});

--- a/src/state/__tests__/web-host-adapter.test.ts
+++ b/src/state/__tests__/web-host-adapter.test.ts
@@ -3,7 +3,7 @@
 
 import { Model } from '../model.ts';
 import { State } from '../app-state.ts';
-import { WebHostAdapter, type HostAdapter } from '../web-host-adapter.ts';
+import { WebHostAdapter } from '../web-host-adapter.ts';
 import { defaultSourcePath, defaultModelColor } from '../initial-state.ts';
 
 vi.mock('../../runner/actions.ts', () => {
@@ -53,7 +53,7 @@ function baseState(): State {
   };
 }
 
-function mockHost(): HostAdapter & { [K in keyof HostAdapter]: ReturnType<typeof vi.fn> } {
+function mockHost() {
   return {
     createObjectURL: vi.fn(() => 'blob:fake'),
     revokeObjectURL: vi.fn(),

--- a/src/state/model.ts
+++ b/src/state/model.ts
@@ -9,15 +9,10 @@ import {
 } from './app-state.ts';
 import { VALID_EXPORT_FORMATS_2D, VALID_EXPORT_FORMATS_3D } from './formats.ts';
 import { bubbleUpDeepMutations } from './deep-mutate.ts';
-import {
-  downloadUrl,
-  fetchSource,
-  formatBytes,
-  formatMillis,
-  readFileAsDataURL,
-} from '../utils.ts';
+import { fetchSource, formatBytes, formatMillis, readFileAsDataURL } from '../utils.ts';
 import { openLocalFile, saveActiveFile } from '../fs/filesystem.ts';
 import { ProjectStore } from './project-store.ts';
+import { HostAdapter, WebHostAdapter } from './web-host-adapter.ts';
 import { isExpectedJobCancellation, ProcessStreams } from '../runner/openscad-runner.ts';
 import { is2DFormatExtension } from './formats.ts';
 import { parseOff } from '../io/import_off.ts';
@@ -51,6 +46,7 @@ export class Model extends EventTarget {
     public state: State,
     private setStateCallback?: (state: State) => void,
     private statePersister?: StatePersister,
+    private host: HostAdapter = new WebHostAdapter(),
   ) {
     super();
     this.projectStore = new ProjectStore(fs);
@@ -319,7 +315,7 @@ export class Model extends EventTarget {
           await fetchSource(
             this.fs,
             { path: requestedPath, url },
-            { baseUrl: window.location.href },
+            { baseUrl: this.host.baseUrl() },
           ),
         );
         // The active file may have changed while the fetch was in flight. Write
@@ -428,9 +424,12 @@ export class Model extends EventTarget {
       if (normalPassThrough || glbPassThrough) {
         this.mutate((s) => (s.export = s.output));
         if (glbPassThrough) {
-          downloadUrl(this.state.output.displayFileURL!, this.state.output.displayFile!.name);
+          this.host.download(
+            this.state.output.displayFileURL!,
+            this.state.output.displayFile!.name,
+          );
         } else {
-          downloadUrl(this.state.output.outFileURL, this.state.output.outFile.name);
+          this.host.download(this.state.output.outFileURL, this.state.output.outFile.name);
         }
         return;
       }
@@ -496,11 +495,11 @@ export class Model extends EventTarget {
         })({ now: true });
       }
 
-      const outFileURL = URL.createObjectURL(output.outFile);
+      const outFileURL = this.host.createObjectURL(output.outFile);
       this.mutate((s) => {
         s.exporting = false;
         if (s.export?.outFileURL?.startsWith('blob:') ?? false) {
-          URL.revokeObjectURL(s.export!.outFileURL);
+          this.host.revokeObjectURL(s.export!.outFileURL);
         }
         s.export = {
           outFile: output.outFile,
@@ -509,7 +508,7 @@ export class Model extends EventTarget {
           formattedElapsedMillis: formatMillis(output.elapsedMillis),
           formattedOutFileSize: formatBytes(output.outFile.size),
         };
-        downloadUrl(s.export.outFileURL, output.outFile.name);
+        this.host.download(s.export.outFileURL, output.outFile.name);
       });
     } catch (err) {
       this.mutate((s) => {
@@ -589,12 +588,12 @@ export class Model extends EventTarget {
       const contentBytes = new TextEncoder().encode(content) as Uint8Array<ArrayBuffer>;
       const blob = new Blob([contentBytes], { type: 'text/plain' });
       const file = new File([blob], this.state.params.activePath.split('/').pop()!);
-      downloadUrl(URL.createObjectURL(file), file.name);
+      this.host.download(this.host.createObjectURL(file), file.name);
     } else {
       try {
         const blob = await this.projectStore.buildZip(this.state.params.sources);
         const file = new File([blob], 'project.zip');
-        downloadUrl(URL.createObjectURL(file), file.name);
+        this.host.download(this.host.createObjectURL(file), file.name);
       } catch (err) {
         this.mutate((s) => {
           this.applyUserFacingError(s, err, 'model');
@@ -677,7 +676,7 @@ export class Model extends EventTarget {
       } else {
         is2D = false;
       }
-      const outFileURL = URL.createObjectURL(output.outFile);
+      const outFileURL = this.host.createObjectURL(output.outFile);
       const displayFileURL = displayFile && (await readFileAsDataURL(displayFile));
       this.mutate((s) => {
         setRendering(s, false);
@@ -689,10 +688,10 @@ export class Model extends EventTarget {
           markers: output.markers,
         };
         if (s.output?.outFileURL?.startsWith('blob:') ?? false) {
-          URL.revokeObjectURL(s.output!.outFileURL);
+          this.host.revokeObjectURL(s.output!.outFileURL);
         }
         if (s.output?.displayFileURL?.startsWith('blob:') ?? false) {
-          URL.revokeObjectURL(s.output!.displayFileURL!);
+          this.host.revokeObjectURL(s.output!.displayFileURL!);
         }
 
         s.output = {
@@ -707,8 +706,7 @@ export class Model extends EventTarget {
         };
 
         if (!isPreview) {
-          const audio = document.getElementById('complete-sound') as HTMLAudioElement;
-          audio?.play();
+          this.host.playCompletionChime();
         }
       });
     } catch (err) {

--- a/src/state/web-host-adapter.ts
+++ b/src/state/web-host-adapter.ts
@@ -1,0 +1,39 @@
+import { downloadUrl } from '../utils.ts';
+
+/**
+ * The browser-platform side effects the domain layer needs: object-URL
+ * lifecycle, file downloads, the render-complete chime, and the document base
+ * URL. Abstracting these behind an interface keeps direct DOM/`window` access
+ * out of `Model` (and lets tests inject a stub).
+ */
+export interface HostAdapter {
+  createObjectURL(blob: Blob | File): string;
+  revokeObjectURL(url: string): void;
+  download(url: string, filename: string): void;
+  playCompletionChime(): void;
+  baseUrl(): string;
+}
+
+/** Default `HostAdapter` backed by the real browser APIs. */
+export class WebHostAdapter implements HostAdapter {
+  createObjectURL(blob: Blob | File): string {
+    return URL.createObjectURL(blob);
+  }
+
+  revokeObjectURL(url: string): void {
+    URL.revokeObjectURL(url);
+  }
+
+  download(url: string, filename: string): void {
+    downloadUrl(url, filename);
+  }
+
+  playCompletionChime(): void {
+    const audio = document.getElementById('complete-sound') as HTMLAudioElement | null;
+    audio?.play();
+  }
+
+  baseUrl(): string {
+    return window.location.href;
+  }
+}


### PR DESCRIPTION
## Summary
Extracts a `HostAdapter` interface (with a `WebHostAdapter` default implementation backed by the real browser APIs) and routes all of `Model`'s browser side effects through it:

- object-URL lifecycle (`createObjectURL` / `revokeObjectURL`)
- file downloads
- the render-complete chime (`#complete-sound`)
- the document base URL (`window.location.href`)

`Model` no longer touches the DOM or `window` directly — grep of `model.ts` for `document.` / `window.` / `URL.createObjectURL` / `getElementById` / `downloadUrl` returns zero matches. This satisfies the **"no DOM in domain"** acceptance criterion of #59 and lets tests inject a stub host.

## Scope
This is a **slice** of #59, not a full close. It removes the DOM coupling (the audit's specific complaint, e.g. the completion chime reaching into the document). The broader decomposition — a compile coordinator / export service and reducing `Model` to a thin façade — remains tracked on #59.

## Verification
- Unit: `258 passed`
- e2e (Playwright): `22 passed` (render/chime/export paths)
- eslint + prettier: clean
- Adversarial subagent review: behavior faithfully preserved, no blockers — every host call replaced one-for-one, object-URL create/revoke pairing preserved, chime still gated to full (non-preview) renders.

Refs #59