### PR TITLE
refactor(state): extract the /home/state.json persistence seam

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -10,6 +10,7 @@ import { ensureBrowserFSLoaded, getBrowserFS } from './runtime/browserfs-runtime
 import { loadBootConfig, mergeConfigIntoSearch } from './runtime/boot-config.ts';
 import { registerAppServiceWorker } from './runtime/service-worker.ts';
 import { readStateFromFragment, writeStateInFragment } from './state/fragment-state.ts';
+import { readPersistedState, writePersistedState } from './state/persisted-state.ts';
 import { createInitialState } from './state/initial-state.ts';
 import { parseUrlMode } from './state/url-mode.ts';
 import { setModel } from './state/model-context.ts';
@@ -95,19 +96,9 @@ window.addEventListener('load', async () => {
 
   if (isInStandaloneMode()) {
     const bfs: FS = getBrowserFS().BFSRequire('fs');
-    try {
-      const data = JSON.parse(
-        new TextDecoder('utf-8').decode(bfs.readFileSync('/home/state.json')),
-      );
-      const { view, params, preview } = data;
-      persistedState = { view, params, preview };
-    } catch (e) {
-      console.log('Failed to read the persisted state from local storage.', e);
-    }
+    persistedState = readPersistedState(bfs);
     statePersister = {
-      set: async ({ view, params, preview }) => {
-        bfs.writeFile('/home/state.json', JSON.stringify({ view, params, preview }));
-      },
+      set: async (state) => writePersistedState(bfs, state),
     };
   } else {
     persistedState = await readStateFromFragment();

--- a/src/state/__tests__/persisted-state-compat.test.ts
+++ b/src/state/__tests__/persisted-state-compat.test.ts
@@ -1,0 +1,119 @@
+import { describe, expect, it } from 'vitest';
+
+import type { ProjectFileSystem } from '../../fs/project-filesystem.ts';
+import type { Source, State } from '../app-state.ts';
+import { readPersistedState, writePersistedState } from '../persisted-state.ts';
+
+// An in-memory stand-in for the BrowserFS home partition.
+function fakeFs(initial: Record<string, string> = {}) {
+  const files = new Map(Object.entries(initial));
+  const fs: ProjectFileSystem = {
+    readFileSync(path: string) {
+      const value = files.get(path);
+      if (value == null) throw new Error(`ENOENT: ${path}`);
+      return new TextEncoder().encode(value);
+    },
+    writeFile(path: string, content: string) {
+      files.set(path, content);
+    },
+  };
+  return { fs, files };
+}
+
+function baseState(sources: Source[]): State {
+  return {
+    params: {
+      activePath: sources[0]?.path ?? '/home/playground.scad',
+      sources,
+      features: ['lazy-union'],
+      exportFormat2D: 'svg',
+      exportFormat3D: 'stl',
+    },
+    view: {
+      layout: { mode: 'multi', editor: true, viewer: true, customizer: false },
+      color: '#f9d72c',
+      showAxes: true,
+      lineNumbers: false,
+    },
+    preview: { thumbhash: 'abc' },
+  };
+}
+
+const STATE_PATH = '/home/state.json';
+
+describe('persisted-state on-disk compatibility (#56)', () => {
+  it('round-trips every source shape verbatim (flat keys, order preserved)', () => {
+    const sources: Source[] = [
+      { path: '/home/main.scad', content: 'cube(10);' },
+      { path: '/home/loaded.scad', url: 'http://localhost/loaded.scad', content: 'module a(){}' },
+      { path: '/home/unloaded.scad', url: 'http://localhost/unloaded.scad' },
+      { path: '/home/lib/', url: 'http://localhost/lib.zip' },
+    ];
+    const { fs } = fakeFs();
+
+    writePersistedState(fs, baseState(sources));
+    const restored = readPersistedState(fs);
+
+    expect(restored?.params.sources).toEqual(sources);
+  });
+
+  it('reads a hand-written legacy on-disk state.json with flat sources', () => {
+    // Exactly the bytes an existing standalone user has on disk today.
+    const legacy = JSON.stringify({
+      params: {
+        activePath: '/home/playground.scad',
+        sources: [
+          { path: '/home/playground.scad', content: 'sphere(5);' },
+          { path: '/home/remote.scad', url: 'http://localhost/remote.scad' },
+        ],
+        features: ['lazy-union'],
+        exportFormat2D: 'svg',
+        exportFormat3D: 'stl',
+      },
+      view: {
+        layout: { mode: 'multi', editor: true, viewer: true, customizer: false },
+        color: '#000',
+      },
+      preview: undefined,
+    });
+    const { fs } = fakeFs({ [STATE_PATH]: legacy });
+
+    const restored = readPersistedState(fs);
+
+    expect(restored?.params.sources).toEqual([
+      { path: '/home/playground.scad', content: 'sphere(5);' },
+      { path: '/home/remote.scad', url: 'http://localhost/remote.scad' },
+    ]);
+  });
+
+  it('writes the durable slice as flat JSON with no discriminant keys', () => {
+    const { fs, files } = fakeFs();
+    writePersistedState(fs, baseState([{ path: '/home/a.scad', content: 'cube();' }]));
+
+    const onDisk = JSON.parse(files.get(STATE_PATH)!);
+    expect(Object.keys(onDisk).sort()).toEqual(['params', 'preview', 'view']);
+    expect(onDisk.params.sources).toEqual([{ path: '/home/a.scad', content: 'cube();' }]);
+    // No `kind` discriminant must leak onto disk.
+    expect(JSON.stringify(onDisk)).not.toContain('"kind"');
+  });
+
+  it('persists only the durable slice (drops transient runtime fields)', () => {
+    const { fs, files } = fakeFs();
+    const state = baseState([{ path: '/home/a.scad', content: 'cube();' }]);
+    state.rendering = true;
+    state.error = 'boom';
+    state.output = { isPreview: true } as State['output'];
+
+    writePersistedState(fs, state);
+    const onDisk = JSON.parse(files.get(STATE_PATH)!);
+
+    expect(onDisk).not.toHaveProperty('rendering');
+    expect(onDisk).not.toHaveProperty('error');
+    expect(onDisk).not.toHaveProperty('output');
+  });
+
+  it('returns null when state.json is missing or corrupt', () => {
+    expect(readPersistedState(fakeFs().fs)).toBeNull();
+    expect(readPersistedState(fakeFs({ [STATE_PATH]: 'not json{' }).fs)).toBeNull();
+  });
+});

--- a/src/state/persisted-state.ts
+++ b/src/state/persisted-state.ts
@@ -1,0 +1,34 @@
+// The persisted-state seam for standalone/PWA mode.
+//
+// In standalone mode the durable slice of app state is stored on the BrowserFS
+// home partition at /home/state.json. This is per-user data with NO server-side
+// migration — the app is a static GitHub Pages deploy — so the on-disk JSON
+// shape must stay backward-compatible across releases. Routing the read/write
+// through this single seam (instead of inline in index.ts) makes that contract
+// explicit and unit-testable, and gives a later source-shape change exactly one
+// place to add a normalization shim.
+//
+// The read path intentionally performs no normalization today: it returns the
+// persisted {view, params, preview} verbatim, matching the historical behavior.
+
+import { ProjectFileSystem } from '../fs/project-filesystem.ts';
+import type { State } from './app-state.ts';
+
+const STATE_PATH = '/home/state.json';
+
+/** Read the persisted durable state, or null if absent/unreadable. */
+export function readPersistedState(fs: ProjectFileSystem): State | null {
+  try {
+    const data = JSON.parse(new TextDecoder('utf-8').decode(fs.readFileSync(STATE_PATH)));
+    const { view, params, preview } = data;
+    return { view, params, preview };
+  } catch (e) {
+    console.log('Failed to read the persisted state from local storage.', e);
+    return null;
+  }
+}
+
+/** Persist the durable slice (view/params/preview) of the given state. */
+export function writePersistedState(fs: ProjectFileSystem, { view, params, preview }: State): void {
+  fs.writeFile(STATE_PATH, JSON.stringify({ view, params, preview }));
+}


### PR DESCRIPTION
First slice of the #56 source-type migration, and its **safety net**. Behavior-preserving, no functional change.

## Why this is first
`/home/state.json` (standalone/PWA mode) is the highest backward-compat risk in the whole #56 migration: it persists per-user data with **no server-side migration** (static Pages), and the read path currently does **zero** normalization — `index.ts` parsed it and assigned `params` verbatim into the initial state. There was no test guarding its on-disk shape. Before any source-type change can perturb that shape, this slice isolates the boundary and pins its contract.

## What this does
- New `src/state/persisted-state.ts` with `readPersistedState` / `writePersistedState`, lifted verbatim from `index.ts` (same `{view, params, preview}` shape, same try/catch, same log). Reuses the existing `ProjectFileSystem` interface for the BrowserFS handle.
- `index.ts` calls the seam instead of the inline block.
- New `persisted-state-compat.test.ts` pinning: verbatim round-trip of text/loaded-remote/unloaded-remote/archive/multi-source; reading a hand-written legacy `state.json`; durable-slice-only persistence (drops transient fields); **no `kind` keys on disk**; null on missing/corrupt.

When the later flip makes `params.sources` a discriminated union, the union↔flat shim goes in exactly one place (this module), and these tests already prove the flat on-disk contract it must preserve.

## Safety
- Diff is behavior-identical (verified line-by-line): same read result/log, same serialized write, `bfs` still satisfies the param.
- `npm run verify` green; 5 new tests pass.

Refs #56