### PR TITLE
fix(fs): scope the FSAPI write-back handle to its source (slice of #62)

### DIFF
--- a/src/__tests__/filesystem.test.ts
+++ b/src/__tests__/filesystem.test.ts
@@ -1,13 +1,12 @@
 // Unit tests for Phase 2 filesystem layer — F2/F3/F7 exit criteria
 
 import {
-  clearActiveFileHandle,
   clearHomeDirectory,
   extractLibraryNames,
   getParentDir,
   join,
   openLocalFile,
-  saveActiveFile,
+  saveViaHandle,
 } from '../fs/filesystem.ts';
 import { zipArchives, deployedArchiveNames, ZipArchive } from '../fs/zip-archives.generated.ts';
 import libsConfig from '../../libs-config.json';
@@ -213,7 +212,6 @@ describe('clearHomeDirectory', () => {
 
 describe('File System Access helpers', () => {
   afterEach(() => {
-    clearActiveFileHandle();
     delete (window as Window & { showOpenFilePicker?: unknown }).showOpenFilePicker;
   });
 
@@ -221,7 +219,7 @@ describe('File System Access helpers', () => {
     await expect(openLocalFile()).resolves.toBeNull();
   });
 
-  it('openLocalFile returns file metadata and saveActiveFile writes via the retained handle', async () => {
+  it('openLocalFile returns file metadata + handle; saveViaHandle writes through it', async () => {
     const writable = {
       write: vi.fn().mockResolvedValue(undefined),
       close: vi.fn().mockResolvedValue(undefined),
@@ -239,36 +237,32 @@ describe('File System Access helpers', () => {
       value: vi.fn().mockResolvedValue([handle]),
     });
 
-    await expect(openLocalFile()).resolves.toEqual({
-      name: 'demo.scad',
-      content: 'cube(10);',
-    });
-    await expect(saveActiveFile('sphere(5);')).resolves.toBe(true);
+    const result = await openLocalFile();
+    expect(result).toMatchObject({ name: 'demo.scad', content: 'cube(10);' });
+    expect(result!.handle).toBe(handle as unknown as FileSystemFileHandle);
+
+    await expect(saveViaHandle(result!.handle, 'sphere(5);')).resolves.toBe(true);
     expect(writable.write).toHaveBeenCalledWith('sphere(5);');
     expect(writable.close).toHaveBeenCalled();
   });
 
-  it('openLocalFile treats AbortError as a user cancel and resets failed save handles', async () => {
-    const handle = {
-      getFile: vi.fn().mockResolvedValue({
-        name: 'demo.scad',
-        text: vi.fn().mockResolvedValue('cube(10);'),
-      }),
-      createWritable: vi.fn().mockRejectedValue(new Error('disk full')),
-    };
-
+  it('openLocalFile treats AbortError as a user cancel', async () => {
     Object.defineProperty(window, 'showOpenFilePicker', {
       configurable: true,
       value: vi
         .fn()
-        .mockRejectedValueOnce(Object.assign(new Error('cancelled'), { name: 'AbortError' }))
-        .mockResolvedValueOnce([handle]),
+        .mockRejectedValueOnce(Object.assign(new Error('cancelled'), { name: 'AbortError' })),
     });
 
     await expect(openLocalFile()).resolves.toBeNull();
-    await openLocalFile();
-    await expect(saveActiveFile('cube(1);')).resolves.toBe(false);
-    await expect(saveActiveFile('cube(2);')).resolves.toBe(false);
+  });
+
+  it('saveViaHandle returns false when the handle write fails', async () => {
+    const handle = {
+      createWritable: vi.fn().mockRejectedValue(new Error('disk full')),
+    } as unknown as FileSystemFileHandle;
+
+    await expect(saveViaHandle(handle, 'cube(1);')).resolves.toBe(false);
   });
 
   it('openLocalFile rethrows non-abort picker failures', async () => {

--- a/src/fs/filesystem.ts
+++ b/src/fs/filesystem.ts
@@ -229,23 +229,27 @@ export async function symlinkLibraries(
 // File System Access API (Chromium) with graceful degradation
 // ---------------------------------------------------------------------------
 
-// eslint-disable-next-line @typescript-eslint/no-explicit-any
-let _activeHandle: any | null = null;
-
 /**
  * Opens a local .scad file via the File System Access API (Chromium).
  * Returns null on Firefox/Safari — the caller falls back to <input type="file">.
+ *
+ * The returned `handle` is owned by the caller, which must retain it scoped to
+ * the opened source (so write-back targets the right file even after other
+ * sources are opened) and pass it back to `saveViaHandle()`.
  */
-export async function openLocalFile(): Promise<{ name: string; content: string } | null> {
+export async function openLocalFile(): Promise<{
+  name: string;
+  content: string;
+  handle: FileSystemFileHandle;
+} | null> {
   if (!('showOpenFilePicker' in window)) return null;
   try {
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    const [handle] = await (window as any).showOpenFilePicker({
+    const [handle] = (await (window as any).showOpenFilePicker({
       types: [{ description: 'OpenSCAD files', accept: { 'text/plain': ['.scad'] } }],
-    });
-    _activeHandle = handle;
+    })) as FileSystemFileHandle[];
     const file = await handle.getFile();
-    return { name: file.name, content: await file.text() };
+    return { name: file.name, content: await file.text(), handle };
   } catch (e) {
     if ((e as Error).name === 'AbortError') return null; // user cancelled
     throw e;
@@ -253,25 +257,22 @@ export async function openLocalFile(): Promise<{ name: string; content: string }
 }
 
 /**
- * Writes back through the retained FSAPI handle.
- * Returns true on success, false if no handle is retained (caller uses download fallback).
+ * Writes `content` back through a retained FSAPI handle.
+ * Returns true on success, false if the handle is invalid (caller drops it and
+ * uses the download fallback).
  */
-export async function saveActiveFile(content: string): Promise<boolean> {
-  if (!_activeHandle) return false;
+export async function saveViaHandle(
+  handle: FileSystemFileHandle,
+  content: string,
+): Promise<boolean> {
   try {
-    const writable = await _activeHandle.createWritable();
+    const writable = await handle.createWritable();
     await writable.write(content);
     await writable.close();
     return true;
   } catch {
-    _activeHandle = null; // handle invalidated — reset
     return false;
   }
-}
-
-/** Clears the active file handle (e.g. when a new project is started). */
-export function clearActiveFileHandle(): void {
-  _activeHandle = null;
 }
 
 type MutableFS = FS & {

--- a/src/state/__tests__/fsapi-handle-scope.test.ts
+++ b/src/state/__tests__/fsapi-handle-scope.test.ts
@@ -1,0 +1,170 @@
+// Issue #62 (slice): the File System Access write-back handle is scoped to the
+// source it was opened for (Model-instance state keyed by path), not a global
+// "last opened" handle. This prevents saveProject() from writing one source's
+// content back into a different file's local handle.
+
+import { Model } from '../model.ts';
+import { State } from '../app-state.ts';
+import { defaultModelColor } from '../initial-state.ts';
+import { HostAdapter } from '../web-host-adapter.ts';
+
+vi.mock('../../runner/actions.ts', () => {
+  const makeDelayable = (resolved: unknown) =>
+    vi.fn().mockReturnValue(vi.fn().mockResolvedValue(resolved));
+  return {
+    checkSyntax: makeDelayable({ logText: '', markers: [], parameterSet: undefined }),
+    render: makeDelayable({
+      outFile: new File([''], 't.off'),
+      logText: '',
+      markers: [],
+      elapsedMillis: 0,
+    }),
+  };
+});
+vi.mock('../../io/import_off.ts', () => ({ parseOff: vi.fn() }));
+
+// Control archive contents without depending on real JSZip in jsdom.
+vi.mock('jszip', () => ({ default: { loadAsync: vi.fn() } }));
+import JSZip from 'jszip';
+const mockLoadAsync = (JSZip as unknown as { loadAsync: ReturnType<typeof vi.fn> }).loadAsync;
+
+function fakeZip(entries: Record<string, string>) {
+  const files: Record<string, { dir: boolean; async: () => Promise<string> }> = {};
+  for (const [name, content] of Object.entries(entries)) {
+    files[name] = { dir: false, async: () => Promise.resolve(content) };
+  }
+  return { files };
+}
+
+function makeFs() {
+  return {
+    readFileSync: vi.fn(() => new Uint8Array(0)),
+    writeFile: vi.fn(),
+    isFile: vi.fn(() => false),
+  } as unknown as FS;
+}
+
+function singleSourceState(path: string): State {
+  return {
+    params: {
+      activePath: path,
+      sources: [{ path, content: 'cube(1);' }],
+      features: [],
+      exportFormat2D: 'svg',
+      exportFormat3D: 'stl',
+      autoCompile: false,
+    },
+    view: {
+      layout: {
+        mode: 'multi',
+        editor: true,
+        viewer: true,
+        customizer: false,
+      } as State['view']['layout'],
+      color: defaultModelColor,
+      showAxes: true,
+      lineNumbers: false,
+    },
+  };
+}
+
+function mockHost(): HostAdapter {
+  return {
+    createObjectURL: vi.fn(() => 'blob:fake'),
+    revokeObjectURL: vi.fn(),
+    download: vi.fn(),
+    playCompletionChime: vi.fn(),
+    baseUrl: vi.fn(() => 'http://localhost/'),
+  };
+}
+
+/** Stub the Chromium picker so openLocalFile() resolves to a handle for `name`. */
+function stubPicker(name: string, content: string) {
+  const writable = {
+    write: vi.fn().mockResolvedValue(undefined),
+    close: vi.fn().mockResolvedValue(undefined),
+  };
+  const handle = {
+    getFile: vi.fn().mockResolvedValue({ name, text: vi.fn().mockResolvedValue(content) }),
+    createWritable: vi.fn().mockResolvedValue(writable),
+  };
+  Object.defineProperty(window, 'showOpenFilePicker', {
+    configurable: true,
+    value: vi.fn().mockResolvedValue([handle]),
+  });
+  return { handle, writable };
+}
+
+describe('FSAPI handle scoping (#62)', () => {
+  afterEach(() => {
+    delete (window as Window & { showOpenFilePicker?: unknown }).showOpenFilePicker;
+  });
+
+  it('saves the active FSAPI-opened source back through its own handle', async () => {
+    const { writable } = stubPicker('demo.scad', 'cube(10);');
+    const host = mockHost();
+    const model = new Model(
+      makeFs(),
+      singleSourceState('/home/demo.scad'),
+      undefined,
+      undefined,
+      host,
+    );
+
+    expect(await model.openFileViaFSAPI()).toBe(true);
+    await model.saveProject();
+
+    expect(writable.write).toHaveBeenCalledWith('cube(10);');
+    expect(host.download).not.toHaveBeenCalled();
+  });
+
+  it('does not reuse a stale handle after a ZIP import replaces the project', async () => {
+    const { writable } = stubPicker('a.scad', 'cube(10);');
+    const host = mockHost();
+    const model = new Model(
+      makeFs(),
+      singleSourceState('/home/a.scad'),
+      undefined,
+      undefined,
+      host,
+    );
+
+    // Open /home/a.scad via FSAPI — registers a write-back handle for that path.
+    await model.openFileViaFSAPI();
+
+    // Importing an archive with a different single file replaces the project.
+    mockLoadAsync.mockResolvedValue(fakeZip({ 'b.scad': 'sphere(5);' }));
+    await model.importProjectZip(new ArrayBuffer(0));
+    expect(model.state.params.activePath).toBe('/home/b.scad');
+
+    // Saving the imported source must NOT write back through a.scad's handle;
+    // with no handle for the active path it falls back to a download.
+    await model.saveProject();
+    expect(writable.write).not.toHaveBeenCalled();
+    expect(host.download).toHaveBeenCalled();
+  });
+
+  it('drops the handle even when the imported archive reuses the opened path', async () => {
+    const { writable } = stubPicker('a.scad', 'cube(10);');
+    const host = mockHost();
+    const model = new Model(
+      makeFs(),
+      singleSourceState('/home/a.scad'),
+      undefined,
+      undefined,
+      host,
+    );
+
+    await model.openFileViaFSAPI();
+
+    // Archive reuses the same path — its content is a *different* file, so the
+    // original FSAPI handle must not survive to receive it.
+    mockLoadAsync.mockResolvedValue(fakeZip({ 'a.scad': 'sphere(5);' }));
+    await model.importProjectZip(new ArrayBuffer(0));
+    expect(model.state.params.activePath).toBe('/home/a.scad');
+
+    await model.saveProject();
+    expect(writable.write).not.toHaveBeenCalled();
+    expect(host.download).toHaveBeenCalled();
+  });
+});

--- a/src/state/model.ts
+++ b/src/state/model.ts
@@ -10,7 +10,7 @@ import {
 import { VALID_EXPORT_FORMATS_2D, VALID_EXPORT_FORMATS_3D } from './formats.ts';
 import { bubbleUpDeepMutations } from './deep-mutate.ts';
 import { fetchSource, formatBytes, formatMillis, readFileAsDataURL } from '../utils.ts';
-import { openLocalFile, saveActiveFile } from '../fs/filesystem.ts';
+import { openLocalFile, saveViaHandle } from '../fs/filesystem.ts';
 import { ProjectStore } from './project-store.ts';
 import { HostAdapter, WebHostAdapter } from './web-host-adapter.ts';
 import { isExpectedJobCancellation, ProcessStreams } from '../runner/openscad-runner.ts';
@@ -61,6 +61,11 @@ export class Model extends EventTarget {
   private _previewSeq = 0;
   private _renderSeq = 0;
   private _syntaxSeq = 0;
+
+  // FSAPI write-back handles, keyed by source path (Chromium only). Scoping the
+  // handle to a path keeps `saveProject()` writing back to the source the handle
+  // was opened for, rather than whichever file was opened last.
+  private fsapiHandles = new Map<string, FileSystemFileHandle>();
 
   // Scoped persistence: only the durable slice (params/view/preview) is written,
   // so transient mutations (rendering flags, logs, errors, output URLs) don't
@@ -539,6 +544,11 @@ export class Model extends EventTarget {
     try {
       const next = await this.projectStore.importZip(zipBuffer);
       if (!next) return; // archive had no files
+      // A ZIP import replaces the whole project — none of the imported sources
+      // were opened via FSAPI, so drop every retained handle (a surviving
+      // handle for a colliding path would write archive content to the user's
+      // original on-disk file).
+      this.fsapiHandles.clear();
       this.mutate((s) => {
         s.params.sources = next.sources;
         s.params.activePath = next.activePath;
@@ -559,11 +569,9 @@ export class Model extends EventTarget {
   async openFileViaFSAPI(): Promise<boolean> {
     const result = await openLocalFile();
     if (!result) return false;
-    const next = this.projectStore.addFile(
-      this.state.params.sources,
-      `/home/${result.name}`,
-      result.content,
-    );
+    const path = `/home/${result.name}`;
+    const next = this.projectStore.addFile(this.state.params.sources, path, result.content);
+    this.fsapiHandles.set(path, result.handle);
     this.mutate((s) => {
       s.params.sources = next.sources;
       s.params.activePath = next.activePath;
@@ -579,9 +587,14 @@ export class Model extends EventTarget {
   async saveProject() {
     if (this.state.params.sources.length == 1) {
       const content = this.state.params.sources[0].content ?? '';
-      // Try FSAPI save first (if user opened file via File System Access API)
-      const saved = await saveActiveFile(content);
-      if (saved) return;
+      // Write back through the FSAPI handle for the *active* source, if it was
+      // opened that way; otherwise fall back to a download.
+      const activePath = this.state.params.activePath;
+      const handle = this.fsapiHandles.get(activePath);
+      if (handle) {
+        if (await saveViaHandle(handle, content)) return;
+        this.fsapiHandles.delete(activePath); // handle invalidated — drop it
+      }
       // TextEncoder.encode() always returns an ArrayBuffer-backed Uint8Array;
       // cast required because the TS lib defines encode() → Uint8Array (= <ArrayBufferLike>)
       // while Blob's BlobPart expects ArrayBufferView<ArrayBuffer>. TS 5.7+ issue.


### PR DESCRIPTION
## Summary
Removes the module-level `_activeHandle` global from `src/fs/filesystem.ts` and scopes the File System Access write-back handle to the source it was opened for.

- `openLocalFile()` now **returns** the `FileSystemFileHandle` instead of stashing it in a module global.
- `saveActiveFile(content)` → pure `saveViaHandle(handle, content)`.
- `Model` owns the handles in a `Map<path, FileSystemFileHandle>`. `saveProject()` looks up the handle for the **active** source; `importProjectZip()` (a full-project replace) drops all retained handles.

## The bug
`_activeHandle` was set on every FSAPI open and **never cleared in production** (`clearActiveFileHandle()` had no production caller). So after opening any local file via FSAPI, `saveProject()` would keep writing the active source's content back through that one handle — even after the project was replaced — risking writing one file's content into a different file on disk.

## Scope
Slice A of #62 (the separable, main-thread-only, criterion-2 win: *"saving to a local file is scoped to the correct source"*). The larger `ProjectFileSystem` interface + instance-owned BrowserFS mount state (criteria 1 & 3, which span the worker boundary) remain tracked on #62.

## Verification
- Unit: `262 passed` (incl. new `fsapi-handle-scope.test.ts` — opened-source write-back, stale-handle-after-import for both differing and **colliding** paths)
- e2e: `22 passed`
- tsc + eslint + prettier: clean
- Adversarial subagent review: bug fixed, save-flow behavior preserved, handle confirmed not to leak into persisted state / URL fragment. Its one SHOULD-FIX (drop handles even on a same-path ZIP collision) is incorporated (`clear()` on import) with a dedicated test.

Refs #62