### PR TITLE
refactor(fs): depend domain code on a narrow ProjectFileSystem interface

### DIFF
--- a/src/fs/__tests__/project-filesystem.test.ts
+++ b/src/fs/__tests__/project-filesystem.test.ts
@@ -1,0 +1,46 @@
+import { describe, expect, it } from 'vitest';
+
+import type { ProjectFileSystem } from '../project-filesystem.ts';
+import { ProjectStore } from '../../state/project-store.ts';
+import { fetchSource } from '../../utils.ts';
+
+// A minimal in-memory implementation providing ONLY the two methods of the
+// contract — note the absence of any `as FS` cast. If a domain consumer is ever
+// re-widened back to the full ambient BrowserFS `FS`, these constructions stop
+// compiling, which is the regression this file guards (#62 Slice B).
+function memFs(initial: Record<string, string> = {}): ProjectFileSystem {
+  const files = new Map(Object.entries(initial));
+  return {
+    readFileSync(path: string) {
+      const value = files.get(path);
+      if (value == null) throw new Error(`ENOENT: ${path}`);
+      return new TextEncoder().encode(value);
+    },
+    writeFile(path: string, content: string) {
+      files.set(path, content);
+    },
+  };
+}
+
+describe('ProjectFileSystem contract (#62 Slice B)', () => {
+  it('ProjectStore operates on a bare two-method filesystem', () => {
+    const store = new ProjectStore(memFs({ '/a.scad': 'A' }));
+    const snapshot = store.openFile([{ path: '/x.scad', content: 'x' }], '/x.scad', '/a.scad');
+    // openFile reads /a.scad through readFileSync and adds it to the sources.
+    expect(snapshot?.activePath).toBe('/a.scad');
+    expect(snapshot?.sources.find((s) => s.path === '/a.scad')?.content).toBe('A');
+  });
+
+  it('ProjectStore.newFile writes through the contract', () => {
+    const fs = memFs();
+    const store = new ProjectStore(fs);
+    const snapshot = store.newFile([]);
+    // The new empty file is readable back through the same fs instance.
+    expect(new TextDecoder().decode(fs.readFileSync(snapshot.activePath))).toBe('');
+  });
+
+  it('fetchSource reads bytes through the narrow contract', async () => {
+    const bytes = await fetchSource(memFs({ '/a.scad': 'cube();' }), { path: '/a.scad' });
+    expect(new TextDecoder().decode(bytes)).toBe('cube();');
+  });
+});

--- a/src/fs/project-filesystem.ts
+++ b/src/fs/project-filesystem.ts
@@ -1,0 +1,14 @@
+// The narrow filesystem contract the domain layer actually depends on.
+//
+// Model, ProjectStore, and fetchSource only ever read a file's bytes and write
+// text content; they have no need for the full BrowserFS-backed ambient `FS`
+// surface (readdir, symlink, lstat, install/mount lifecycle, …). Depending on
+// this interface instead keeps domain code decoupled from the global BrowserFS
+// install and makes it trivially testable with a plain object (#62).
+//
+// `ProjectFileSystem` is a structural subset of the ambient `FS`, so a real FS
+// instance satisfies it without any adapter.
+export interface ProjectFileSystem {
+  readFileSync(path: string): BufferSource;
+  writeFile(path: string, content: string): void;
+}

--- a/src/state/model.ts
+++ b/src/state/model.ts
@@ -11,6 +11,7 @@ import { VALID_EXPORT_FORMATS_2D, VALID_EXPORT_FORMATS_3D } from './formats.ts';
 import { bubbleUpDeepMutations } from './deep-mutate.ts';
 import { fetchSource, formatBytes, formatMillis, readFileAsDataURL } from '../utils.ts';
 import { openLocalFile, saveViaHandle } from '../fs/filesystem.ts';
+import { ProjectFileSystem } from '../fs/project-filesystem.ts';
 import { ProjectStore } from './project-store.ts';
 import { HostAdapter, WebHostAdapter } from './web-host-adapter.ts';
 import { isExpectedJobCancellation, ProcessStreams } from '../runner/openscad-runner.ts';
@@ -42,7 +43,7 @@ export class Model extends EventTarget {
   private readonly projectStore: ProjectStore;
 
   constructor(
-    private fs: FS,
+    private fs: ProjectFileSystem,
     public state: State,
     private setStateCallback?: (state: State) => void,
     private statePersister?: StatePersister,

--- a/src/state/project-store.ts
+++ b/src/state/project-store.ts
@@ -1,5 +1,6 @@
 import JSZip from 'jszip';
 import { Source } from './app-state.ts';
+import { ProjectFileSystem } from '../fs/project-filesystem.ts';
 import { fetchSource } from '../utils.ts';
 import {
   MAX_PROJECT_FILE_COUNT,
@@ -21,7 +22,7 @@ export interface ProjectSnapshot {
  * returned snapshot and drive any follow-up (e.g. recompiling).
  */
 export class ProjectStore {
-  constructor(private fs: FS) {}
+  constructor(private fs: ProjectFileSystem) {}
 
   /** Content of the active source, or '' if absent/not yet loaded. */
   activeContent(sources: Source[], activePath: string): string {

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,6 +1,7 @@
 // Portions of this file are Copyright 2021 Google LLC, and licensed under GPL2+. See COPYING.
 
 import { fetchExternalSourceBytes } from './external-source.ts';
+import { ProjectFileSystem } from './fs/project-filesystem.ts';
 import { Source } from './state/app-state.ts';
 
 export function mapObject<T, R>(
@@ -183,7 +184,7 @@ export function downloadUrl(url: string, filename: string) {
 }
 
 export async function fetchSource(
-  fs: FS,
+  fs: ProjectFileSystem,
   { content, path, url }: Source,
   { baseUrl }: { baseUrl?: string } = {},
 ): Promise<Uint8Array> {


### PR DESCRIPTION
Slice B of #62 — isolate the filesystem behind an interface. Compile-only, behavior-preserving.

## What this does
- Adds **`src/fs/project-filesystem.ts`** — `ProjectFileSystem`, the exact two-method subset (`readFileSync`, `writeFile`) the domain layer actually uses.
- Retypes the three domain consumers — `ProjectStore`, `Model`, and `fetchSource` — to depend on `ProjectFileSystem` instead of the broad ambient BrowserFS `FS`.
- Adds a contract test that builds `ProjectStore`/`fetchSource` from a bare two-method object **with no `as FS` cast** — a genuine compile-time guard against re-widening.

This satisfies #62 criterion 1 (*"domain code depends on a filesystem interface, not global BrowserFS"*) for the domain layer.

## Why a standalone interface (not `Pick<FS, …>`)
Deriving from the ambient `FS` would re-introduce the type-level coupling to BrowserFS that this issue exists to remove. Assignability of a real `FS` to the interface is already enforced where it matters — `index.ts` constructs `Model` with the real BrowserFS-backed `fs`, so tsc catches any signature drift there.

## Safety
- Signatures match the ambient `FS` character-for-character, so a real `FS` is assignable without an adapter; no runtime change.
- `writeFile` content stays `string` — every write site passes a string (verified: zip import uses `zipObj.async('string')`, addFile/newFile pass strings).
- Existing `as FS` test mocks remain assignable (FS ⊇ ProjectFileSystem); all tests pass.
- Adversarially reviewed (no MUST/SHOULD-FIX). `npm run verify` green.

Refs #62 (slices D — per-thread mount-state owner — and E — drop the fs-context global — remain; tracked on the issue).