### PR TITLE
ci(build): enforce gzipped bundle-size budgets (slice of #68)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -71,6 +71,9 @@ jobs:
         env:
           PUBLIC_URL: /openscad-web/
 
+      - name: Check bundle budgets
+        run: npm run check:budgets
+
   publish-artifact:
     runs-on: ubuntu-24.04
     env:

--- a/bundle-budgets.json
+++ b/bundle-budgets.json
@@ -1,0 +1,9 @@
+{
+  "_comment": "Gzipped-size budgets (KB) enforced in CI by scripts/check-bundle-budgets.mjs (#68). These bound regressions of the boot-critical artifacts; update deliberately when a size change is intended and understood. Monaco and Three.js currently share the initial app JS chunk — split them into named chunks to budget separately.",
+  "budgets": [
+    { "label": "initial app JS", "pattern": "assets/index-*.js", "maxGzipKB": 1024 },
+    { "label": "app CSS", "pattern": "assets/index-*.css", "maxGzipKB": 115 },
+    { "label": "openscad worker", "pattern": "assets/openscad-worker-*.js", "maxGzipKB": 110 },
+    { "label": "openscad WASM", "pattern": "assets/openscad-*.wasm", "maxGzipKB": 3072 }
+  ]
+}

--- a/package.json
+++ b/package.json
@@ -53,8 +53,9 @@
     "perf:ci": "npm run perf:capture:series && npm run perf:compare",
     "security:check-install-scripts": "node ./scripts/security/check-install-scripts.mjs",
     "verify:publish-archive": "node ./scripts/verify-publish-archive.mjs",
-    "verify": "npm run format:check && npm run lint && npm run typecheck && npm run test:unit && npm run test:assembly && npm run build && npm run build:publish && npm run verify:publish-archive",
-    "verify:full": "npm run verify && npm run test:e2e && npm run test:e2e:publish:skip-build"
+    "verify": "npm run format:check && npm run lint && npm run typecheck && npm run test:unit && npm run test:assembly && npm run build && npm run check:budgets && npm run build:publish && npm run verify:publish-archive",
+    "verify:full": "npm run verify && npm run test:e2e && npm run test:e2e:publish:skip-build",
+    "check:budgets": "node ./scripts/check-bundle-budgets.mjs"
   },
   "browserslist": {
     "production": [

--- a/scripts/__tests__/check-bundle-budgets.test.mjs
+++ b/scripts/__tests__/check-bundle-budgets.test.mjs
@@ -1,0 +1,68 @@
+// @vitest-environment node
+
+import { describe, expect, it } from 'vitest';
+
+import { globToRegExp, evaluateBudgets } from '../check-bundle-budgets.mjs';
+
+describe('globToRegExp', () => {
+  it('matches a hashed filename and is anchored', () => {
+    const re = globToRegExp('assets/index-*.js');
+    expect(re.test('assets/index-CTYg1Ic3.js')).toBe(true);
+    expect(re.test('assets/index-CTYg1Ic3.css')).toBe(false);
+    expect(re.test('x/assets/index-a.js')).toBe(false); // anchored
+  });
+
+  it('does not let * cross a path separator', () => {
+    expect(globToRegExp('assets/index-*.js').test('assets/sub/index-a.js')).toBe(false);
+  });
+});
+
+describe('evaluateBudgets', () => {
+  const files = ['assets/index-AAAA.js', 'assets/index-AAAA.css', 'assets/openscad-BBBB.wasm'];
+  const sizes = {
+    'assets/index-AAAA.js': 900,
+    'assets/index-AAAA.css': 100,
+    'assets/openscad-BBBB.wasm': 2800,
+  };
+  const sizeOf = (f) => sizes[f] ?? 0;
+
+  it('passes when every artifact is within budget', () => {
+    const { failed, rows } = evaluateBudgets({
+      files,
+      sizeOf,
+      budgets: [{ label: 'js', pattern: 'assets/index-*.js', maxGzipKB: 1024 }],
+    });
+    expect(failed).toBe(false);
+    expect(rows[0]).toMatchObject({ status: 'ok', files: 1, actualKB: 900 });
+  });
+
+  it('fails when an artifact exceeds its budget', () => {
+    const { failed, rows } = evaluateBudgets({
+      files,
+      sizeOf,
+      budgets: [{ label: 'wasm', pattern: 'assets/openscad-*.wasm', maxGzipKB: 2048 }],
+    });
+    expect(failed).toBe(true);
+    expect(rows[0].status).toBe('OVER');
+  });
+
+  it('fails when a pattern matches no file (renamed/removed chunk)', () => {
+    const { failed, rows } = evaluateBudgets({
+      files,
+      sizeOf,
+      budgets: [{ label: 'missing', pattern: 'assets/gone-*.js', maxGzipKB: 9999 }],
+    });
+    expect(failed).toBe(true);
+    expect(rows[0].status).toBe('NO MATCH');
+  });
+
+  it('does not fail in report mode even when over budget', () => {
+    const { failed } = evaluateBudgets({
+      files,
+      sizeOf,
+      reportOnly: true,
+      budgets: [{ label: 'js', pattern: 'assets/index-*.js', maxGzipKB: 1 }],
+    });
+    expect(failed).toBe(false);
+  });
+});

--- a/scripts/check-bundle-budgets.mjs
+++ b/scripts/check-bundle-budgets.mjs
@@ -1,0 +1,89 @@
+#!/usr/bin/env node
+// Bundle-size budgets (#68). Fails the build when a tracked artifact regresses
+// past its gzipped budget, so initial JS / CSS / worker / WASM growth is caught
+// in CI instead of silently shipping. Budgets live in bundle-budgets.json.
+
+import { readFileSync, readdirSync, statSync } from 'node:fs';
+import { gzipSync } from 'node:zlib';
+import { fileURLToPath } from 'node:url';
+import path from 'node:path';
+
+/** Convert a `*`-glob (relative to dist/) into an anchored RegExp. */
+export function globToRegExp(glob) {
+  const escaped = glob.replace(/[.+^${}()|[\]\\]/g, '\\$&').replace(/\*/g, '[^/]*');
+  return new RegExp(`^${escaped}$`);
+}
+
+/**
+ * Evaluate budgets against a file list. `sizeOf(relPath)` returns a file's
+ * gzipped size in KB (injected so this stays pure and testable). A pattern that
+ * matches no file is a failure — a renamed/removed chunk must not pass silently.
+ */
+export function evaluateBudgets({ files, budgets, sizeOf, reportOnly = false }) {
+  let failed = false;
+  const rows = [];
+  for (const { label, pattern, maxGzipKB } of budgets) {
+    const re = globToRegExp(pattern);
+    const matches = files.filter((f) => re.test(f));
+    const totalKB = matches.reduce((sum, f) => sum + sizeOf(f), 0);
+    const over = matches.length === 0 || totalKB > maxGzipKB;
+    if (over && !reportOnly) failed = true;
+    rows.push({
+      label,
+      files: matches.length,
+      actualKB: totalKB,
+      budgetKB: maxGzipKB,
+      status: matches.length === 0 ? 'NO MATCH' : over ? 'OVER' : 'ok',
+    });
+  }
+  return { rows, failed };
+}
+
+/** All files under `dir`, as paths relative to it (posix separators). */
+function listFiles(dir, prefix = '') {
+  const out = [];
+  for (const entry of readdirSync(dir)) {
+    const abs = path.join(dir, entry);
+    const rel = prefix ? `${prefix}/${entry}` : entry;
+    if (statSync(abs).isDirectory()) out.push(...listFiles(abs, rel));
+    else out.push(rel);
+  }
+  return out;
+}
+
+function main() {
+  const distDir = path.resolve('dist');
+  const budgetsPath = path.resolve('bundle-budgets.json');
+  const reportOnly = process.argv.includes('--report');
+
+  const { budgets } = JSON.parse(readFileSync(budgetsPath, 'utf8'));
+  const files = listFiles(distDir);
+  const sizeOf = (rel) => gzipSync(readFileSync(path.join(distDir, rel))).length / 1024;
+
+  const { rows, failed } = evaluateBudgets({ files, budgets, sizeOf, reportOnly });
+
+  const pad = (s, n) => String(s).padEnd(n);
+  console.log(
+    `${pad('artifact', 22)}${pad('files', 7)}${pad('gzip KB', 10)}${pad('budget', 9)}status`,
+  );
+  for (const r of rows) {
+    console.log(
+      `${pad(r.label, 22)}${pad(r.files, 7)}${pad(r.actualKB.toFixed(1), 10)}${pad(
+        reportOnly ? '—' : r.budgetKB,
+        9,
+      )}${r.status}`,
+    );
+  }
+
+  if (failed) {
+    console.error(
+      '\n[bundle-budgets] One or more artifacts exceeded budget (or matched no file). ' +
+        'Investigate the regression, or update bundle-budgets.json deliberately.',
+    );
+    process.exit(1);
+  }
+}
+
+if (process.argv[1] && fileURLToPath(import.meta.url) === path.resolve(process.argv[1])) {
+  main();
+}


### PR DESCRIPTION
## Summary
Adds a CI guardrail that fails the build when a boot-critical artifact regresses past a gzipped-size budget (acceptance criterion 2 of #68: *"CI tracks bundle-size budgets and fails on regressions beyond budget"*).

- `scripts/check-bundle-budgets.mjs` — measures gzipped sizes of tracked `dist/` artifacts and compares to `bundle-budgets.json`. Fails on over-budget **or** a pattern that matches no file (so a renamed/removed chunk can't pass silently). `--report` prints sizes without failing.
- `bundle-budgets.json` — current budgets (gzip KB, ~10% headroom): initial app JS 1024, CSS 115, worker 110, WASM 3072. Current actuals: 921.7 / 99.9 / 91.8 / 2872.1.
- Wired into the CI `build-and-test` job (after the build) and the `verify` script.
- Pure budget logic (`globToRegExp`, `evaluateBudgets`) is unit-tested (pass / over / no-match / report).

## Scope
Slice of #68. This delivers the **bundle-budget tracking** half. The other half — deferring mode-specific imports so a reduced surface (embed/customizer) doesn't eagerly load editor-only code (Monaco), plus splitting Monaco/Three into named chunks so they can be budgeted separately — is a boot-path/chunk-graph change on the auto-deployed bootstrap and remains tracked on #68 (recommended attended). The budget config notes Monaco/Three currently share the initial JS chunk.

## Verification
- `npm run verify` green end-to-end with the budget step in the chain (build → check:budgets → publish).
- Manually verified: passes at current sizes, fails on a tightened budget, fails on a no-match pattern.
- Unit/assembly suites green incl. 6 new budget tests.

Refs #68