### PR TITLE
refactor(state): make project sources a typed discriminated union

### DIFF
--- a/src/__tests__/app-stability.test.ts
+++ b/src/__tests__/app-stability.test.ts
@@ -7,7 +7,7 @@ import { State } from '../state/app-state.ts';
 const minimalState: State = {
   params: {
     activePath: '/test.scad',
-    sources: [{ path: '/test.scad', content: 'cube(10);' }],
+    sources: [{ kind: 'text', path: '/test.scad', content: 'cube(10);' }],
     features: [],
     exportFormat2D: 'svg',
     exportFormat3D: 'stl',

--- a/src/__tests__/fragment-state.test.ts
+++ b/src/__tests__/fragment-state.test.ts
@@ -6,6 +6,7 @@ import {
   buildUrlForStateParams,
   encodeStateParamsAsFragment,
 } from '../state/fragment-state.ts';
+import { contentOf } from '../state/project-source.ts';
 
 // ---------------------------------------------------------------------------
 // BUG-5 — readStateFromFragment reads view?.layout?.showAxis instead of view?.showAxes
@@ -114,7 +115,7 @@ describe('round-trip: encodeStateParamsAsFragment → readStateFromFragment', ()
     const restored = await readStateFromFragment();
 
     expect(restored?.params.activePath).toBe('/home/playground.scad');
-    expect(restored?.params.sources?.[0].content).toBe('cube(10);');
+    expect(contentOf(restored!.params.sources[0])).toBe('cube(10);');
     expect(restored?.params.exportFormat2D).toBe('dxf');
     expect(restored?.params.exportFormat3D).toBe('off');
     expect(restored?.params.vars).toEqual({ size: 20 });
@@ -205,13 +206,13 @@ describe('fragment-state — edge cases (T2)', () => {
     window.location.hash = '#blank';
     const state = await readStateFromFragment();
     expect(state).not.toBeNull();
-    expect(state?.params.sources[0]?.content).toBe('');
+    expect(contentOf(state!.params.sources[0])).toBe('');
   });
 
   it('src= fragment produces state with the given source', async () => {
     window.location.hash = '#src=' + encodeURIComponent('cylinder(5, 3);');
     const state = await readStateFromFragment();
-    expect(state?.params.sources[0]?.content).toBe('cylinder(5, 3);');
+    expect(contentOf(state!.params.sources[0])).toBe('cylinder(5, 3);');
   });
 
   it('rejects legacy #url fragments that target cross-origin sources', async () => {
@@ -243,7 +244,10 @@ describe('fragment-state — edge cases (T2)', () => {
 
     const state = await readStateFromFragment();
 
-    expect(state?.params.sources[0]?.url).toBe('http://localhost/fixtures/test.scad');
+    {
+      const s0 = state!.params.sources[0];
+      expect(s0.kind === 'remote' ? s0.url : undefined).toBe('http://localhost/fixtures/test.scad');
+    }
   });
 });
 
@@ -292,16 +296,26 @@ describe('fragment backward-compat fixtures (#56)', () => {
     const state = createInitialState(null, { content: 'cube(10);' });
     // A same-origin absolute url is canonicalized to itself (no drift).
     state.params.sources = [
-      { path: '/main.scad', content: 'include <lib.scad>' },
-      { path: '/lib.scad', url: 'http://localhost/lib.scad', content: 'module lib(){}' },
+      { kind: 'text', path: '/main.scad', content: 'include <lib.scad>' },
+      {
+        kind: 'remote',
+        path: '/lib.scad',
+        url: 'http://localhost/lib.scad',
+        content: 'module lib(){}',
+      },
     ];
 
     history.replaceState(null, '', '#' + (await encodeStateParamsAsFragment(state)));
     const restored = await readStateFromFragment();
 
     expect(restored?.params.sources).toEqual([
-      { path: '/main.scad', content: 'include <lib.scad>', url: undefined },
-      { path: '/lib.scad', url: 'http://localhost/lib.scad', content: 'module lib(){}' },
+      { kind: 'text', path: '/main.scad', content: 'include <lib.scad>' },
+      {
+        kind: 'remote',
+        path: '/lib.scad',
+        url: 'http://localhost/lib.scad',
+        content: 'module lib(){}',
+      },
     ]);
   });
 
@@ -312,16 +326,16 @@ describe('fragment backward-compat fixtures (#56)', () => {
     // The two discriminant edges most at risk in a future union migration: a
     // url-only remote (no content yet) and a trailing-slash archive directory.
     state.params.sources = [
-      { path: '/r.scad', url: 'http://localhost/r.scad' },
-      { path: '/lib/', url: 'http://localhost/lib.zip' },
+      { kind: 'remote', path: '/r.scad', url: 'http://localhost/r.scad' },
+      { kind: 'archive', path: '/lib/', url: 'http://localhost/lib.zip' },
     ];
 
     history.replaceState(null, '', '#' + (await encodeStateParamsAsFragment(state)));
     const restored = await readStateFromFragment();
 
     expect(restored?.params.sources).toEqual([
-      { path: '/r.scad', url: 'http://localhost/r.scad', content: undefined },
-      { path: '/lib/', url: 'http://localhost/lib.zip', content: undefined },
+      { kind: 'remote', path: '/r.scad', url: 'http://localhost/r.scad' },
+      { kind: 'archive', path: '/lib/', url: 'http://localhost/lib.zip' },
     ]);
   });
 
@@ -330,16 +344,47 @@ describe('fragment backward-compat fixtures (#56)', () => {
     const createInitialState = (await import('../state/initial-state.ts')).createInitialState;
     const state = createInitialState(null, { content: 'a' });
     state.params.sources = [
-      { path: '/a.scad', content: 'a();' },
-      { path: '/b.scad', content: 'b();' },
-      { path: '/c.scad', content: 'c();' },
+      { kind: 'text', path: '/a.scad', content: 'a();' },
+      { kind: 'text', path: '/b.scad', content: 'b();' },
+      { kind: 'text', path: '/c.scad', content: 'c();' },
     ];
 
     history.replaceState(null, '', '#' + (await encodeStateParamsAsFragment(state)));
     const restored = await readStateFromFragment();
 
     expect(restored?.params.sources.map((s) => s.path)).toEqual(['/a.scad', '/b.scad', '/c.scad']);
-    expect(restored?.params.sources.map((s) => s.content)).toEqual(['a();', 'b();', 'c();']);
+    expect(restored?.params.sources.map((s) => contentOf(s))).toEqual(['a();', 'b();', 'c();']);
+  });
+
+  it('encodes the fragment with flat, kind-less sources (bookmarked-URL compatibility)', async () => {
+    mockMatchMedia();
+    const createInitialState = (await import('../state/initial-state.ts')).createInitialState;
+    const state = createInitialState(null, { content: 'cube(10);' });
+    state.params.sources = [
+      { kind: 'text', path: '/a.scad', content: 'a();' },
+      { kind: 'remote', path: '/r.scad', url: 'http://localhost/r.scad' },
+    ];
+
+    // Decode the gzip+base64 fragment back to its raw JSON and assert the
+    // serialized sources are the FLAT shape (no `kind`), so URLs shared by this
+    // build remain readable by older deploys and vice versa.
+    const fragment = await encodeStateParamsAsFragment(state);
+    const raw = new TextDecoder().decode(
+      await new Response(
+        new ReadableStream({
+          start(controller) {
+            controller.enqueue(Uint8Array.from(atob(fragment), (c) => c.charCodeAt(0)));
+            controller.close();
+          },
+        }).pipeThrough(new DecompressionStream('gzip')),
+      ).arrayBuffer(),
+    );
+    const parsed = JSON.parse(raw);
+    expect(parsed.params.sources).toEqual([
+      { path: '/a.scad', content: 'a();' },
+      { path: '/r.scad', url: 'http://localhost/r.scad' },
+    ]);
+    expect(raw).not.toContain('"kind"');
   });
 
   it('decodes an uncompressed (legacy, non-gzip) JSON fragment', async () => {
@@ -358,7 +403,7 @@ describe('fragment backward-compat fixtures (#56)', () => {
 
     expect(state?.params.activePath).toBe('/legacy.scad');
     expect(state?.params.sources).toEqual([
-      { path: '/legacy.scad', content: 'legacy();', url: undefined },
+      { kind: 'text', path: '/legacy.scad', content: 'legacy();' },
     ]);
   });
 
@@ -378,7 +423,7 @@ describe('fragment backward-compat fixtures (#56)', () => {
     const state = await readStateFromFragment();
 
     expect(state?.params.sources).toEqual([
-      { path: '/old.scad', content: 'cube(1);', url: undefined },
+      { kind: 'text', path: '/old.scad', content: 'cube(1);' },
     ]);
   });
 
@@ -396,7 +441,7 @@ describe('fragment backward-compat fixtures (#56)', () => {
     const state = await readStateFromFragment();
 
     expect(state?.params.sources).toEqual([
-      { path: '/home/playground.scad', content: 'cube(2);', url: undefined },
+      { kind: 'text', path: '/home/playground.scad', content: 'cube(2);' },
     ]);
   });
 });

--- a/src/__tests__/model-checkingSyntax.test.ts
+++ b/src/__tests__/model-checkingSyntax.test.ts
@@ -18,7 +18,7 @@ describe('Model.checkSyntax', () => {
     return {
       params: {
         activePath: defaultSourcePath,
-        sources: [{ path: defaultSourcePath, content: 'cube(10);' }],
+        sources: [{ kind: 'text', path: defaultSourcePath, content: 'cube(10);' }],
         features: [],
         exportFormat2D: 'svg',
         exportFormat3D: 'stl',

--- a/src/__tests__/parameter-set.test.ts
+++ b/src/__tests__/parameter-set.test.ts
@@ -18,7 +18,7 @@ import { ParameterSet, NumberParameter } from '../state/customizer-types.ts';
 const minimalState: State = {
   params: {
     activePath: '/test.scad',
-    sources: [{ path: '/test.scad', content: 'myChoice = 2; // [0:No, 2:Yes]' }],
+    sources: [{ kind: 'text', path: '/test.scad', content: 'myChoice = 2; // [0:No, 2:Yes]' }],
     features: [],
     exportFormat2D: 'svg',
     exportFormat3D: 'stl',

--- a/src/fs/__tests__/project-filesystem.test.ts
+++ b/src/fs/__tests__/project-filesystem.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from 'vitest';
 
 import type { ProjectFileSystem } from '../project-filesystem.ts';
 import { ProjectStore } from '../../state/project-store.ts';
+import { contentOf } from '../../state/project-source.ts';
 import { fetchSource } from '../../utils.ts';
 
 // A minimal in-memory implementation providing ONLY the two methods of the
@@ -25,10 +26,14 @@ function memFs(initial: Record<string, string> = {}): ProjectFileSystem {
 describe('ProjectFileSystem contract (#62 Slice B)', () => {
   it('ProjectStore operates on a bare two-method filesystem', () => {
     const store = new ProjectStore(memFs({ '/a.scad': 'A' }));
-    const snapshot = store.openFile([{ path: '/x.scad', content: 'x' }], '/x.scad', '/a.scad');
+    const snapshot = store.openFile(
+      [{ kind: 'text', path: '/x.scad', content: 'x' }],
+      '/x.scad',
+      '/a.scad',
+    );
     // openFile reads /a.scad through readFileSync and adds it to the sources.
     expect(snapshot?.activePath).toBe('/a.scad');
-    expect(snapshot?.sources.find((s) => s.path === '/a.scad')?.content).toBe('A');
+    expect(contentOf(snapshot!.sources.find((s) => s.path === '/a.scad')!)).toBe('A');
   });
 
   it('ProjectStore.newFile writes through the contract', () => {

--- a/src/state/__tests__/fsapi-handle-scope.test.ts
+++ b/src/state/__tests__/fsapi-handle-scope.test.ts
@@ -48,7 +48,7 @@ function singleSourceState(path: string): State {
   return {
     params: {
       activePath: path,
-      sources: [{ path, content: 'cube(1);' }],
+      sources: [{ kind: 'text', path, content: 'cube(1);' }],
       features: [],
       exportFormat2D: 'svg',
       exportFormat3D: 'stl',

--- a/src/state/__tests__/model.test.ts
+++ b/src/state/__tests__/model.test.ts
@@ -48,7 +48,7 @@ function createTestState(content = 'cube(10);'): State {
   return {
     params: {
       activePath: defaultSourcePath,
-      sources: [{ path: defaultSourcePath, content }],
+      sources: [{ kind: 'text', path: defaultSourcePath, content }],
       features: [],
       exportFormat2D: 'svg',
       exportFormat3D: 'stl',
@@ -187,7 +187,7 @@ describe('Model — render triggering', () => {
     model.mutate((s) => {
       s.params.sources = [
         ...s.params.sources,
-        { path: '/home/other.scad', content: 'cylinder(5,3);' },
+        { kind: 'text', path: '/home/other.scad', content: 'cylinder(5,3);' },
       ];
     });
     vi.clearAllMocks(); // reset call counts after the above mutation
@@ -201,7 +201,11 @@ describe('Model — render triggering', () => {
     model.mutate((s) => {
       s.params.sources = [
         ...s.params.sources,
-        { path: '/home/image.svg', content: '<svg xmlns="http://www.w3.org/2000/svg"></svg>' },
+        {
+          kind: 'text',
+          path: '/home/image.svg',
+          content: '<svg xmlns="http://www.w3.org/2000/svg"></svg>',
+        },
       ];
     });
     vi.clearAllMocks();
@@ -219,7 +223,11 @@ describe('Model — render triggering', () => {
       s.params.exportFormat2D = 'dxf';
       s.params.sources = [
         ...s.params.sources,
-        { path: '/home/image.svg', content: '<svg xmlns="http://www.w3.org/2000/svg"></svg>' },
+        {
+          kind: 'text',
+          path: '/home/image.svg',
+          content: '<svg xmlns="http://www.w3.org/2000/svg"></svg>',
+        },
       ];
     });
     vi.clearAllMocks();
@@ -385,7 +393,9 @@ describe('Model — expected cancellation handling', () => {
         ...createTestState(undefined),
         params: {
           activePath: defaultSourcePath,
-          sources: [{ path: defaultSourcePath, url: 'https://example.com/model.scad' }],
+          sources: [
+            { kind: 'remote', path: defaultSourcePath, url: 'https://example.com/model.scad' },
+          ],
           features: [],
           exportFormat2D: 'svg',
           exportFormat3D: 'stl',

--- a/src/state/__tests__/persisted-state-compat.test.ts
+++ b/src/state/__tests__/persisted-state-compat.test.ts
@@ -1,7 +1,8 @@
 import { describe, expect, it } from 'vitest';
 
 import type { ProjectFileSystem } from '../../fs/project-filesystem.ts';
-import type { Source, State } from '../app-state.ts';
+import type { State } from '../app-state.ts';
+import type { SerializableSource } from '../project-source.ts';
 import { readPersistedState, writePersistedState } from '../persisted-state.ts';
 
 // An in-memory stand-in for the BrowserFS home partition.
@@ -20,7 +21,7 @@ function fakeFs(initial: Record<string, string> = {}) {
   return { fs, files };
 }
 
-function baseState(sources: Source[]): State {
+function baseState(sources: SerializableSource[]): State {
   return {
     params: {
       activePath: sources[0]?.path ?? '/home/playground.scad',
@@ -42,12 +43,17 @@ function baseState(sources: Source[]): State {
 const STATE_PATH = '/home/state.json';
 
 describe('persisted-state on-disk compatibility (#56)', () => {
-  it('round-trips every source shape verbatim (flat keys, order preserved)', () => {
-    const sources: Source[] = [
-      { path: '/home/main.scad', content: 'cube(10);' },
-      { path: '/home/loaded.scad', url: 'http://localhost/loaded.scad', content: 'module a(){}' },
-      { path: '/home/unloaded.scad', url: 'http://localhost/unloaded.scad' },
-      { path: '/home/lib/', url: 'http://localhost/lib.zip' },
+  it('round-trips every source shape (union in memory, order preserved)', () => {
+    const sources: SerializableSource[] = [
+      { kind: 'text', path: '/home/main.scad', content: 'cube(10);' },
+      {
+        kind: 'remote',
+        path: '/home/loaded.scad',
+        url: 'http://localhost/loaded.scad',
+        content: 'module a(){}',
+      },
+      { kind: 'remote', path: '/home/unloaded.scad', url: 'http://localhost/unloaded.scad' },
+      { kind: 'archive', path: '/home/lib/', url: 'http://localhost/lib.zip' },
     ];
     const { fs } = fakeFs();
 
@@ -80,15 +86,20 @@ describe('persisted-state on-disk compatibility (#56)', () => {
 
     const restored = readPersistedState(fs);
 
+    // The flat on-disk sources are classified into the typed union on read —
+    // the load-bearing normalization for existing standalone users.
     expect(restored?.params.sources).toEqual([
-      { path: '/home/playground.scad', content: 'sphere(5);' },
-      { path: '/home/remote.scad', url: 'http://localhost/remote.scad' },
+      { kind: 'text', path: '/home/playground.scad', content: 'sphere(5);' },
+      { kind: 'remote', path: '/home/remote.scad', url: 'http://localhost/remote.scad' },
     ]);
   });
 
   it('writes the durable slice as flat JSON with no discriminant keys', () => {
     const { fs, files } = fakeFs();
-    writePersistedState(fs, baseState([{ path: '/home/a.scad', content: 'cube();' }]));
+    writePersistedState(
+      fs,
+      baseState([{ kind: 'text', path: '/home/a.scad', content: 'cube();' }]),
+    );
 
     const onDisk = JSON.parse(files.get(STATE_PATH)!);
     expect(Object.keys(onDisk).sort()).toEqual(['params', 'preview', 'view']);
@@ -99,7 +110,7 @@ describe('persisted-state on-disk compatibility (#56)', () => {
 
   it('persists only the durable slice (drops transient runtime fields)', () => {
     const { fs, files } = fakeFs();
-    const state = baseState([{ path: '/home/a.scad', content: 'cube();' }]);
+    const state = baseState([{ kind: 'text', path: '/home/a.scad', content: 'cube();' }]);
     state.rendering = true;
     state.error = 'boom';
     state.output = { isPreview: true } as State['output'];

--- a/src/state/__tests__/project-source.test.ts
+++ b/src/state/__tests__/project-source.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from 'vitest';
 
 import {
+  contentOf,
   fromFragment,
   fromWire,
   toFragment,
@@ -142,6 +143,25 @@ describe('round-trip: toWire(fromWire(x)) === x for real source shapes', () => {
     for (const s of sources) {
       expect(fromWire(toWire(s))).toEqual(s);
     }
+  });
+});
+
+describe('contentOf', () => {
+  it('returns inline text for a text source', () => {
+    expect(contentOf({ kind: 'text', path: '/a.scad', content: 'cube();' })).toBe('cube();');
+  });
+
+  it('returns loaded content for a remote source, undefined when unloaded', () => {
+    expect(contentOf({ kind: 'remote', path: '/a', url: 'u', content: 'c' })).toBe('c');
+    expect(contentOf({ kind: 'remote', path: '/a', url: 'u' })).toBeUndefined();
+  });
+
+  it('returns undefined for sources whose content is not in-memory text', () => {
+    expect(contentOf({ kind: 'local', path: '/a.scad' })).toBeUndefined();
+    expect(contentOf({ kind: 'archive', path: '/lib/', url: 'z' })).toBeUndefined();
+    expect(
+      contentOf({ kind: 'binary', path: '/a.stl', content: new Uint8Array([1]) }),
+    ).toBeUndefined();
   });
 });
 

--- a/src/state/__tests__/project-store.test.ts
+++ b/src/state/__tests__/project-store.test.ts
@@ -1,5 +1,5 @@
 import { ProjectStore } from '../project-store.ts';
-import type { Source } from '../app-state.ts';
+import { contentOf, type SerializableSource } from '../project-source.ts';
 
 function makeFs(files: Record<string, string> = {}) {
   const written: Record<string, string> = {};
@@ -20,44 +20,54 @@ function makeFs(files: Record<string, string> = {}) {
 describe('ProjectStore (#57)', () => {
   it('reads and replaces the active source content', () => {
     const store = new ProjectStore(makeFs().fs);
-    const sources: Source[] = [
-      { path: '/a.scad', content: 'A' },
-      { path: '/b.scad', content: 'B' },
+    const sources: SerializableSource[] = [
+      { kind: 'text', path: '/a.scad', content: 'A' },
+      { kind: 'text', path: '/b.scad', content: 'B' },
     ];
     expect(store.activeContent(sources, '/b.scad')).toBe('B');
     expect(store.activeContent(sources, '/missing')).toBe('');
 
     const updated = store.withActiveContent(sources, '/a.scad', 'A2');
-    expect(updated.find((s) => s.path === '/a.scad')?.content).toBe('A2');
-    expect(updated.find((s) => s.path === '/b.scad')?.content).toBe('B');
+    expect(contentOf(updated.find((s) => s.path === '/a.scad')!)).toBe('A2');
+    expect(contentOf(updated.find((s) => s.path === '/b.scad')!)).toBe('B');
   });
 
   it('openFile returns null when the path is already active', () => {
     const store = new ProjectStore(makeFs().fs);
-    expect(store.openFile([{ path: '/a.scad', content: 'A' }], '/a.scad', '/a.scad')).toBeNull();
+    expect(
+      store.openFile([{ kind: 'text', path: '/a.scad', content: 'A' }], '/a.scad', '/a.scad'),
+    ).toBeNull();
   });
 
   it('openFile drops the previous active source when it is unmodified vs disk', () => {
     const store = new ProjectStore(makeFs({ '/a.scad': 'A', '/b.scad': 'B' }).fs);
-    const next = store.openFile([{ path: '/a.scad', content: 'A' }], '/a.scad', '/b.scad');
+    const next = store.openFile(
+      [{ kind: 'text', path: '/a.scad', content: 'A' }],
+      '/a.scad',
+      '/b.scad',
+    );
     expect(next).not.toBeNull();
     expect(next!.activePath).toBe('/b.scad');
     expect(next!.sources.map((s) => s.path)).toEqual(['/b.scad']); // /a.scad dropped, /b.scad added
-    expect(next!.sources[0].content).toBe('B');
+    expect(contentOf(next!.sources[0])).toBe('B');
   });
 
   it('openFile keeps the previous active source when it was modified', () => {
     const store = new ProjectStore(makeFs({ '/a.scad': 'ON_DISK', '/b.scad': 'B' }).fs);
-    const next = store.openFile([{ path: '/a.scad', content: 'EDITED' }], '/a.scad', '/b.scad');
+    const next = store.openFile(
+      [{ kind: 'text', path: '/a.scad', content: 'EDITED' }],
+      '/a.scad',
+      '/b.scad',
+    );
     expect(next!.sources.map((s) => s.path)).toEqual(['/a.scad', '/b.scad']);
   });
 
   it('openFile does not re-read a source already in the set', () => {
     const { fs } = makeFs({ '/a.scad': 'A' });
     const store = new ProjectStore(fs);
-    const sources: Source[] = [
-      { path: '/a.scad', content: 'A' },
-      { path: '/b.scad', content: 'B' },
+    const sources: SerializableSource[] = [
+      { kind: 'text', path: '/a.scad', content: 'A' },
+      { kind: 'text', path: '/b.scad', content: 'B' },
     ];
     const next = store.openFile(sources, '/a.scad', '/b.scad');
     expect(next!.activePath).toBe('/b.scad');
@@ -68,7 +78,9 @@ describe('ProjectStore (#57)', () => {
   it('newFile picks a unique untitled name', () => {
     const store = new ProjectStore(makeFs().fs);
     expect(store.newFile([]).activePath).toBe('/home/untitled.scad');
-    const taken: Source[] = [{ path: '/home/untitled.scad', content: '' }];
+    const taken: SerializableSource[] = [
+      { kind: 'text', path: '/home/untitled.scad', content: '' },
+    ];
     const next = store.newFile(taken);
     expect(next.activePath).toBe('/home/untitled-2.scad');
     expect(next.sources.map((s) => s.path)).toContain('/home/untitled-2.scad');
@@ -77,11 +89,15 @@ describe('ProjectStore (#57)', () => {
   it('addFile writes to the fs and replaces any existing same-path source', () => {
     const { fs, written } = makeFs();
     const store = new ProjectStore(fs);
-    const next = store.addFile([{ path: '/home/x.scad', content: 'old' }], '/home/x.scad', 'new');
+    const next = store.addFile(
+      [{ kind: 'text', path: '/home/x.scad', content: 'old' }],
+      '/home/x.scad',
+      'new',
+    );
     expect(written['/home/x.scad']).toBe('new');
     expect(next.activePath).toBe('/home/x.scad');
     expect(next.sources.filter((s) => s.path === '/home/x.scad')).toHaveLength(1);
-    expect(next.sources[0].content).toBe('new');
+    expect(contentOf(next.sources[0])).toBe('new');
   });
 
   // Note: buildZip (real JSZip -> Blob) is exercised in production via saveProject;

--- a/src/state/__tests__/scoped-persistence.test.ts
+++ b/src/state/__tests__/scoped-persistence.test.ts
@@ -33,7 +33,7 @@ function baseState(): State {
   return {
     params: {
       activePath: defaultSourcePath,
-      sources: [{ path: defaultSourcePath, content: 'cube(1);' }],
+      sources: [{ kind: 'text', path: defaultSourcePath, content: 'cube(1);' }],
       features: [],
       exportFormat2D: 'svg',
       exportFormat3D: 'stl',

--- a/src/state/__tests__/source-fetch-race.test.ts
+++ b/src/state/__tests__/source-fetch-race.test.ts
@@ -4,6 +4,7 @@
 
 import { Model } from '../model.ts';
 import { State } from '../app-state.ts';
+import { contentOf } from '../project-source.ts';
 import { defaultModelColor } from '../initial-state.ts';
 
 // Avoid touching the real runner (Worker/WASM) and heavy IO.
@@ -47,8 +48,8 @@ function stateWithUrlSources(): State {
     params: {
       activePath: '/a.scad',
       sources: [
-        { path: '/a.scad', url: 'a.scad' },
-        { path: '/b.scad', url: 'b.scad' },
+        { kind: 'remote', path: '/a.scad', url: 'a.scad' },
+        { kind: 'remote', path: '/b.scad', url: 'b.scad' },
       ],
       features: [],
       exportFormat2D: 'svg',
@@ -118,8 +119,8 @@ describe('source fetch write-back race (#49)', () => {
     const b = sources.find((s) => s.path === '/b.scad');
 
     // Content landed in /a.scad...
-    expect(a?.content).toBe('A_CONTENT');
+    expect(a && contentOf(a)).toBe('A_CONTENT');
     // ...and NOT in the now-active /b.scad.
-    expect(b?.content ?? null).not.toBe('A_CONTENT');
+    expect((b && contentOf(b)) ?? null).not.toBe('A_CONTENT');
   });
 });

--- a/src/state/__tests__/web-host-adapter.test.ts
+++ b/src/state/__tests__/web-host-adapter.test.ts
@@ -33,7 +33,7 @@ function baseState(): State {
   return {
     params: {
       activePath: defaultSourcePath,
-      sources: [{ path: defaultSourcePath, content: 'cube(1);' }],
+      sources: [{ kind: 'text', path: defaultSourcePath, content: 'cube(1);' }],
       features: [],
       exportFormat2D: 'svg',
       exportFormat3D: 'stl',

--- a/src/state/__tests__/zip-import.test.ts
+++ b/src/state/__tests__/zip-import.test.ts
@@ -47,7 +47,7 @@ function baseState(): State {
   return {
     params: {
       activePath: defaultSourcePath,
-      sources: [{ path: defaultSourcePath, content: 'cube(1);' }],
+      sources: [{ kind: 'text', path: defaultSourcePath, content: 'cube(1);' }],
       features: [],
       exportFormat2D: 'svg',
       exportFormat3D: 'stl',

--- a/src/state/app-state.ts
+++ b/src/state/app-state.ts
@@ -3,10 +3,17 @@
 import type { Diagnostic } from '../diagnostics.ts';
 import { ParameterSet } from './customizer-types.ts';
 import { VALID_EXPORT_FORMATS_2D, VALID_EXPORT_FORMATS_3D } from './formats.ts';
+import type { SerializableSource } from './project-source.ts';
 
 export type MultiLayoutComponentId = 'editor' | 'viewer' | 'customizer';
 export type SingleLayoutComponentId = MultiLayoutComponentId;
 
+/**
+ * The flat, untagged source shape used at the worker/runner boundary and in the
+ * serialized fragment / state.json. In-memory project state uses the typed
+ * `ProjectSource` union (see project-source.ts) and converts to this flat shape
+ * at those boundaries.
+ */
 export type Source = {
   // If path ends w/ /, it's a directory, and URL should contain a ZIP file that can be mounted
   path: string;
@@ -27,7 +34,7 @@ export interface FileOutput {
 export interface State {
   params: {
     activePath: string;
-    sources: Source[];
+    sources: SerializableSource[];
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     vars?: { [name: string]: any };
     features: string[];

--- a/src/state/fragment-state.ts
+++ b/src/state/fragment-state.ts
@@ -4,6 +4,7 @@ import { resolveExternalSourceUrl } from '../external-source.ts';
 import { State } from './app-state.ts';
 import { VALID_EXPORT_FORMATS_2D, VALID_EXPORT_FORMATS_3D } from './formats.ts';
 import { validateArray, validateBoolean, validateString, validateStringEnum } from '../utils.ts';
+import { fromFragment, toFragment, type FragmentSource } from './project-source.ts';
 import { createInitialState, defaultModelColor, defaultSourcePath } from './initial-state.ts';
 
 function validateVars(v: unknown): State['params']['vars'] {
@@ -23,15 +24,18 @@ function validateSourceUrl(value: unknown): string | undefined {
 }
 
 function validateSources(value: unknown): State['params']['sources'] {
-  return validateArray(
-    value as State['params']['sources'],
-    (src) => ({
+  // Validate into the flat wire shape, then classify into the typed union. The
+  // on-the-wire fragment stays flat (no `kind`); see encodeStateParamsAsFragment.
+  const flat = validateArray(
+    value as FragmentSource[],
+    (src): FragmentSource => ({
       path: validateString(src?.path, () => defaultSourcePath),
       content: src?.content != null ? validateString(src.content) : undefined,
       url: validateSourceUrl(src?.url),
     }),
     () => [{ path: defaultSourcePath, content: '' }],
   );
+  return flat.map(fromFragment);
 }
 
 export async function buildUrlForStateParams(state: State) {
@@ -72,7 +76,9 @@ async function decompressString(compressedInput: string): Promise<string> {
 
 export function encodeStateParamsAsFragment(state: State) {
   const json = JSON.stringify({
-    params: state.params,
+    // Flatten the typed source union back to the flat on-the-wire shape so the
+    // encoded fragment stays byte-compatible with previously-shared URLs.
+    params: { ...state.params, sources: state.params.sources.map(toFragment) },
     view: state.view,
     preview: state.preview,
   });

--- a/src/state/initial-state.ts
+++ b/src/state/initial-state.ts
@@ -2,6 +2,7 @@
 
 import defaultScad from './default-scad.ts';
 import { State } from './app-state.ts';
+import { fromFragment } from './project-source.ts';
 
 export const defaultSourcePath = '/home/playground.scad';
 export const defaultModelColor = '#f9d72c';
@@ -36,7 +37,7 @@ export function createInitialState(
     initialState = {
       params: {
         activePath,
-        sources: [{ path: activePath, content, url }],
+        sources: [fromFragment({ path: activePath, content, url })],
         features: [],
         exportFormat2D: 'svg',
         exportFormat3D: 'stl',

--- a/src/state/model.ts
+++ b/src/state/model.ts
@@ -12,6 +12,7 @@ import { bubbleUpDeepMutations } from './deep-mutate.ts';
 import { fetchSource, formatBytes, formatMillis, readFileAsDataURL } from '../utils.ts';
 import { openLocalFile, saveViaHandle } from '../fs/filesystem.ts';
 import { ProjectFileSystem } from '../fs/project-filesystem.ts';
+import { contentOf } from './project-source.ts';
 import { ProjectStore } from './project-store.ts';
 import { HostAdapter, WebHostAdapter } from './web-host-adapter.ts';
 import { isExpectedJobCancellation, ProcessStreams } from '../runner/openscad-runner.ts';
@@ -329,9 +330,11 @@ export class Model extends EventTarget {
     immediatePreview?: boolean;
   } = {}) {
     const src = this.state.params.sources.find((src) => src.path === this.state.params.activePath);
-    if (src && src.content == null) {
+    // A source needs its content materialized when it is not yet inline text: an
+    // unloaded remote (fetch its url) or an on-disk local file (read the fs).
+    if (src && src.kind !== 'archive' && contentOf(src) == null) {
       const requestedPath = src.path;
-      const { url } = src;
+      const url = src.kind === 'remote' ? src.url : undefined;
       try {
         const content = new TextDecoder().decode(
           await fetchSource(
@@ -346,10 +349,15 @@ export class Model extends EventTarget {
         let written = false;
         this.mutate((s) => {
           const target = s.params.sources.find((cur) => cur.path === requestedPath);
-          if (!target || target.content != null) return; // source removed or already filled
-          s.params.sources = s.params.sources.map((cur) =>
-            cur.path === requestedPath ? { ...cur, content } : cur,
-          );
+          if (!target || contentOf(target) != null) return; // removed or already filled
+          s.params.sources = s.params.sources.map((cur) => {
+            if (cur.path !== requestedPath) return cur;
+            // A remote stays remote (now loaded, keeps its url); a local file's
+            // content is inlined as text.
+            return cur.kind === 'remote'
+              ? { ...cur, content }
+              : { kind: 'text', path: cur.path, content };
+          });
           s.error = undefined;
           s.errorDetails = undefined;
           written = true;
@@ -607,7 +615,7 @@ export class Model extends EventTarget {
 
   async saveProject() {
     if (this.state.params.sources.length == 1) {
-      const content = this.state.params.sources[0].content ?? '';
+      const content = contentOf(this.state.params.sources[0]) ?? '';
       // Write back through the FSAPI handle for the *active* source, if it was
       // opened that way; otherwise fall back to a download.
       const activePath = this.state.params.activePath;
@@ -683,6 +691,7 @@ export class Model extends EventTarget {
       activePath = loaderPath;
       sources = [
         {
+          kind: 'text',
           path: activePath,
           content: `${is2D ? 'linear_extrude(1) ' : ''} import("${resourcePath}");`,
         },

--- a/src/state/persisted-state.ts
+++ b/src/state/persisted-state.ts
@@ -13,14 +13,23 @@
 
 import { ProjectFileSystem } from '../fs/project-filesystem.ts';
 import type { State } from './app-state.ts';
+import { fromFragment, toFragment, type FragmentSource } from './project-source.ts';
 
 const STATE_PATH = '/home/state.json';
 
-/** Read the persisted durable state, or null if absent/unreadable. */
+/**
+ * Read the persisted durable state, or null if absent/unreadable. The on-disk
+ * sources are the flat `{ path, url?, content? }` shape; classify them into the
+ * typed union so in-memory state is well-formed (this is the load-bearing
+ * normalization for existing users' state.json).
+ */
 export function readPersistedState(fs: ProjectFileSystem): State | null {
   try {
     const data = JSON.parse(new TextDecoder('utf-8').decode(fs.readFileSync(STATE_PATH)));
     const { view, params, preview } = data;
+    if (params && Array.isArray(params.sources)) {
+      params.sources = (params.sources as FragmentSource[]).map(fromFragment);
+    }
     return { view, params, preview };
   } catch (e) {
     console.log('Failed to read the persisted state from local storage.', e);
@@ -28,7 +37,8 @@ export function readPersistedState(fs: ProjectFileSystem): State | null {
   }
 }
 
-/** Persist the durable slice (view/params/preview) of the given state. */
+/** Persist the durable slice (view/params/preview), flattening sources to disk. */
 export function writePersistedState(fs: ProjectFileSystem, { view, params, preview }: State): void {
-  fs.writeFile(STATE_PATH, JSON.stringify({ view, params, preview }));
+  const flatParams = { ...params, sources: params.sources.map(toFragment) };
+  fs.writeFile(STATE_PATH, JSON.stringify({ view, params: flatParams, preview }));
 }

--- a/src/state/project-source.ts
+++ b/src/state/project-source.ts
@@ -107,3 +107,21 @@ export function fromFragment(source: FragmentSource): SerializableSource {
 export function toFragment(source: SerializableSource): FragmentSource {
   return toWire(source) as FragmentSource;
 }
+
+/**
+ * The in-memory text content of a source, or `undefined` when it is not yet
+ * materialized as text: an unloaded `remote`, an on-disk `local`, an `archive`,
+ * or in-memory `binary` bytes. Lets callers read content without re-deriving
+ * which variants carry it.
+ */
+export function contentOf(source: ProjectSource): string | undefined {
+  switch (source.kind) {
+    case 'text':
+    case 'remote':
+      return source.content;
+    case 'local':
+    case 'archive':
+    case 'binary':
+      return undefined;
+  }
+}

--- a/src/state/project-store.ts
+++ b/src/state/project-store.ts
@@ -1,6 +1,6 @@
 import JSZip from 'jszip';
-import { Source } from './app-state.ts';
 import { ProjectFileSystem } from '../fs/project-filesystem.ts';
+import { contentOf, type SerializableSource } from './project-source.ts';
 import { fetchSource } from '../utils.ts';
 import {
   MAX_PROJECT_FILE_COUNT,
@@ -11,7 +11,7 @@ import {
 
 /** The project's file set and which one is the active entry point. */
 export interface ProjectSnapshot {
-  sources: Source[];
+  sources: SerializableSource[];
   activePath: string;
 }
 
@@ -25,13 +25,20 @@ export class ProjectStore {
   constructor(private fs: ProjectFileSystem) {}
 
   /** Content of the active source, or '' if absent/not yet loaded. */
-  activeContent(sources: Source[], activePath: string): string {
-    return sources.find((s) => s.path === activePath)?.content ?? '';
+  activeContent(sources: SerializableSource[], activePath: string): string {
+    const found = sources.find((s) => s.path === activePath);
+    return (found ? contentOf(found) : undefined) ?? '';
   }
 
-  /** Sources with the active source's content replaced. */
-  withActiveContent(sources: Source[], activePath: string, content: string): Source[] {
-    return sources.map((s) => (s.path === activePath ? { path: s.path, content } : s));
+  /** Sources with the active source's content replaced (it becomes inline text). */
+  withActiveContent(
+    sources: SerializableSource[],
+    activePath: string,
+    content: string,
+  ): SerializableSource[] {
+    return sources.map((s) =>
+      s.path === activePath ? { kind: 'text', path: s.path, content } : s,
+    );
   }
 
   private read(path: string): string {
@@ -48,18 +55,22 @@ export class ProjectStore {
    * unmodified vs disk, and add `path` (reading its content) if not already
    * present. Returns null if `path` is already active (no change).
    */
-  openFile(sources: Source[], activePath: string, path: string): ProjectSnapshot | null {
+  openFile(
+    sources: SerializableSource[],
+    activePath: string,
+    path: string,
+  ): ProjectSnapshot | null {
     if (activePath === path) return null;
     const activeContent = this.read(activePath);
-    let next = sources.filter((src) => src.path !== activePath || src.content != activeContent);
+    let next = sources.filter((src) => src.path !== activePath || contentOf(src) != activeContent);
     if (!next.find((src) => src.path === path)) {
-      next = [...next, { path, content: this.read(path) }];
+      next = [...next, { kind: 'text', path, content: this.read(path) }];
     }
     return { sources: next, activePath: path };
   }
 
   /** Create a new empty .scad file with a unique /home/untitled* name. */
-  newFile(sources: Source[]): ProjectSnapshot {
+  newFile(sources: SerializableSource[]): ProjectSnapshot {
     const base = '/home/untitled';
     let path = `${base}.scad`;
     let n = 2;
@@ -70,18 +81,18 @@ export class ProjectStore {
     } catch {
       /* fs may not support it yet */
     }
-    return { sources: [...sources, { path, content: '' }], activePath: path };
+    return { sources: [...sources, { kind: 'text', path, content: '' }], activePath: path };
   }
 
   /** Add (or replace) an externally-opened file and make it active. */
-  addFile(sources: Source[], path: string, content: string): ProjectSnapshot {
+  addFile(sources: SerializableSource[], path: string, content: string): ProjectSnapshot {
     try {
       this.fs.writeFile(path, content);
     } catch {
       /* ignore */
     }
     const withoutExisting = sources.filter((src) => src.path !== path);
-    return { sources: [...withoutExisting, { path, content }], activePath: path };
+    return { sources: [...withoutExisting, { kind: 'text', path, content }], activePath: path };
   }
 
   /**
@@ -129,13 +140,17 @@ export class ProjectStore {
       files[0])?.[0];
     if (!entryRel) return null;
     return {
-      sources: files.map(([p, content]) => ({ path: `/home/${p}`, content })),
+      sources: files.map(([p, content]) => ({
+        kind: 'text' as const,
+        path: `/home/${p}`,
+        content,
+      })),
       activePath: `/home/${entryRel}`,
     };
   }
 
   /** Build a project ZIP blob from the current sources (caller downloads it). */
-  async buildZip(sources: Source[]): Promise<Blob> {
+  async buildZip(sources: SerializableSource[]): Promise<Blob> {
     const zip = new JSZip();
     for (const source of sources) {
       let path = source.path;


### PR DESCRIPTION
The final slice of #56 — flips `State['params']['sources']` to the typed `ProjectSource` union, closing acceptance criterion 1 (*"no ambiguous source states are representable"*). **Closes #56.**

## What changed
- `State['params']['sources']` is now `SerializableSource[]` (text / local / remote / archive — binary excluded, since state is JSON).
- The **flat** `{ path, url?, content? }` shape is kept only at the boundaries:
  - **URL fragment** — `encodeStateParamsAsFragment` maps `toFragment`; `validateSources` maps `fromFragment`.
  - **/home/state.json** — `writePersistedState` maps `toFragment`; `readPersistedState` maps `fromFragment` (guarded).
  - **worker/runner** — unchanged; the union is structurally assignable to the flat `Source`, and the runner already projects `{path, content, url}`, dropping `kind` before `postMessage`.
- Domain branch logic (`processSource`, `saveProject`, `project-store`, the render loader source) switches on `kind` / `contentOf` instead of probing optional-field presence.
- Adds `contentOf(source)` and a `LocalSource`-aware path.

## Backward compatibility (deploy-critical)
No server-side migration exists, so existing bookmarked URLs and existing `state.json` must keep working across the deploy:
- **Encoded fragments stay flat and `kind`-less** — new test decodes the gzip fragment and asserts the raw JSON sources have no `kind` (old deploys read new URLs; new deploys read old URLs).
- **Legacy `state.json` loads into the union** — a hand-written flat on-disk fixture is asserted to classify into the correct tagged sources, and re-persist flat.
- Legacy `source`/`sourcePath`, `#blank`/`#src`/`#path`/`#url` paths all verified.

## Verification
- `npm run verify` green; **345 unit + 20 assembly** tests pass.
- An adversarial review traced every conversion boundary and `.content`/`.url` read site and found **no required fixes** — confirmed byte-compatibility (JSON-equivalent; decode is order-independent) and compile-path behavior preservation. The CI e2e suite (all three modes + publish artifact) exercises the real serialization.

Closes #56