### PR TITLE
test(coverage): per-module coverage thresholds for critical modules

### DIFF
--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -41,6 +41,8 @@ export default defineConfig({
         'src/fs/**/*.ts',
         'src/language/**/*.ts',
         'src/runner/**/*.ts',
+        'src/embed/protocol.ts',
+        'src/utils.ts',
         'src/runtime/asset-urls.ts',
         'src/runtime/boot-config.ts',
         'scripts/deploy-configure.mjs',
@@ -48,7 +50,19 @@ export default defineConfig({
       ],
       exclude: ['src/**/__tests__/**', 'scripts/**/__tests__/**', 'src/**/*.d.ts'],
       thresholds: {
+        // Global baseline across all included files.
         lines: 45,
+        // Per-module gates for the critical modules this epic introduced or
+        // hardened (#67): the scheduler/validators (utils), the path validator,
+        // the project store, the embed protocol, and the project-source
+        // contracts. Each sits a few points below current coverage so a real
+        // regression fails CI while small, fully-covered edits do not. Raise a
+        // gate when coverage rises; never lower one to make a regression pass.
+        'src/utils.ts': { statements: 66, branches: 58, functions: 75, lines: 66 },
+        'src/fs/project-path.ts': { statements: 95, branches: 95, functions: 100, lines: 95 },
+        'src/embed/protocol.ts': { statements: 95, branches: 90, functions: 100, lines: 95 },
+        'src/state/project-store.ts': { statements: 80, branches: 78, functions: 90, lines: 80 },
+        'src/state/project-source.ts': { statements: 95, branches: 95, functions: 100, lines: 95 },
       },
     },
   },


### PR DESCRIPTION
Coverage half of #67. Replaces sole reliance on the flat **45% global** line threshold with per-module coverage floors on the modules this epic introduced or hardened, so each critical module is protected individually.

## Gates (each a few points below current coverage)
| Module | lines | branches | functions | statements | actual lines |
|---|---|---|---|---|---|
| `src/utils.ts` (scheduler + validators) | 66 | 58 | 75 | 66 | 69.9% |
| `src/fs/project-path.ts` (path validator) | 95 | 95 | 100 | 95 | 100% |
| `src/embed/protocol.ts` | 95 | 90 | 100 | 95 | 100% |
| `src/state/project-store.ts` | 80 | 78 | 90 | 80 | 85.5% |
| `src/state/project-source.ts` | 95 | 95 | 100 | 95 | 100% |

`src/utils.ts` and `src/embed/protocol.ts` are added to the coverage `include` set so they are measured (they weren't before). The global `lines: 45` baseline is unchanged (global is ~64%, ample headroom).

## Why these levels
Gates sit below current numbers so a genuine regression fails CI while a small, fully-covered edit doesn't churn the gate. The `functions: 100` floors are deliberate on the small pure modules (protocol, path validator, project-source) — adding an untested function there *should* fail until tested. `check-bundle-budgets.mjs` is intentionally **not** gated: its `main()` is untested (~37%), and #67 scopes this to the four named core modules.

## Verification
- Enforcement proven: temporarily setting an impossible gate (`utils.ts` lines 99) fails the run with `Coverage for lines (69.89%) does not meet "src/utils.ts" threshold (99%)`, exit 1.
- All current numbers pass with margin; 323 unit tests pass; format/lint/typecheck green.

Refs #67 (the import-boundary lint half remains, blocked on #59/#62 landing the boundaries to enforce).