### PR TITLE
feat(pwa): add an update-available reload prompt UI (#78)

### DIFF
--- a/scripts/build-sw.mjs
+++ b/scripts/build-sw.mjs
@@ -64,6 +64,18 @@ try {
     ],
   });
 
+  // generateSW already emits a `SKIP_WAITING` message listener in the worker,
+  // so the app can let the user apply a waiting update on demand (see
+  // applyServiceWorkerUpdate / osc-update-banner, #78) even though
+  // skipWaiting:false keeps it from auto-activating. The update banner depends
+  // on that handler — fail the build if a Workbox change ever drops it.
+  const swContents = await fs.readFile(swDest, 'utf8');
+  if (!swContents.includes('SKIP_WAITING')) {
+    throw new Error(
+      '[build-sw] generated sw.js has no SKIP_WAITING handler; the update-on-reload flow (#78) would break.',
+    );
+  }
+
   if (result.warnings.length > 0) {
     for (const warning of result.warnings) {
       console.warn(`[build-sw] ${warning}`);

--- a/src/components/elements/osc-app-shell.ts
+++ b/src/components/elements/osc-app-shell.ts
@@ -14,6 +14,7 @@ import './osc-editor-panel.ts';
 import './osc-viewer-panel.ts';
 import './osc-customizer-panel.ts';
 import './osc-footer.ts';
+import './osc-update-banner.ts';
 
 @customElement('osc-app-shell')
 export class OscAppShell extends LitElement {
@@ -155,6 +156,7 @@ export class OscAppShell extends LitElement {
             : ''}
         </div>
         <osc-footer></osc-footer>
+        <osc-update-banner></osc-update-banner>
       `;
     } else {
       // Single panel mode — stack all, use z-index to show focused
@@ -195,6 +197,7 @@ export class OscAppShell extends LitElement {
           ></osc-customizer-panel>
         </div>
         <osc-footer></osc-footer>
+        <osc-update-banner></osc-update-banner>
       `;
     }
   }

--- a/src/components/elements/osc-update-banner.test.ts
+++ b/src/components/elements/osc-update-banner.test.ts
@@ -1,0 +1,89 @@
+// Issue #78: the update banner appears when the SW update event fires and
+// triggers a user-initiated update on reload.
+
+import {
+  applyServiceWorkerUpdate,
+  SW_UPDATE_AVAILABLE_EVENT,
+} from '../../runtime/service-worker.ts';
+import './osc-update-banner.ts';
+import type { OscUpdateBanner } from './osc-update-banner.ts';
+
+vi.mock('../../runtime/service-worker.ts', async (importActual) => {
+  const actual = await importActual<typeof import('../../runtime/service-worker.ts')>();
+  return { ...actual, applyServiceWorkerUpdate: vi.fn() };
+});
+
+async function mountBanner(): Promise<OscUpdateBanner> {
+  const el = document.createElement('osc-update-banner') as OscUpdateBanner;
+  document.body.appendChild(el);
+  await el.updateComplete;
+  return el;
+}
+
+function fireUpdate(
+  registration: Partial<ServiceWorkerRegistration> = { waiting: {} as ServiceWorker },
+) {
+  window.dispatchEvent(new CustomEvent(SW_UPDATE_AVAILABLE_EVENT, { detail: { registration } }));
+}
+
+describe('osc-update-banner (#78)', () => {
+  afterEach(() => {
+    document.body.replaceChildren();
+    vi.clearAllMocks();
+  });
+
+  it('is hidden until an update is available', async () => {
+    const el = await mountBanner();
+    expect(el.shadowRoot?.querySelector('[data-testid=update-banner]')).toBeNull();
+  });
+
+  it('appears when the update event fires and applies the update on reload', async () => {
+    const el = await mountBanner();
+    const registration = { waiting: {} as ServiceWorker } as ServiceWorkerRegistration;
+    fireUpdate(registration);
+    await el.updateComplete;
+
+    expect(el.shadowRoot?.querySelector('[data-testid=update-banner]')).not.toBeNull();
+
+    const reload = el.shadowRoot?.querySelector('.reload') as HTMLButtonElement;
+    reload.click();
+    await el.updateComplete;
+
+    expect(applyServiceWorkerUpdate).toHaveBeenCalledWith(registration);
+    expect((el.shadowRoot?.querySelector('.reload') as HTMLButtonElement).disabled).toBe(true);
+  });
+
+  it('hides when dismissed without applying the update', async () => {
+    const el = await mountBanner();
+    fireUpdate();
+    await el.updateComplete;
+
+    const dismiss = el.shadowRoot?.querySelector('.dismiss') as HTMLButtonElement;
+    dismiss.click();
+    await el.updateComplete;
+
+    expect(el.shadowRoot?.querySelector('[data-testid=update-banner]')).toBeNull();
+    expect(applyServiceWorkerUpdate).not.toHaveBeenCalled();
+  });
+
+  it('reappears and resets the applying state when a later update fires', async () => {
+    const el = await mountBanner();
+    fireUpdate();
+    await el.updateComplete;
+
+    // Apply, leaving the button disabled ("Updating…").
+    (el.shadowRoot?.querySelector('.reload') as HTMLButtonElement).click();
+    await el.updateComplete;
+    expect((el.shadowRoot?.querySelector('.reload') as HTMLButtonElement).disabled).toBe(true);
+
+    // Dismiss, then a fresh update event re-shows the banner with a usable button.
+    (el.shadowRoot?.querySelector('.dismiss') as HTMLButtonElement).click();
+    await el.updateComplete;
+    expect(el.shadowRoot?.querySelector('[data-testid=update-banner]')).toBeNull();
+
+    fireUpdate();
+    await el.updateComplete;
+    expect(el.shadowRoot?.querySelector('[data-testid=update-banner]')).not.toBeNull();
+    expect((el.shadowRoot?.querySelector('.reload') as HTMLButtonElement).disabled).toBe(false);
+  });
+});

--- a/src/components/elements/osc-update-banner.ts
+++ b/src/components/elements/osc-update-banner.ts
@@ -1,0 +1,113 @@
+// Issue #78: a non-blocking "update available" affordance. Listens for the
+// SW_UPDATE_AVAILABLE_EVENT dispatched by the service-worker registration and
+// offers a user-initiated reload, which applies the waiting worker safely
+// rather than swapping it mid-session.
+import { LitElement, html, css } from 'lit';
+import { customElement, state } from 'lit/decorators.js';
+import {
+  SW_UPDATE_AVAILABLE_EVENT,
+  applyServiceWorkerUpdate,
+} from '../../runtime/service-worker.ts';
+
+@customElement('osc-update-banner')
+export class OscUpdateBanner extends LitElement {
+  static override styles = css`
+    .banner {
+      position: fixed;
+      left: 50%;
+      bottom: 16px;
+      transform: translateX(-50%);
+      z-index: 1000;
+      display: flex;
+      align-items: center;
+      gap: 12px;
+      max-width: calc(100vw - 24px);
+      padding: 10px 14px;
+      border: 1px solid #cbd5e1;
+      border-radius: 10px;
+      background: #1e293b;
+      color: #f8fafc;
+      box-shadow: 0 6px 24px rgba(0, 0, 0, 0.25);
+      font-size: 0.9rem;
+    }
+    .msg {
+      line-height: 1.3;
+    }
+    .actions {
+      display: flex;
+      gap: 6px;
+      flex-shrink: 0;
+    }
+    button {
+      cursor: pointer;
+      padding: 5px 12px;
+      border-radius: 6px;
+      border: 1px solid transparent;
+      font: inherit;
+    }
+    .reload {
+      background: #38bdf8;
+      color: #0b1220;
+      font-weight: 600;
+    }
+    .reload:disabled {
+      opacity: 0.7;
+      cursor: default;
+    }
+    .dismiss {
+      background: transparent;
+      color: #cbd5e1;
+      border-color: #475569;
+    }
+  `;
+
+  @state() private _registration: ServiceWorkerRegistration | null = null;
+  @state() private _applying = false;
+
+  private _onUpdate = (event: Event) => {
+    const detail = (event as CustomEvent<{ registration: ServiceWorkerRegistration }>).detail;
+    this._registration = detail?.registration ?? null;
+    this._applying = false;
+  };
+
+  override connectedCallback() {
+    super.connectedCallback();
+    window.addEventListener(SW_UPDATE_AVAILABLE_EVENT, this._onUpdate);
+  }
+
+  override disconnectedCallback() {
+    super.disconnectedCallback();
+    window.removeEventListener(SW_UPDATE_AVAILABLE_EVENT, this._onUpdate);
+  }
+
+  private _reload() {
+    if (!this._registration) return;
+    this._applying = true;
+    applyServiceWorkerUpdate(this._registration);
+  }
+
+  private _dismiss() {
+    this._registration = null;
+  }
+
+  override render() {
+    if (!this._registration) return html``;
+    return html`
+      <div class="banner" role="status" data-testid="update-banner">
+        <span class="msg">A new version is available.</span>
+        <span class="actions">
+          <button class="reload" ?disabled=${this._applying} @click=${this._reload}>
+            ${this._applying ? 'Updating…' : 'Reload to update'}
+          </button>
+          <button class="dismiss" @click=${this._dismiss}>Later</button>
+        </span>
+      </div>
+    `;
+  }
+}
+
+declare global {
+  interface HTMLElementTagNameMap {
+    'osc-update-banner': OscUpdateBanner;
+  }
+}

--- a/src/runtime/__tests__/service-worker.test.ts
+++ b/src/runtime/__tests__/service-worker.test.ts
@@ -4,7 +4,11 @@
 vi.mock('../build-env.ts', () => ({ isProductionBuild: () => true }));
 vi.mock('../asset-urls.ts', () => ({ resolveRuntimeAssetUrl: (p: string) => `/${p}` }));
 
-import { registerAppServiceWorker, SW_UPDATE_AVAILABLE_EVENT } from '../service-worker.ts';
+import {
+  registerAppServiceWorker,
+  applyServiceWorkerUpdate,
+  SW_UPDATE_AVAILABLE_EVENT,
+} from '../service-worker.ts';
 
 type FakeWorker = { state: string; onstatechange: (() => void) | null };
 type FakeRegistration = {
@@ -100,5 +104,57 @@ describe('registerAppServiceWorker update flow (#53)', () => {
     expect(reloadSpy).not.toHaveBeenCalled();
 
     window.removeEventListener(SW_UPDATE_AVAILABLE_EVENT, listener);
+  });
+});
+
+describe('applyServiceWorkerUpdate (#78)', () => {
+  let reloadSpy: ReturnType<typeof vi.fn>;
+  const realLocation = window.location;
+
+  beforeEach(() => {
+    reloadSpy = vi.fn();
+    Object.defineProperty(window, 'location', {
+      configurable: true,
+      value: { reload: reloadSpy },
+    });
+  });
+
+  afterEach(() => {
+    Object.defineProperty(window, 'location', { configurable: true, value: realLocation });
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    delete (navigator as any).serviceWorker;
+  });
+
+  it('posts SKIP_WAITING to the waiting worker and reloads on controllerchange', () => {
+    const postMessage = vi.fn();
+    let controllerChangeHandler: (() => void) | undefined;
+    Object.defineProperty(navigator, 'serviceWorker', {
+      configurable: true,
+      value: {
+        addEventListener: vi.fn((type: string, handler: () => void) => {
+          if (type === 'controllerchange') controllerChangeHandler = handler;
+        }),
+      },
+    });
+    const registration = { waiting: { postMessage } } as unknown as ServiceWorkerRegistration;
+
+    applyServiceWorkerUpdate(registration);
+
+    expect(postMessage).toHaveBeenCalledWith({ type: 'SKIP_WAITING' });
+    expect(reloadSpy).not.toHaveBeenCalled(); // not until the new worker takes control
+
+    controllerChangeHandler?.();
+    expect(reloadSpy).toHaveBeenCalledTimes(1);
+  });
+
+  it('reloads directly when there is no waiting worker', () => {
+    Object.defineProperty(navigator, 'serviceWorker', {
+      configurable: true,
+      value: { addEventListener: vi.fn() },
+    });
+    const registration = { waiting: null } as unknown as ServiceWorkerRegistration;
+
+    applyServiceWorkerUpdate(registration);
+    expect(reloadSpy).toHaveBeenCalledTimes(1);
   });
 });

