### PR TITLE
feat(embed): versioned, validated postMessage protocol with origin hardening (#63)

### DIFF
--- a/docs/EMBED.md
+++ b/docs/EMBED.md
@@ -4,6 +4,15 @@ OpenSCAD Web supports a hosted iframe integration via `?mode=embed`.
 
 This document describes the parent/iframe `postMessage` contract, origin-handling expectations, and the recommended integration pattern for storefront or product-page embeds.
 
+## Protocol version
+
+The messaging protocol is versioned. The current version is **2** (`EMBED_PROTOCOL_VERSION`).
+
+- Every **inbound** message (host → iframe) **must** carry `protocolVersion: 2`. Messages without it, or with a different version, are rejected with a structured `error` (see below). There is no implicit acceptance of unversioned/legacy messages.
+- Every **outbound** message (iframe → host) carries `protocolVersion: 2`.
+
+> **Breaking change (v1 → v2):** v1 accepted unversioned messages and, when `parentOrigin` was omitted, accepted control messages from any parent origin and broadcast outbound messages to `'*'`. v2 requires the version field, defaults to same-origin trust, never uses the wildcard, and replaces the `renderComplete` blob URL with durable metadata plus an explicit `getArtifact` request. Update integrations accordingly.
+
 ## URL Parameters
 
 Embed mode is enabled with:
@@ -17,7 +26,7 @@ Supported embed-specific query parameters:
 - `model`: optional external model URL; same-origin paths and cross-origin `https://` URLs are allowed
 - `controls=true`: show the built-in customizer panel
 - `download=true`: show the built-in download button
-- `parentOrigin=https://host.example.com`: optional origin hardening for parent/iframe messaging
+- `parentOrigin=https://host.example.com`: the trusted parent origin (see [Security Model](#security-model))
 
 `parentOrigin` must be an absolute `http://` or `https://` origin. Paths, query strings, and fragments are ignored and normalized to the origin.
 
@@ -25,53 +34,60 @@ Supported embed-specific query parameters:
 
 ### Host → iframe
 
-| Type       | Payload                                            | Description                                    |
-| ---------- | -------------------------------------------------- | ---------------------------------------------- |
-| `setModel` | `{ type: 'setModel', source: string }`             | Replace the current model with raw source text |
-| `setVar`   | `{ type: 'setVar', name: string, value: unknown }` | Set one customizer variable                    |
-| `getVars`  | `{ type: 'getVars', requestId?: string }`          | Request the current effective variable map     |
+Every inbound message must include `protocolVersion: 2`. A `requestId` is optional but recommended; it is echoed back on the corresponding `ack` / `error` / response.
+
+| Type          | Payload (in addition to `protocolVersion`, optional `requestId`) | Description                                    |
+| ------------- | ---------------------------------------------------------------- | ---------------------------------------------- |
+| `setModel`    | `{ type: 'setModel', source: string }`                           | Replace the current model with raw source text |
+| `setVar`      | `{ type: 'setVar', name: string, value: unknown }`               | Set one customizer variable                    |
+| `getVars`     | `{ type: 'getVars' }`                                            | Request the current effective variable map     |
+| `getArtifact` | `{ type: 'getArtifact' }`                                        | Request the bytes of the latest render output  |
+
+Limits (oversized messages are rejected with a `too-large` error):
+
+- `setModel.source` ≤ 5 MiB
+- `setVar.name` ≤ 256 chars; `setVar.value` ≤ 64 KiB JSON-encoded
 
 Notes:
 
-- `setModel` is a source-text replacement API, not a URL-loading API.
-- External URL loading remains attached to the `model=` boot flow, not `postMessage`.
+- `setModel` is a source-text replacement API, not a URL-loading API. External URL loading remains attached to the `model=` boot flow, not `postMessage`.
+- `setModel` and `setVar` are acknowledged with an `ack` message.
 
 ### iframe → host
 
-| Type                 | Payload                                        | Description                                              |
-| -------------------- | ---------------------------------------------- | -------------------------------------------------------- |
-| `ready`              | `{ type: 'ready', vars, parameterSet? }`       | Initial embed state is ready for host interaction        |
-| `varsChanged`        | `{ type: 'varsChanged', vars }`                | Effective variable map changed                           |
-| `parameterSetLoaded` | `{ type: 'parameterSetLoaded', parameterSet }` | Parameter metadata is available                          |
-| `varsSnapshot`       | `{ type: 'varsSnapshot', vars, requestId? }`   | Response to `getVars`                                    |
-| `renderComplete`     | `{ type: 'renderComplete', outFileURL }`       | A render finished and produced a new output blob URL     |
-| `stateChange`        | `{ type: 'stateChange', error }`               | Legacy error event used for external model-load failures |
+| Type                 | Payload (in addition to `protocolVersion`)                                   | Description                                                       |
+| -------------------- | ---------------------------------------------------------------------------- | ----------------------------------------------------------------- |
+| `ready`              | `{ type: 'ready', vars, parameterSet? }`                                     | Initial embed state is ready for host interaction                 |
+| `ack`                | `{ type: 'ack', requestId? }`                                                | A `setModel` / `setVar` command was applied                       |
+| `error`              | `{ type: 'error', code, reason, requestId? }`                                | An inbound message was rejected (see error codes)                 |
+| `varsChanged`        | `{ type: 'varsChanged', vars }`                                              | Effective variable map changed                                    |
+| `parameterSetLoaded` | `{ type: 'parameterSetLoaded', parameterSet }`                               | Parameter metadata is available                                   |
+| `varsSnapshot`       | `{ type: 'varsSnapshot', vars, requestId? }`                                 | Response to `getVars`                                             |
+| `renderComplete`     | `{ type: 'renderComplete', artifact: { name, size, format } }`               | A render finished; metadata only — fetch bytes with `getArtifact` |
+| `artifact`           | `{ type: 'artifact', available, name?, size?, format?, bytes?, requestId? }` | Response to `getArtifact`; `bytes` is a transferred `ArrayBuffer` |
+| `stateChange`        | `{ type: 'stateChange', error }`                                             | Error event used for external model-load failures                 |
+
+Error `code` values: `malformed`, `unsupported-version`, `unknown-type`, `invalid-payload`, `too-large`.
 
 Notes:
 
 - `ready` fires once.
 - `varsChanged` carries the current effective values, including parameter defaults when available.
-- `parameterSetLoaded` may arrive after `ready`.
-- if the host needs a fully default-expanded variable map for a parameterized model, call `getVars` after `parameterSetLoaded`.
-- `stateChange` is retained for backward compatibility.
+- `parameterSetLoaded` may arrive after `ready`. If the host needs a fully default-expanded variable map for a parameterized model, call `getVars` after `parameterSetLoaded`.
+- `renderComplete` no longer includes a blob URL. Call `getArtifact` to receive the output bytes as a transferred `ArrayBuffer` (`artifact.available === false` if no render output exists yet).
 
 ## Security Model
 
-### Parent origin hardening
+### Origin trust
 
-If `parentOrigin` is provided:
+The trusted peer origin is:
 
-- outbound messages are posted only to that origin
-- inbound messages are accepted only when:
-  - `event.source === window.parent`
-  - `event.origin === parentOrigin`
+- the configured `parentOrigin`, if set (**explicit-origin mode**); otherwise
+- this document's own origin (**same-origin mode**).
 
-If `parentOrigin` is omitted:
+Inbound messages are accepted only when `event.source === window.parent` **and** `event.origin` equals the trusted peer origin. Outbound messages are posted only to the trusted peer origin — never the wildcard `'*'`.
 
-- outbound messages use `'*'`
-- inbound messages only check `event.source === window.parent`
-
-For production embeds, prefer setting `parentOrigin` explicitly.
+Consequently, a **cross-origin** parent must set `parentOrigin` to exchange messages; without it, only a same-origin parent is trusted. There is no default acceptance of arbitrary parent origins.
 
 ### Host-side validation
 
@@ -81,6 +97,7 @@ The parent page should still validate messages before acting on them:
 window.addEventListener('message', (event) => {
   if (event.source !== iframe.contentWindow) return;
   if (event.origin !== 'https://your-app.example.com') return;
+  if (event.data?.protocolVersion !== 2) return;
   // handle event.data
 });
 ```
@@ -104,16 +121,16 @@ See [docs/SECURITY.md](./SECURITY.md) for the current baseline CSP guidance.
 
 <script>
   const iframe = document.getElementById('osc');
+  const APP_ORIGIN = 'https://example.com';
   const currentVars = {};
 
   window.addEventListener('message', (event) => {
     if (event.source !== iframe.contentWindow) return;
-    if (event.origin !== 'https://example.com') return;
+    if (event.origin !== APP_ORIGIN) return;
+    if (event.data?.protocolVersion !== 2) return;
 
     switch (event.data.type) {
       case 'ready':
-        Object.assign(currentVars, event.data.vars || {});
-        break;
       case 'varsChanged':
       case 'varsSnapshot':
         Object.assign(currentVars, event.data.vars || {});
@@ -122,7 +139,21 @@ See [docs/SECURITY.md](./SECURITY.md) for the current baseline CSP guidance.
         console.log('Parameter metadata:', event.data.parameterSet);
         break;
       case 'renderComplete':
-        console.log('Output blob URL:', event.data.outFileURL);
+        console.log('Render ready:', event.data.artifact);
+        // request the bytes when you actually need them:
+        send({ type: 'getArtifact', requestId: 'dl-1' });
+        break;
+      case 'artifact':
+        if (event.data.available) {
+          const blob = new Blob([event.data.bytes]);
+          // e.g. trigger a download or upload the bytes
+        }
+        break;
+      case 'ack':
+        console.log('applied', event.data.requestId);
+        break;
+      case 'error':
+        console.error('embed error', event.data.code, event.data.reason);
         break;
       case 'stateChange':
         console.error(event.data.error);
@@ -130,21 +161,16 @@ See [docs/SECURITY.md](./SECURITY.md) for the current baseline CSP guidance.
     }
   });
 
+  function send(msg) {
+    iframe.contentWindow.postMessage({ protocolVersion: 2, ...msg }, APP_ORIGIN);
+  }
+
   function setVar(name, value) {
-    iframe.contentWindow.postMessage({ type: 'setVar', name, value }, 'https://example.com');
+    send({ type: 'setVar', name, value, requestId: 'v-' + name });
   }
 
   function refreshVars() {
-    iframe.contentWindow.postMessage(
-      { type: 'getVars', requestId: 'checkout' },
-      'https://example.com',
-    );
+    send({ type: 'getVars', requestId: 'checkout' });
   }
 </script>
 ```
-
-## Blob URL Lifetime
-
-`renderComplete.outFileURL` is a blob URL owned by the iframe document.
-
-If the host page fetches or reuses blob URLs over time, it should revoke old URLs with `URL.revokeObjectURL()` when they are no longer needed to avoid memory leaks.

--- a/src/components/elements/osc-embed-shell.ts
+++ b/src/components/elements/osc-embed-shell.ts
@@ -9,18 +9,20 @@ import type { State } from '../../state/app-state.ts';
 import type { Model } from '../../state/model.ts';
 import './osc-viewer-panel.ts';
 import './osc-customizer-panel.ts';
+import { validateInbound, outbound, isTrustedOrigin } from '../../embed/protocol.ts';
 
 // ---------------------------------------------------------------------------
-// postMessage protocol (host → iframe)
+// postMessage protocol — see src/embed/protocol.ts and docs/EMBED.md
 // ---------------------------------------------------------------------------
-type SetModelMsg = { type: 'setModel'; source: string };
-type SetVarMsg = { type: 'setVar'; name: string; value: unknown };
-type GetVarsMsg = { type: 'getVars'; requestId?: string };
-type InboundMsg = SetModelMsg | SetVarMsg | GetVarsMsg;
 
-function notifyHost(type: string, targetOrigin: string, payload?: Record<string, unknown>) {
+function notifyHost(
+  type: string,
+  targetOrigin: string,
+  payload?: Record<string, unknown>,
+  transfer?: Transferable[],
+) {
   if (window.parent !== window) {
-    window.parent.postMessage({ type, ...payload }, targetOrigin);
+    window.parent.postMessage(outbound(type, payload), targetOrigin, transfer ?? []);
   }
 }
 
@@ -35,6 +37,16 @@ function coerceUrlVars(vars: Record<string, string>): Record<string, unknown> {
     }
   }
   return result;
+}
+
+/** Durable artifact descriptor sent to the host instead of a blob URL. */
+function artifactMeta(file: File): Record<string, unknown> {
+  const dot = file.name.lastIndexOf('.');
+  return {
+    name: file.name,
+    size: file.size,
+    format: dot >= 0 ? file.name.slice(dot + 1).toLowerCase() : '',
+  };
 }
 
 function getVarsSnapshot(st: State): Record<string, unknown> {
@@ -86,16 +98,27 @@ export class OscEmbedShell extends LitElement {
   private _lastSentParamSet: object | null = null;
   private _lastSentRenderURL: string | null = null;
   private _lastSentVars: Record<string, unknown> | null | undefined = undefined;
-  private _targetOrigin() {
-    return this.urlParams?.parentOrigin ?? '*';
+  /**
+   * Resolved peer origin. When `parentOrigin` is configured we target it
+   * (explicit-origin mode); otherwise we fall back to this document's own
+   * origin (same-origin mode) — never the wildcard `'*'`, so messages are
+   * never broadcast to arbitrary origins.
+   */
+  private _peerOrigin() {
+    return this.urlParams?.parentOrigin ?? window.location.origin;
   }
-  private _notifyHost(type: string, payload?: Record<string, unknown>) {
-    notifyHost(type, this._targetOrigin(), payload);
+  private _notifyHost(type: string, payload?: Record<string, unknown>, transfer?: Transferable[]) {
+    notifyHost(type, this._peerOrigin(), payload, transfer);
   }
   private _acceptsMessage(event: MessageEvent) {
     if (event.source !== window.parent) return false;
-    const expectedOrigin = this.urlParams?.parentOrigin;
-    return expectedOrigin == null || event.origin === expectedOrigin;
+    // No default acceptance of arbitrary origins: an unconfigured embed only
+    // trusts a same-origin parent; cross-origin parents must set parentOrigin.
+    return isTrustedOrigin(
+      event.origin,
+      this.urlParams?.parentOrigin ?? null,
+      window.location.origin,
+    );
   }
   private _maybeNotifyReady(st: State) {
     if (this._readyNotified) return;
@@ -128,29 +151,68 @@ export class OscEmbedShell extends LitElement {
     if (st.output && !st.rendering && !st.previewing) {
       if (st.output.outFileURL !== this._lastSentRenderURL) {
         this._lastSentRenderURL = st.output.outFileURL;
-        this._notifyHost('renderComplete', { outFileURL: st.output.outFileURL });
+        // Send durable metadata only; the host fetches bytes on demand via
+        // `getArtifact`. A blob URL owned by the iframe document is not even
+        // usable cross-origin, so it is never leaked into the event.
+        this._notifyHost('renderComplete', { artifact: artifactMeta(st.output.outFile) });
       }
     }
   };
 
   private _messageHandler = (event: MessageEvent) => {
     if (!this._acceptsMessage(event)) return;
-    const msg = event.data as InboundMsg;
-    if (!msg || typeof msg.type !== 'string') return;
-    if (msg.type === 'setModel') {
-      const m = msg as SetModelMsg;
-      if (typeof m.source === 'string') this._model.source = m.source;
-    } else if (msg.type === 'setVar') {
-      const m = msg as SetVarMsg;
-      if (typeof m.name === 'string') this._model.setVar(m.name, m.value as never);
-    } else if (msg.type === 'getVars') {
-      const m = msg as GetVarsMsg;
-      this._notifyHost('varsSnapshot', {
-        vars: getVarsSnapshot(this._model.state),
-        ...(typeof m.requestId === 'string' ? { requestId: m.requestId } : {}),
+    const result = validateInbound(event.data);
+    if (!result.ok) {
+      this._notifyHost('error', {
+        code: result.code,
+        reason: result.reason,
+        ...(result.requestId ? { requestId: result.requestId } : {}),
       });
+      return;
+    }
+    const msg = result.message;
+    const requestId = msg.requestId;
+    const ack = requestId ? { requestId } : {};
+    switch (msg.type) {
+      case 'setModel':
+        this._model.source = msg.source;
+        this._notifyHost('ack', ack);
+        break;
+      case 'setVar':
+        this._model.setVar(msg.name, msg.value as never);
+        this._notifyHost('ack', ack);
+        break;
+      case 'getVars':
+        this._notifyHost('varsSnapshot', {
+          vars: getVarsSnapshot(this._model.state),
+          ...(requestId ? { requestId } : {}),
+        });
+        break;
+      case 'getArtifact':
+        void this._sendArtifact(requestId);
+        break;
     }
   };
+
+  /** Respond to `getArtifact` with the current render bytes (transferred). */
+  private async _sendArtifact(requestId: string | undefined) {
+    const output = this._model.state.output;
+    if (!output) {
+      this._notifyHost('artifact', { available: false, ...(requestId ? { requestId } : {}) });
+      return;
+    }
+    const bytes = await output.outFile.arrayBuffer();
+    this._notifyHost(
+      'artifact',
+      {
+        available: true,
+        ...artifactMeta(output.outFile),
+        bytes,
+        ...(requestId ? { requestId } : {}),
+      },
+      [bytes],
+    );
+  }
 
   override connectedCallback() {
     super.connectedCallback();

--- a/src/embed/__tests__/protocol.test.ts
+++ b/src/embed/__tests__/protocol.test.ts
@@ -1,0 +1,208 @@
+// Issue #63: versioned, validated embed protocol — malformed/oversized/unknown
+// messages are rejected with structured errors; origin trust is same-origin by
+// default with no acceptance of arbitrary parent origins.
+
+import {
+  validateInbound,
+  isTrustedOrigin,
+  outbound,
+  EMBED_PROTOCOL_VERSION,
+  MAX_SOURCE_LENGTH,
+  MAX_VAR_NAME_LENGTH,
+  MAX_VAR_VALUE_LENGTH,
+} from '../protocol.ts';
+
+const V = EMBED_PROTOCOL_VERSION;
+
+describe('validateInbound — version gate', () => {
+  it('rejects a non-object payload as malformed', () => {
+    for (const bad of [null, undefined, 'setModel', 42, true]) {
+      const r = validateInbound(bad);
+      expect(r).toMatchObject({ ok: false, code: 'malformed' });
+    }
+  });
+
+  it('rejects an unversioned message and echoes the requestId', () => {
+    const r = validateInbound({ type: 'getVars', requestId: 'abc' });
+    expect(r).toMatchObject({ ok: false, code: 'unsupported-version', requestId: 'abc' });
+  });
+
+  it('rejects a mismatched protocol version', () => {
+    const r = validateInbound({ protocolVersion: V + 1, type: 'getVars' });
+    expect(r).toMatchObject({ ok: false, code: 'unsupported-version' });
+  });
+
+  it('rejects a missing/non-string type as malformed', () => {
+    expect(validateInbound({ protocolVersion: V })).toMatchObject({
+      ok: false,
+      code: 'malformed',
+    });
+    expect(validateInbound({ protocolVersion: V, type: 7 })).toMatchObject({
+      ok: false,
+      code: 'malformed',
+    });
+  });
+
+  it('rejects an unknown type', () => {
+    const r = validateInbound({ protocolVersion: V, type: 'dropTable' });
+    expect(r).toMatchObject({ ok: false, code: 'unknown-type' });
+  });
+});
+
+describe('validateInbound — setModel', () => {
+  it('accepts a well-formed setModel and narrows it', () => {
+    const r = validateInbound({
+      protocolVersion: V,
+      type: 'setModel',
+      source: 'cube(1);',
+      requestId: 'r1',
+    });
+    expect(r).toEqual({
+      ok: true,
+      message: { type: 'setModel', source: 'cube(1);', requestId: 'r1' },
+    });
+  });
+
+  it('rejects a non-string source as invalid-payload', () => {
+    const r = validateInbound({ protocolVersion: V, type: 'setModel', source: 123 });
+    expect(r).toMatchObject({ ok: false, code: 'invalid-payload' });
+  });
+
+  it('rejects an oversized source as too-large', () => {
+    const source = 'x'.repeat(MAX_SOURCE_LENGTH + 1);
+    const r = validateInbound({ protocolVersion: V, type: 'setModel', source });
+    expect(r).toMatchObject({ ok: false, code: 'too-large' });
+  });
+});
+
+describe('validateInbound — setVar', () => {
+  it('accepts a well-formed setVar', () => {
+    const r = validateInbound({ protocolVersion: V, type: 'setVar', name: 'n', value: 5 });
+    expect(r).toEqual({
+      ok: true,
+      message: { type: 'setVar', name: 'n', value: 5, requestId: undefined },
+    });
+  });
+
+  it('rejects an empty or non-string name', () => {
+    expect(
+      validateInbound({ protocolVersion: V, type: 'setVar', name: '', value: 1 }),
+    ).toMatchObject({
+      ok: false,
+      code: 'invalid-payload',
+    });
+    expect(
+      validateInbound({ protocolVersion: V, type: 'setVar', name: 9, value: 1 }),
+    ).toMatchObject({
+      ok: false,
+      code: 'invalid-payload',
+    });
+  });
+
+  it('rejects an oversized name', () => {
+    const name = 'n'.repeat(MAX_VAR_NAME_LENGTH + 1);
+    expect(validateInbound({ protocolVersion: V, type: 'setVar', name, value: 1 })).toMatchObject({
+      ok: false,
+      code: 'too-large',
+    });
+  });
+
+  it('rejects an oversized value', () => {
+    const value = 'v'.repeat(MAX_VAR_VALUE_LENGTH + 1);
+    expect(validateInbound({ protocolVersion: V, type: 'setVar', name: 'n', value })).toMatchObject(
+      {
+        ok: false,
+        code: 'too-large',
+      },
+    );
+  });
+
+  it('rejects a non-serialisable value', () => {
+    const circular: Record<string, unknown> = {};
+    circular.self = circular;
+    expect(
+      validateInbound({ protocolVersion: V, type: 'setVar', name: 'n', value: circular }),
+    ).toMatchObject({ ok: false, code: 'invalid-payload' });
+  });
+
+  it('rejects exotic cloneable types that bypass the JSON size limit', () => {
+    // These stringify to "{}" (tiny) but carry an arbitrarily large payload,
+    // so the encoded-length guard alone would not bound them.
+    for (const value of [new ArrayBuffer(8), new Map(), new Set(), new Uint8Array(8), new Date()]) {
+      expect(
+        validateInbound({ protocolVersion: V, type: 'setVar', name: 'n', value }),
+      ).toMatchObject({ ok: false, code: 'invalid-payload' });
+    }
+    // Nested exotic value inside an otherwise-plain object is also rejected.
+    expect(
+      validateInbound({
+        protocolVersion: V,
+        type: 'setVar',
+        name: 'n',
+        value: { buf: new ArrayBuffer(8) },
+      }),
+    ).toMatchObject({ ok: false, code: 'invalid-payload' });
+  });
+
+  it('rejects (does not throw on) a function or symbol value', () => {
+    expect(
+      validateInbound({ protocolVersion: V, type: 'setVar', name: 'n', value: () => 1 }),
+    ).toMatchObject({ ok: false, code: 'invalid-payload' });
+    expect(
+      validateInbound({ protocolVersion: V, type: 'setVar', name: 'n', value: Symbol('x') }),
+    ).toMatchObject({ ok: false, code: 'invalid-payload' });
+  });
+
+  it('accepts plain nested JSON values (arrays/objects of primitives)', () => {
+    const r = validateInbound({
+      protocolVersion: V,
+      type: 'setVar',
+      name: 'vec',
+      value: { a: [1, 2, 3], b: { c: true, d: 'x' }, e: null },
+    });
+    expect(r).toMatchObject({ ok: true });
+  });
+});
+
+describe('validateInbound — read commands', () => {
+  it('accepts getVars and getArtifact, echoing requestId', () => {
+    expect(validateInbound({ protocolVersion: V, type: 'getVars', requestId: 'g' })).toEqual({
+      ok: true,
+      message: { type: 'getVars', requestId: 'g' },
+    });
+    expect(validateInbound({ protocolVersion: V, type: 'getArtifact' })).toEqual({
+      ok: true,
+      message: { type: 'getArtifact', requestId: undefined },
+    });
+  });
+});
+
+describe('isTrustedOrigin', () => {
+  const self = 'https://app.example.com';
+
+  it('trusts only the same origin when no parentOrigin is configured', () => {
+    expect(isTrustedOrigin(self, null, self)).toBe(true);
+    expect(isTrustedOrigin('https://evil.example', null, self)).toBe(false);
+  });
+
+  it('trusts only the configured parentOrigin when set', () => {
+    const parent = 'https://store.example.com';
+    expect(isTrustedOrigin(parent, parent, self)).toBe(true);
+    expect(isTrustedOrigin(self, parent, self)).toBe(false);
+    expect(isTrustedOrigin('https://evil.example', parent, self)).toBe(false);
+  });
+
+  it('never trusts the wildcard', () => {
+    expect(isTrustedOrigin('*', null, self)).toBe(false);
+  });
+});
+
+describe('outbound', () => {
+  it('stamps the protocol version and type', () => {
+    expect(outbound('ready', { vars: {} })).toEqual({
+      protocolVersion: V,
+      type: 'ready',
+      vars: {},
+    });
+  });
+});

--- a/src/embed/protocol.ts
+++ b/src/embed/protocol.ts
@@ -1,0 +1,170 @@
+// Versioned, validated embed message protocol (issue #63).
+//
+// The embed iframe and its host page communicate over `postMessage`. This
+// module is the single source of truth for the wire format: a protocol
+// version, strict inbound validation with size limits, and structured error /
+// acknowledgement envelopes. It is intentionally free of DOM/Lit dependencies
+// so the validation can be unit-tested in isolation.
+
+/**
+ * Wire protocol version. Inbound messages MUST carry this exact value;
+ * unversioned or mismatched messages are rejected (no implicit legacy
+ * acceptance). Bump on any breaking change to the inbound/outbound shapes.
+ */
+export const EMBED_PROTOCOL_VERSION = 2;
+
+// Inbound size limits — guard rails against a hostile or buggy parent flooding
+// the iframe. Lengths are measured in UTF-16 code units (cheap, and a safe
+// over-approximation of byte intent for a DoS guard).
+export const MAX_SOURCE_LENGTH = 5 * 1024 * 1024; // setModel source text
+export const MAX_VAR_NAME_LENGTH = 256; // setVar variable name
+export const MAX_VAR_VALUE_LENGTH = 64 * 1024; // setVar JSON-encoded value
+
+export type InboundMessage =
+  | { type: 'setModel'; source: string; requestId?: string }
+  | { type: 'setVar'; name: string; value: unknown; requestId?: string }
+  | { type: 'getVars'; requestId?: string }
+  | { type: 'getArtifact'; requestId?: string };
+
+export type EmbedErrorCode =
+  | 'malformed' // not an object / missing fields
+  | 'unsupported-version' // protocolVersion absent or != current
+  | 'unknown-type' // type not a recognised inbound command
+  | 'invalid-payload' // recognised type, wrong field types
+  | 'too-large'; // a bounded field exceeded its size limit
+
+export type ValidationResult =
+  | { ok: true; message: InboundMessage }
+  | { ok: false; code: EmbedErrorCode; reason: string; requestId?: string };
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null;
+}
+
+/**
+ * Whether `value` is a plain JSON value (primitive, or array/plain-object
+ * thereof). Exotic structured-cloneable types — `ArrayBuffer`, typed arrays,
+ * `Map`, `Set`, `Blob`, `Date`, class instances, functions, symbols — are
+ * rejected. `JSON.stringify` collapses those to `"{}"`/`undefined`, which would
+ * let a multi-megabyte payload slip the encoded-size limit, so a setVar value
+ * must be genuinely JSON-shaped. Assumes an acyclic input (callers stringify
+ * first, which rejects cycles).
+ */
+function isPlainJsonValue(value: unknown): boolean {
+  if (value === null) return true;
+  const t = typeof value;
+  if (t === 'string' || t === 'boolean') return true;
+  if (t === 'number') return Number.isFinite(value);
+  if (t !== 'object') return false; // function, symbol, bigint, undefined
+  if (Array.isArray(value)) return value.every(isPlainJsonValue);
+  const proto = Object.getPrototypeOf(value);
+  if (proto !== Object.prototype && proto !== null) return false; // exotic object
+  return Object.values(value as Record<string, unknown>).every(isPlainJsonValue);
+}
+
+/** Extract a string requestId if present, so errors/acks can echo it. */
+function readRequestId(data: Record<string, unknown>): string | undefined {
+  return typeof data.requestId === 'string' ? data.requestId : undefined;
+}
+
+/**
+ * Validate an untrusted inbound `postMessage` payload against the protocol.
+ * Returns a discriminated result: either the narrowed `InboundMessage` or a
+ * structured rejection the caller relays back to the host as an `error`.
+ */
+export function validateInbound(data: unknown): ValidationResult {
+  if (!isRecord(data)) {
+    return { ok: false, code: 'malformed', reason: 'message is not an object' };
+  }
+  const requestId = readRequestId(data);
+
+  if (data.protocolVersion !== EMBED_PROTOCOL_VERSION) {
+    return {
+      ok: false,
+      code: 'unsupported-version',
+      reason: `expected protocolVersion ${EMBED_PROTOCOL_VERSION}`,
+      requestId,
+    };
+  }
+
+  if (typeof data.type !== 'string') {
+    return { ok: false, code: 'malformed', reason: 'missing message type', requestId };
+  }
+
+  switch (data.type) {
+    case 'setModel': {
+      if (typeof data.source !== 'string') {
+        return { ok: false, code: 'invalid-payload', reason: 'source must be a string', requestId };
+      }
+      if (data.source.length > MAX_SOURCE_LENGTH) {
+        return { ok: false, code: 'too-large', reason: 'source exceeds size limit', requestId };
+      }
+      return { ok: true, message: { type: 'setModel', source: data.source, requestId } };
+    }
+    case 'setVar': {
+      if (typeof data.name !== 'string' || data.name.length === 0) {
+        return {
+          ok: false,
+          code: 'invalid-payload',
+          reason: 'name must be a non-empty string',
+          requestId,
+        };
+      }
+      if (data.name.length > MAX_VAR_NAME_LENGTH) {
+        return { ok: false, code: 'too-large', reason: 'name exceeds size limit', requestId };
+      }
+      const value = data.value ?? null;
+      let encoded: string | undefined;
+      try {
+        encoded = JSON.stringify(value);
+      } catch {
+        encoded = undefined; // circular reference
+      }
+      // `encoded` is `undefined` for functions/symbols/circular values; an
+      // exotic but cloneable type (ArrayBuffer, Map, …) stringifies to a tiny
+      // string while carrying a large payload, so also require a plain JSON
+      // shape rather than trusting the encoded length alone.
+      if (typeof encoded !== 'string' || !isPlainJsonValue(value)) {
+        return {
+          ok: false,
+          code: 'invalid-payload',
+          reason: 'value must be a JSON value',
+          requestId,
+        };
+      }
+      if (encoded.length > MAX_VAR_VALUE_LENGTH) {
+        return { ok: false, code: 'too-large', reason: 'value exceeds size limit', requestId };
+      }
+      return {
+        ok: true,
+        message: { type: 'setVar', name: data.name, value: data.value, requestId },
+      };
+    }
+    case 'getVars':
+      return { ok: true, message: { type: 'getVars', requestId } };
+    case 'getArtifact':
+      return { ok: true, message: { type: 'getArtifact', requestId } };
+    default:
+      return { ok: false, code: 'unknown-type', reason: `unknown type "${data.type}"`, requestId };
+  }
+}
+
+/**
+ * Whether an inbound message's origin is trusted. With no configured
+ * `parentOrigin` only this document's own origin is trusted (same-origin mode);
+ * a configured `parentOrigin` is then the sole trusted origin (explicit-origin
+ * mode). The wildcard is never trusted — there is no default acceptance of
+ * arbitrary parent origins.
+ */
+export function isTrustedOrigin(
+  eventOrigin: string,
+  parentOrigin: string | null,
+  selfOrigin: string,
+): boolean {
+  return eventOrigin === (parentOrigin ?? selfOrigin);
+}
+
+/** Stamp an outbound payload with the protocol version. */
+export function outbound(type: string, payload: Record<string, unknown> = {}) {
+  return { protocolVersion: EMBED_PROTOCOL_VERSION, type, ...payload };
+}

--- a/tests/e2e.spec.ts
+++ b/tests/e2e.spec.ts
@@ -629,7 +629,7 @@ test.describe('embed mode', () => {
     await page.evaluate(() => {
       const iframe = document.getElementById('embed-frame') as HTMLIFrameElement | null;
       iframe?.contentWindow?.postMessage(
-        { type: 'setVar', name: 'myVar', value: 20 },
+        { protocolVersion: 2, type: 'setVar', name: 'myVar', value: 20 },
         window.location.origin,
       );
     });
@@ -654,7 +654,7 @@ test.describe('embed mode', () => {
     await page.evaluate(() => {
       const iframe = document.getElementById('embed-frame') as HTMLIFrameElement | null;
       iframe?.contentWindow?.postMessage(
-        { type: 'getVars', requestId: 'checkout' },
+        { protocolVersion: 2, type: 'getVars', requestId: 'checkout' },
         window.location.origin,
       );
     });
@@ -686,6 +686,83 @@ test.describe('embed mode', () => {
     expect(varsChangedMessage?.data?.vars).toMatchObject({ myVar: 20 });
     expect(varsSnapshotMessage?.data?.requestId).toBe('checkout');
     expect(varsSnapshotMessage?.data?.vars).toMatchObject({ myVar: 20 });
+  });
+
+  test('acknowledges valid commands, rejects malformed ones, and serves artifact bytes on request', async ({
+    page,
+  }) => {
+    const source = 'cube(10);';
+
+    await loadEmbedHost(page, buildEmbedUrl({ source, parentOrigin: appOrigin }));
+    const frame = await getEmbedFrame(page);
+
+    await waitForEmbedViewer(frame);
+    await waitForEmbedMessage(page, 'ready');
+    await waitForEmbedMessage(page, 'renderComplete');
+
+    // A valid command is acknowledged with the echoed requestId.
+    await page.evaluate(() => {
+      const iframe = document.getElementById('embed-frame') as HTMLIFrameElement | null;
+      iframe?.contentWindow?.postMessage(
+        { protocolVersion: 2, type: 'setVar', name: 'x', value: 1, requestId: 'ok-1' },
+        window.location.origin,
+      );
+    });
+    await waitForEmbedMessage(page, 'ack');
+
+    // An unversioned message is rejected with a structured error.
+    await page.evaluate(() => {
+      const iframe = document.getElementById('embed-frame') as HTMLIFrameElement | null;
+      iframe?.contentWindow?.postMessage(
+        { type: 'setVar', name: 'x', value: 2, requestId: 'bad-1' },
+        window.location.origin,
+      );
+    });
+    await waitForEmbedMessage(page, 'error');
+
+    // getArtifact returns the render bytes as a transferred ArrayBuffer.
+    await page.evaluate(() => {
+      const iframe = document.getElementById('embed-frame') as HTMLIFrameElement | null;
+      iframe?.contentWindow?.postMessage(
+        { protocolVersion: 2, type: 'getArtifact', requestId: 'art-1' },
+        window.location.origin,
+      );
+    });
+    await waitForEmbedMessage(page, 'artifact');
+
+    const messages = await getEmbedMessages(page);
+    const ackMsg = messages.find((m) => m.data?.type === 'ack');
+    expect(ackMsg?.data?.requestId).toBe('ok-1');
+    expect(ackMsg?.data?.protocolVersion).toBe(2);
+
+    const errMsg = messages.find((m) => m.data?.type === 'error');
+    expect(errMsg?.data?.code).toBe('unsupported-version');
+    expect(errMsg?.data?.requestId).toBe('bad-1');
+
+    const renderComplete = messages.find((m) => m.data?.type === 'renderComplete');
+    expect(renderComplete?.data?.artifact).toEqual(
+      expect.objectContaining({ name: expect.any(String) }),
+    );
+    expect('outFileURL' in (renderComplete?.data ?? {})).toBe(false);
+
+    // The transferred ArrayBuffer does not survive serialization back to Node,
+    // so inspect it inside the page realm.
+    const artifact = await page.evaluate(() => {
+      const messages = (
+        window as Window & {
+          __embedMessages?: Array<{
+            data?: { type?: string; available?: boolean; bytes?: ArrayBuffer };
+          }>;
+        }
+      ).__embedMessages;
+      const msg = messages?.find((m) => m?.data?.type === 'artifact');
+      return {
+        available: msg?.data?.available ?? false,
+        byteLength: msg?.data?.bytes?.byteLength ?? 0,
+      };
+    });
+    expect(artifact.available).toBe(true);
+    expect(artifact.byteLength).toBeGreaterThan(0);
   });
 
   test('rejects host messages when parentOrigin does not match the real parent origin', async ({
@@ -742,7 +819,10 @@ test.describe('embed mode', () => {
 
     await page.evaluate((src) => {
       const iframe = document.getElementById('embed-frame') as HTMLIFrameElement | null;
-      iframe?.contentWindow?.postMessage({ type: 'setModel', source: src }, window.location.origin);
+      iframe?.contentWindow?.postMessage(
+        { protocolVersion: 2, type: 'setModel', source: src },
+        window.location.origin,
+      );
     }, replacedSource);
 
     await waitForEmbedMessageCount(page, 'renderComplete', 2);


### PR DESCRIPTION
## Summary
Replaces the ad-hoc, unversioned embed `postMessage` protocol with a versioned, validated one (`protocolVersion: 2`), implemented in a new pure, DOM-free `src/embed/protocol.ts` so validation is unit-testable in isolation.

**Hardening (acceptance criteria):**
- **Malformed/oversized → structured errors:** inbound messages are validated (version → type → per-field), with size limits (`source` ≤ 5 MiB, `setVar.name` ≤ 256, `setVar.value` ≤ 64 KiB JSON). Rejections return `{ type:'error', code, reason, requestId }` with codes `malformed`/`unsupported-version`/`unknown-type`/`invalid-payload`/`too-large`. `setModel`/`setVar` are acknowledged with `ack`.
- **No default acceptance of arbitrary parent origins:** trust only the configured `parentOrigin`, or the **same-origin** parent when none is set. Never `'*'` — inbound and outbound both resolve to the single trusted origin.
- **Versioned + validated schemas:** every inbound message must carry `protocolVersion: 2`; every outbound message is version-stamped.

**Also:** `renderComplete` now sends artifact **metadata** (`{ name, size, format }`); the host fetches bytes on demand via `getArtifact` (transferred `ArrayBuffer`) — no more leaking a blob URL that isn't even usable cross-origin.

## Breaking change
This is a deliberate v1→v2 break (decided with the maintainer): unversioned senders are rejected, the origin default is now same-origin, and `renderComplete` no longer carries a blob URL. `docs/EMBED.md` is rewritten to document the new contract and migration.

## Verification
- Unit: `283 passed` — new `embed/protocol.test.ts` covers every rejection branch, the origin matrix, the exotic-type size-limit bypass (`ArrayBuffer`/`Map`/`Set`/typed arrays rejected), function/symbol values, and nested-plain-JSON acceptance.
- e2e: embed suite green incl. a new test asserting ack-on-valid, structured-error-on-unversioned, `renderComplete` has no `outFileURL`, and `getArtifact` returns non-empty bytes (would have failed pre-change).
- tsc + eslint + prettier clean.
- Adversarial security review: all three criteria met; its SHOULD-FIX (exotic-type size-limit bypass) and nits are incorporated.

Closes #63