### PR TITLE
feat(runner): stamp a source revision on compiles and drop stale results

### DIFF
--- a/src/runner/__tests__/compile-pipeline.test.ts
+++ b/src/runner/__tests__/compile-pipeline.test.ts
@@ -34,11 +34,12 @@ class FakeWorker {
   onmessage: ((e: MessageEvent) => void) | null = null;
   onerror: ((e: ErrorEvent) => void) | null = null;
 
-  postMessage(msg: { type: string; id: string }) {
+  postMessage(msg: { type: string; id: string; revision?: number }) {
     if (msg.type !== 'compile') return;
     const spec = _workerSpecs.shift();
     if (!spec) throw new Error('FakeWorker: no spec queued for this compile call');
     const mergedOutputs = (spec.stderrLines ?? []).map((text) => ({ stderr: text }));
+    // Mirror the real worker: echo the request's revision back on the response.
     const response =
       spec.responseType === 'error'
         ? {
@@ -48,6 +49,7 @@ class FakeWorker {
             mergedOutputs,
             elapsedMillis: 0,
             perf: spec.perf,
+            revision: msg.revision,
           }
         : {
             type: 'result' as const,
@@ -57,6 +59,7 @@ class FakeWorker {
             mergedOutputs,
             elapsedMillis: 0,
             perf: spec.perf,
+            revision: msg.revision,
           };
     // Deliver asynchronously (mirrors real Worker MessageEvent timing)
     setTimeout(() => this.onmessage?.({ data: response } as MessageEvent), 0);
@@ -218,5 +221,30 @@ describe('spawnOpenSCAD', () => {
     expect(snapshot.metrics).toContainEqual(
       expect.objectContaining({ name: 'osc:worker-wasm-init', duration: 44 }),
     );
+  });
+
+  it('threads the request revision through to the result (#56)', async () => {
+    _workerSpecs.push({ exitCode: 0 });
+    const result = await spawnOpenSCAD(
+      { mountArchives: true, args: ['m.scad'], revision: 7 },
+      vi.fn(),
+    );
+    expect(result.revision).toBe(7);
+  });
+
+  it('threads the request revision through to an error result (#56)', async () => {
+    _workerSpecs.push({ responseType: 'error', message: 'boom' });
+    const result = await spawnOpenSCAD(
+      { mountArchives: true, args: ['m.scad'], revision: 9 },
+      vi.fn(),
+    );
+    expect(result.error).toBe('boom');
+    expect(result.revision).toBe(9);
+  });
+
+  it('leaves revision undefined when none is requested (pre-revision host)', async () => {
+    _workerSpecs.push({ exitCode: 0 });
+    const result = await spawnOpenSCAD({ mountArchives: true, args: ['m.scad'] }, vi.fn());
+    expect(result.revision).toBeUndefined();
   });
 });

--- a/src/runner/actions.ts
+++ b/src/runner/actions.ts
@@ -14,14 +14,16 @@ const syntaxDelay = 300;
 type SyntaxCheckArgs = {
   activePath: string;
   sources: Source[];
+  revision?: number;
 };
 type SyntaxCheckOutput = {
   logText: string;
   markers: Diagnostic[];
   parameterSet?: ParameterSet;
+  revision?: number;
 };
 export const checkSyntax = turnIntoDelayableExecution(syntaxDelay, (sargs: SyntaxCheckArgs) => {
-  const { activePath, sources } = sargs;
+  const { activePath, sources, revision } = sargs;
 
   const outFile = 'out.json';
   const job = spawnOpenSCAD(
@@ -30,6 +32,7 @@ export const checkSyntax = turnIntoDelayableExecution(syntaxDelay, (sargs: Synta
       inputs: sources,
       args: buildOpenScadArgs({ scadPath: activePath, outFile, exportFormat: 'param' }),
       outputPaths: [outFile],
+      revision,
     },
     (_streams) => {},
     'syntax',
@@ -63,6 +66,7 @@ export const checkSyntax = turnIntoDelayableExecution(syntaxDelay, (sargs: Synta
             },
           }),
           parameterSet,
+          revision: result.revision,
         });
       } catch (e) {
         if (!isExpectedJobCancellation(e)) {
@@ -81,6 +85,7 @@ export type RenderOutput = {
   logText: string;
   markers: Diagnostic[];
   elapsedMillis: number;
+  revision?: number;
 };
 
 export type RenderArgs = {
@@ -95,6 +100,7 @@ export type RenderArgs = {
   renderFormat: keyof typeof VALID_EXPORT_FORMATS_2D | keyof typeof VALID_EXPORT_FORMATS_3D;
   streamsCallback: (ps: ProcessStreams) => void;
   backend?: 'manifold' | 'cgal';
+  revision?: number;
 };
 
 /** Maximum array-nesting depth accepted for a customizer value. */
@@ -182,6 +188,7 @@ export const render = turnIntoDelayableExecution(renderDelay, (renderArgs: Rende
     renderFormat,
     streamsCallback,
     backend,
+    revision,
   } = renderArgs;
 
   const prefixLines: string[] = [];
@@ -220,6 +227,7 @@ export const render = turnIntoDelayableExecution(renderDelay, (renderArgs: Rende
       inputs: sources.map((s) => (s.path === scadPath ? { path: s.path, content } : s)),
       args,
       outputPaths: [outFile],
+      revision,
     },
     streamsCallback,
     isPreview ? 'preview' : 'render',
@@ -267,7 +275,13 @@ export const render = turnIntoDelayableExecution(renderDelay, (renderArgs: Rende
         // eslint-disable-next-line @typescript-eslint/no-explicit-any
         const blob = new Blob([content as any]);
         const outFile = new File([blob], fileName, { type });
-        resolve({ outFile, logText, markers, elapsedMillis: result.elapsedMillis });
+        resolve({
+          outFile,
+          logText,
+          markers,
+          elapsedMillis: result.elapsedMillis,
+          revision: result.revision,
+        });
       } catch (e) {
         if (!isExpectedJobCancellation(e)) {
           console.error(e);

--- a/src/runner/openscad-runner.ts
+++ b/src/runner/openscad-runner.ts
@@ -24,6 +24,8 @@ export type OpenSCADInvocation = {
   inputs?: Source[];
   args: string[];
   outputPaths?: string[];
+  /** Source/project revision stamped onto the request; echoed on the result. */
+  revision?: number;
 };
 
 export type OpenSCADInvocationResults = {
@@ -33,6 +35,8 @@ export type OpenSCADInvocationResults = {
   mergedOutputs: MergedOutputs;
   elapsedMillis: number;
   perf?: CompilePerfStats;
+  /** Revision echoed back from the worker (see OpenSCADInvocation.revision). */
+  revision?: number;
 };
 
 export type ProcessStreams = { stderr: string } | { stdout: string };
@@ -129,6 +133,7 @@ function handleWorkerMessage(e: MessageEvent<WorkerResponse>, generation: number
       mergedOutputs: r.mergedOutputs,
       elapsedMillis: r.elapsedMillis,
       perf: r.perf,
+      revision: r.revision,
     });
   } else if (msg.type === 'error') {
     const r = msg as CompileError;
@@ -141,6 +146,7 @@ function handleWorkerMessage(e: MessageEvent<WorkerResponse>, generation: number
       mergedOutputs: r.mergedOutputs,
       elapsedMillis: r.elapsedMillis,
       perf: r.perf,
+      revision: r.revision,
     });
   } else if (msg.type === 'stdout') {
     const r = msg as CompileStdout;
@@ -258,6 +264,7 @@ export function spawnOpenSCAD(
       args: invocation.args,
       outputPaths: invocation.outputPaths ?? [],
       mountArchives: invocation.mountArchives,
+      revision: invocation.revision,
     };
     worker.postMessage(request);
 

--- a/src/runner/openscad-worker.ts
+++ b/src/runner/openscad-worker.ts
@@ -97,7 +97,7 @@ self.addEventListener('message', async (e: MessageEvent<WorkerRequest>) => {
   }
 
   if (msg.type === 'compile') {
-    const { id, sources, args, outputPaths, mountArchives } = msg as CompileRequest;
+    const { id, sources, args, outputPaths, mountArchives, revision } = msg as CompileRequest;
     currentJobId = id;
     const mergedOutputs: MergedOutput[] = [];
     currentMergedOutputs = mergedOutputs;
@@ -185,6 +185,7 @@ self.addEventListener('message', async (e: MessageEvent<WorkerRequest>) => {
             mergedOutputs,
             elapsedMillis,
             perf,
+            revision,
           } satisfies CompileError);
           return;
         }
@@ -213,6 +214,7 @@ self.addEventListener('message', async (e: MessageEvent<WorkerRequest>) => {
         mergedOutputs,
         elapsedMillis,
         perf,
+        revision,
       } satisfies CompileResult);
     } catch (err) {
       const elapsedMillis = performance.now() - start;
@@ -227,6 +229,7 @@ self.addEventListener('message', async (e: MessageEvent<WorkerRequest>) => {
         mergedOutputs,
         elapsedMillis,
         perf,
+        revision,
       } satisfies CompileError);
     } finally {
       currentJobId = null;

--- a/src/runner/worker-protocol.ts
+++ b/src/runner/worker-protocol.ts
@@ -6,6 +6,13 @@ export type CompileRequest = {
   args: string[];
   outputPaths: string[];
   mountArchives: boolean;
+  /**
+   * Monotonic source/project revision of the inputs. Echoed back on the result
+   * so a consumer can drop a result produced from inputs that have since
+   * changed. Optional so a host/worker pair across a deploy boundary still
+   * interoperate (an absent revision is treated as "not stale").
+   */
+  revision?: number;
 };
 
 export type CancelRequest = {
@@ -33,6 +40,8 @@ export type CompileResult = {
   mergedOutputs: MergedOutput[];
   elapsedMillis: number;
   perf?: CompilePerfStats;
+  /** Echo of the originating CompileRequest.revision (see there). */
+  revision?: number;
 };
 export type CompileError = {
   type: 'error';
@@ -41,6 +50,8 @@ export type CompileError = {
   mergedOutputs: MergedOutput[];
   elapsedMillis: number;
   perf?: CompilePerfStats;
+  /** Echo of the originating CompileRequest.revision (see there). */
+  revision?: number;
 };
 
 export type MergedOutput = { stdout?: string; stderr?: string; error?: string };

--- a/src/state/__tests__/model.test.ts
+++ b/src/state/__tests__/model.test.ts
@@ -403,3 +403,103 @@ describe('Model — expected cancellation handling', () => {
     expect(mockRender).not.toHaveBeenCalled();
   });
 });
+
+// ---------------------------------------------------------------------------
+// describe: stale-result rejection by source revision (#56)
+// ---------------------------------------------------------------------------
+
+describe('Model — stale-result rejection (#56)', () => {
+  const glb = () => new File(['x'], 'test.glb', { type: 'model/gltf-binary' });
+
+  it('drops a render result carrying a superseded source revision', async () => {
+    mockRender.mockReturnValueOnce(
+      // 99999 can never match the live counter (it starts at 0 and only this
+      // test's single render runs), so the result is stale and must be dropped.
+      vi.fn().mockResolvedValue({
+        outFile: glb(),
+        logText: '',
+        markers: [],
+        elapsedMillis: 0,
+        revision: 99999,
+      }),
+    );
+
+    await model.render({ isPreview: false, now: true });
+    await nextTicks();
+
+    expect(model.state.output).toBeUndefined();
+    // The dropped result must still release the spinner it owns, or the UI
+    // (Render/Export buttons, viewer overlay) stays stuck unrecoverably.
+    expect(model.state.rendering).toBeFalsy();
+  });
+
+  it('applies a render result whose revision matches the current revision', async () => {
+    // No source change since construction, so the live revision is still 0.
+    mockRender.mockReturnValueOnce(
+      vi.fn().mockResolvedValue({
+        outFile: glb(),
+        logText: '',
+        markers: [],
+        elapsedMillis: 0,
+        revision: 0,
+      }),
+    );
+
+    await model.render({ isPreview: false, now: true });
+    await nextTicks();
+
+    expect(model.state.output).toBeDefined();
+  });
+
+  it('applies a render result with no revision (pre-revision worker)', async () => {
+    // The default mock omits `revision`; an absent revision is treated as fresh.
+    await model.render({ isPreview: false, now: true });
+    await nextTicks();
+
+    expect(model.state.output).toBeDefined();
+  });
+
+  it('clears the spinner when an in-flight render is invalidated by newFile()', async () => {
+    // Reproduces the real trigger: a render is in flight when the user creates a
+    // new file, which bumps the source revision without dispatching a new render.
+    let resolveRender!: (v: unknown) => void;
+    mockRender.mockReturnValueOnce(
+      vi.fn().mockReturnValue(
+        new Promise((r) => {
+          resolveRender = r;
+        }),
+      ),
+    );
+
+    const renderPromise = model.render({ isPreview: false, now: true });
+    await nextTicks(1);
+    expect(model.state.rendering).toBe(true);
+
+    model.newFile(); // bumps the revision; does not dispatch a render
+
+    // The in-flight render now lands, stamped with the pre-newFile revision (0).
+    resolveRender({ outFile: glb(), logText: '', markers: [], elapsedMillis: 0, revision: 0 });
+    await renderPromise;
+    await nextTicks();
+
+    expect(model.state.output).toBeUndefined();
+    expect(model.state.rendering).toBeFalsy();
+  });
+
+  it('drops a stale syntax result instead of applying its checker run', async () => {
+    mockCheckSyntax.mockReturnValueOnce(
+      vi.fn().mockResolvedValue({
+        logText: 'STALE',
+        markers: [],
+        parameterSet: undefined,
+        revision: 99999,
+      }),
+    );
+
+    await model.checkSyntax();
+    await nextTicks();
+
+    expect(model.state.lastCheckerRun).toBeUndefined();
+    expect(model.state.checkingSyntax).toBeFalsy();
+  });
+});

--- a/src/state/model.ts
+++ b/src/state/model.ts
@@ -51,6 +51,7 @@ export class Model extends EventTarget {
   ) {
     super();
     this.projectStore = new ProjectStore(fs);
+    this._prevSources = state.params.sources;
     this._lastPersistedJson = JSON.stringify(durableSlice(state));
   }
 
@@ -62,6 +63,14 @@ export class Model extends EventTarget {
   private _previewSeq = 0;
   private _renderSeq = 0;
   private _syntaxSeq = 0;
+
+  // Monotonic source/project revision (#56). Bumped centrally in setState
+  // whenever params.sources changes identity, stamped onto each compile request,
+  // and checked when a result lands: a result produced from a since-superseded
+  // revision is dropped. This is source-identity defense complementing the
+  // call-ordering sequence guards above.
+  private _sourceRevision = 0;
+  private _prevSources: State['params']['sources'];
 
   // FSAPI write-back handles, keyed by source path (Chromium only). Scoping the
   // handle to a path keeps `saveProject()` writing back to the source the handle
@@ -93,6 +102,13 @@ export class Model extends EventTarget {
   }
 
   private setState(state: State) {
+    // bubbleUpDeepMutations gives params.sources a fresh identity exactly when
+    // its contents change (and not on view/var-only edits), so a reference
+    // change here is a reliable "the project sources changed" signal.
+    if (state.params.sources !== this._prevSources) {
+      this._prevSources = state.params.sources;
+      this._sourceRevision++;
+    }
     this.state = state;
     this.schedulePersist();
     this.setStateCallback?.(state);
@@ -379,8 +395,12 @@ export class Model extends EventTarget {
       const checkerRun = await checkSyntax({
         activePath: this.state.params.activePath,
         sources: this.state.params.sources,
+        revision: this._sourceRevision,
       })({ now: false });
       if (!isCurrent()) return; // a newer syntax check superseded this one
+      if (checkerRun?.revision !== undefined && checkerRun.revision !== this._sourceRevision) {
+        return; // sources changed since this check was requested — drop the stale result
+      }
       this.mutate((s) => {
         s.lastCheckerRun = checkerRun;
         s.parameterSet = checkerRun?.parameterSet;
@@ -680,10 +700,19 @@ export class Model extends EventTarget {
       renderFormat: is2D ? this.state.params.exportFormat2D : 'off',
       streamsCallback: this.rawStreamsCallback.bind(this),
       backend: this.state.params.backend,
+      revision: this._sourceRevision,
     };
     try {
       const output = await render(renderArgs)({ now });
       if (!isCurrent()) return; // a newer render/preview superseded this one
+      if (output.revision !== undefined && output.revision !== this._sourceRevision) {
+        // Sources changed since this render was requested — drop the stale result.
+        // Unlike the supersession case above, no newer call owns this spinner
+        // flag, so we must clear it ourselves or it stays stuck (e.g. after
+        // newFile(), which bumps the revision without dispatching a new render).
+        this.mutate((s) => setRendering(s, false));
+        return;
+      }
       const displayFile = output.outFile;
       if (output.outFile.name.endsWith('.svg') || output.outFile.name.endsWith('.dxf')) {
         is2D = true;


### PR DESCRIPTION
Revision-stamping slice of #56 — closes acceptance criterion 2 (*"compile results carry a revision and stale results are dropped"*).

## What this does
- Threads an **optional** monotonic source/project `revision` host → worker → host: `CompileRequest`/`CompileResult`/`CompileError`, the runner `OpenSCADInvocation`/results, and the `render`/`checkSyntax` actions.
- `Model` maintains the revision **centrally** in `setState` — bumped exactly when `params.sources` changes identity (`bubbleUpDeepMutations` gives it a fresh reference on source edits but not on view/var-only edits). Each compile stamps the current revision; when a result lands, it's dropped if its revision no longer matches the live one.
- This is **source-identity** defense that complements (does not replace) the existing #48 sequence-token and #47 worker-generation guards — both are still checked first.

## Backward / deploy safety
`revision` is optional in all nine type sites. Old worker → new host: `result.revision` is `undefined`, treated as fresh (accepted). New host → old worker: the extra request field is ignored by structured clone. Degrades to pre-#56 behavior.

## Adversarial review caught a real bug (fixed)
The render stale-drop path initially returned **without** clearing the `rendering`/`previewing` spinner flag. Unlike the supersession path (a newer call owns and clears the flag) and the syntax path (its `finally` clears `checkingSyntax`), this branch has no successor — so a `newFile()` that bumps the revision while a render is in flight left the spinner **stuck unrecoverably** (Render/Export disabled, viewer overlay frozen). Fixed by clearing the owned flag on drop. A regression test reproduces the exact `newFile()` trigger; both spinner assertions fail without the fix and pass with it.

## Tests
- `compile-pipeline.test.ts`: revision threads request→result and request→error; absent when unrequested.
- `model.test.ts`: stale render result dropped + spinner released; matching/absent revision applied; in-flight render invalidated by `newFile()`; stale syntax result dropped + `checkingSyntax` released.
- `npm run verify` green; 339 unit + 20 assembly tests pass.

Refs #56