--- a/src/runtime/service-worker.ts
+++ b/src/runtime/service-worker.ts
@@ -9,6 +9,24 @@ export interface RegisterServiceWorkerOptions {
   onUpdateAvailable?: (registration: ServiceWorkerRegistration) => void;
 }
 
+/**
+ * Apply a waiting service-worker update: tell the waiting worker to take over
+ * (it listens for `SKIP_WAITING`), then reload once it controls the page. This
+ * is user-initiated, so it is safe to call when the user has accepted a reload.
+ * Falls back to a plain reload if there is no waiting worker.
+ */
+export function applyServiceWorkerUpdate(registration: ServiceWorkerRegistration): void {
+  const waiting = registration.waiting;
+  if (!waiting || !('serviceWorker' in navigator)) {
+    window.location.reload();
+    return;
+  }
+  navigator.serviceWorker.addEventListener('controllerchange', () => window.location.reload(), {
+    once: true,
+  });
+  waiting.postMessage({ type: 'SKIP_WAITING' });
+}
+
 export async function registerAppServiceWorker(
   options: RegisterServiceWorkerOptions = {},
 ): Promise<ServiceWorkerRegistration | null> {


### PR DESCRIPTION
## Summary
Follow-up to #53, which made the service worker dispatch `osc:sw-update-available` and *wait* (`skipWaiting:false`) instead of force-reloading. That signal had no consumer; this adds one.

- **`osc-update-banner`** — a non-blocking Lit banner that listens for `SW_UPDATE_AVAILABLE_EVENT` and offers **"Reload to update"** / **"Later"**. Mounted in the editor app shell.
- **`applyServiceWorkerUpdate(registration)`** — posts `{type:'SKIP_WAITING'}` to the waiting worker and reloads on `controllerchange`, so the swap is **user-initiated** and safe for unsaved work (falls back to a direct reload if there's no waiting worker).
- **`build-sw.mjs`** — Workbox's `generateSW` already emits the `SKIP_WAITING` message handler, so no hand-rolled one is added; instead a **build-time assertion** fails the build if the generated `sw.js` ever loses that handler the flow depends on.

## Verification
- Unit: new `osc-update-banner.test.ts` (hidden-by-default, appears-on-event, applies-with-correct-registration, button-disabled-while-applying, dismiss-hides, re-fire-resets-state) + `applyServiceWorkerUpdate` cases in `service-worker.test.ts` (SKIP_WAITING posted, reload only on controllerchange, no-waiting fallback). Full suite green.
- `npm run verify` green incl. the production build + SW assertion; e2e boot smoke green (banner renders empty when no update, doesn't affect boot).
- Review: acceptance met, no blockers/should-fix; flagged nits (re-fire coverage) incorporated.

Note: the SW (and thus this prompt) ships with the Pages `dist/` build; the relative `dist-publish` embedding bundle intentionally has no SW, so it's unaffected.

Closes #78