### PR TITLE
refactor(state): extract ExportService from Model

### DIFF
--- a/src/state/model.ts
+++ b/src/state/model.ts
@@ -1,6 +1,6 @@
 // Portions of this file are Copyright 2021 Google LLC, and licensed under GPL2+. See COPYING.
 
-import { checkSyntax, render, RenderArgs, RenderOutput } from '../runner/actions.ts';
+import { checkSyntax, render, RenderArgs } from '../runner/actions.ts';
 import {
   MultiLayoutComponentId,
   SingleLayoutComponentId,
@@ -17,11 +17,10 @@ import { ProjectStore } from './project-store.ts';
 import { HostAdapter, WebHostAdapter } from './web-host-adapter.ts';
 import { isExpectedJobCancellation, ProcessStreams } from '../runner/openscad-runner.ts';
 import { is2DFormatExtension } from './formats.ts';
-import { parseOff } from '../io/import_off.ts';
-import { export3MF } from '../io/export_3mf.ts';
-import chroma from 'chroma-js';
 import { isUserFacingOperationError } from '../user-facing-errors.ts';
 import { applyUserFacingError } from './apply-user-facing-error.ts';
+import { ExportService } from './services/export-service.ts';
+import type { ServiceContext } from './services/service-context.ts';
 
 /** Debounce window for durable-state persistence (coalesces rapid edits/drags). */
 const PERSIST_DEBOUNCE_MS = 500;
@@ -39,6 +38,8 @@ const durableSlice = (state: State): PersistedSlice => ({
 export class Model extends EventTarget {
   /** Owns project-source logic (lookup, edits, file ops, ZIP import/export). */
   private readonly projectStore: ProjectStore;
+  private readonly serviceCtx: ServiceContext;
+  private readonly exportService: ExportService;
 
   constructor(
     private fs: ProjectFileSystem,
@@ -51,6 +52,20 @@ export class Model extends EventTarget {
     this.projectStore = new ProjectStore(fs);
     this._prevSources = state.params.sources;
     this._lastPersistedJson = JSON.stringify(durableSlice(state));
+    this.serviceCtx = this.buildServiceContext();
+    this.exportService = new ExportService(this.serviceCtx);
+  }
+
+  /** The shared surface the extracted services read state and mutate through. */
+  private buildServiceContext(): ServiceContext {
+    return {
+      getState: () => this.state,
+      mutate: (f) => this.mutate(f),
+      getSourceRevision: () => this._sourceRevision,
+      getActiveSource: () => this.source,
+      host: this.host,
+      fs: this.fs,
+    };
   }
 
   // Sequence counters identifying the latest in-flight operation of each kind.
@@ -428,116 +443,8 @@ export class Model extends EventTarget {
     });
   }
 
-  async export() {
-    if (this.state.output) {
-      const normalPassThrough =
-        (this.state.is2D && this.state.params.exportFormat2D === 'svg') ||
-        (!this.state.is2D && this.state.params.exportFormat3D === 'off');
-
-      const glbPassThrough =
-        !this.state.is2D &&
-        this.state.params.exportFormat3D === 'glb' &&
-        (this.state.output.displayFile?.name.endsWith('.glb') ?? false) &&
-        this.state.output.displayFileURL != null;
-
-      if (normalPassThrough || glbPassThrough) {
-        this.mutate((s) => (s.export = s.output));
-        if (glbPassThrough) {
-          this.host.download(
-            this.state.output.displayFileURL!,
-            this.state.output.displayFile!.name,
-          );
-        } else {
-          this.host.download(this.state.output.outFileURL, this.state.output.outFile.name);
-        }
-        return;
-      }
-    }
-    if (
-      !this.state.is2D &&
-      this.state.params.exportFormat3D == '3mf' &&
-      !this.state.params.extruderColors
-    ) {
-      if (!this.state.params.skipMultimaterialPrompt) {
-        this.mutate((_s) => (this.state.view.extruderPickerVisibility = 'exporting'));
-        return;
-      }
-    }
-    this.mutate((s) => {
-      s.currentRunLogs ??= [];
-      s.exporting = true;
-      s.error = undefined;
-      s.errorDetails = undefined;
-    });
-
-    try {
-      if (!this.state.output?.outFile || !this.state.output?.outFileURL) {
-        throw new Error('No output file to export');
-      }
-
-      const { features, exportFormat2D, exportFormat3D } = this.state.params;
-      const exportFormat = this.state.is2D ? exportFormat2D : exportFormat3D;
-      let output: RenderOutput;
-      if (exportFormat === '3mf') {
-        const start = performance.now();
-        const data = parseOff(await this.state.output.outFile.text());
-        const exportedData = export3MF(
-          data,
-          this.state.params.extruderColors?.map((c) => chroma(c)),
-        );
-        const elapsedMillis = performance.now() - start;
-        output = {
-          outFile: new File([exportedData], this.state.output.outFile.name.replace('.off', '.3mf')),
-          elapsedMillis,
-          logText: '',
-          markers: [],
-        };
-      } else {
-        output = await render({
-          mountArchives: false,
-          scadPath: '/export.scad',
-          sources: [
-            {
-              path: '/export.scad',
-              content: `import("${this.state.output?.outFile.name}");`,
-            },
-            {
-              path: this.state.output?.outFile.name,
-              url: this.state.output?.outFileURL,
-            },
-          ],
-          extraArgs: [],
-          isPreview: false,
-          features,
-          renderFormat: exportFormat,
-          streamsCallback: this.rawStreamsCallback.bind(this),
-        })({ now: true });
-      }
-
-      const outFileURL = this.host.createObjectURL(output.outFile);
-      this.mutate((s) => {
-        s.exporting = false;
-        if (s.export?.outFileURL?.startsWith('blob:') ?? false) {
-          this.host.revokeObjectURL(s.export!.outFileURL);
-        }
-        s.export = {
-          outFile: output.outFile,
-          outFileURL,
-          elapsedMillis: output.elapsedMillis,
-          formattedElapsedMillis: formatMillis(output.elapsedMillis),
-          formattedOutFileSize: formatBytes(output.outFile.size),
-        };
-        this.host.download(s.export.outFileURL, output.outFile.name);
-      });
-    } catch (err) {
-      this.mutate((s) => {
-        s.exporting = false;
-        if (!isUserFacingOperationError(err)) {
-          console.error('Error while exporting:', err);
-        }
-        applyUserFacingError(s, err, 'export');
-      });
-    }
+  export() {
+    return this.exportService.export();
   }
 
   /** Creates a new empty .scad file in /home/ and activates it. */

--- a/src/state/services/__tests__/export-service.test.ts
+++ b/src/state/services/__tests__/export-service.test.ts
@@ -1,0 +1,152 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+// Mock the heavy compile/IO deps the format-conversion + 3MF paths touch.
+vi.mock('../../../runner/actions.ts', () => ({
+  render: vi.fn().mockReturnValue(
+    vi.fn().mockResolvedValue({
+      outFile: new File(['converted'], 'model.stl'),
+      logText: '',
+      markers: [],
+      elapsedMillis: 1,
+    }),
+  ),
+}));
+vi.mock('../../../io/import_off.ts', () => ({ parseOff: vi.fn(() => ({})) }));
+vi.mock('../../../io/export_3mf.ts', () => ({
+  export3MF: vi.fn(() => new Uint8Array([1, 2, 3])),
+}));
+vi.mock('chroma-js', () => ({ default: vi.fn((c: string) => c) }));
+
+import { render as _mockRender } from '../../../runner/actions.ts';
+import type { State } from '../../app-state.ts';
+import { bubbleUpDeepMutations } from '../../deep-mutate.ts';
+import type { HostAdapter } from '../../web-host-adapter.ts';
+import { ExportService } from '../export-service.ts';
+import type { ServiceContext } from '../service-context.ts';
+
+const mockRender = _mockRender as ReturnType<typeof vi.fn>;
+
+function fileOutput(name: string, url = 'blob:out'): State['output'] {
+  const f = new File(['x'], name);
+  return {
+    isPreview: false,
+    outFile: f,
+    outFileURL: url,
+    displayFile: f,
+    displayFileURL: url,
+    elapsedMillis: 0,
+    formattedElapsedMillis: '0ms',
+    formattedOutFileSize: '1 B',
+  };
+}
+
+function makeCtx(partial: Partial<State['params']> & { is2D?: boolean; output?: State['output'] }) {
+  let state: State = {
+    params: {
+      activePath: '/a.scad',
+      sources: [{ kind: 'text', path: '/a.scad', content: 'cube();' }],
+      features: [],
+      exportFormat2D: 'svg',
+      exportFormat3D: 'off',
+      ...partial,
+    },
+    view: {
+      layout: { mode: 'multi', editor: true, viewer: true, customizer: false },
+      color: '#000',
+    },
+    is2D: partial.is2D,
+    output: partial.output,
+  };
+  const host = {
+    createObjectURL: vi.fn(() => 'blob:new'),
+    revokeObjectURL: vi.fn(),
+    download: vi.fn(),
+    playCompletionChime: vi.fn(),
+    baseUrl: vi.fn(() => 'http://localhost/'),
+  } satisfies HostAdapter;
+  const ctx: ServiceContext = {
+    getState: () => state,
+    // Use the real deep-mutate so the fake matches production identity
+    // semantics — a service that read a stale snapshot after a mutate would be
+    // caught here, not masked by an in-place fake.
+    mutate: (f) => {
+      const next = bubbleUpDeepMutations(state, f);
+      const changed = next !== state;
+      state = next;
+      return changed;
+    },
+    getSourceRevision: () => 0,
+    getActiveSource: () => '',
+    host,
+    fs: { readFileSync: vi.fn(), writeFile: vi.fn() },
+  };
+  return { ctx, host, getState: () => state };
+}
+
+describe('ExportService', () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it('downloads the rendered file directly on an svg pass-through (2D)', async () => {
+    const { ctx, host } = makeCtx({
+      is2D: true,
+      exportFormat2D: 'svg',
+      output: fileOutput('m.svg'),
+    });
+    await new ExportService(ctx).export();
+    expect(host.download).toHaveBeenCalledWith('blob:out', 'm.svg');
+    expect(mockRender).not.toHaveBeenCalled();
+  });
+
+  it('downloads the display file on a glb pass-through', async () => {
+    const { ctx, host } = makeCtx({
+      is2D: false,
+      exportFormat3D: 'glb',
+      output: fileOutput('m.glb', 'blob:glb'),
+    });
+    await new ExportService(ctx).export();
+    expect(host.download).toHaveBeenCalledWith('blob:glb', 'm.glb');
+    expect(mockRender).not.toHaveBeenCalled();
+  });
+
+  it('opens the multimaterial picker for 3mf without extruder colors', async () => {
+    const { ctx, getState } = makeCtx({
+      is2D: false,
+      exportFormat3D: '3mf',
+      output: fileOutput('m.off'),
+    });
+    await new ExportService(ctx).export();
+    expect(getState().view.extruderPickerVisibility).toBe('exporting');
+    expect(mockRender).not.toHaveBeenCalled();
+  });
+
+  it('converts to 3mf when extruder colors are set, then downloads', async () => {
+    const { ctx, host } = makeCtx({
+      is2D: false,
+      exportFormat3D: '3mf',
+      extruderColors: ['#fff'],
+      output: fileOutput('m.off'),
+    });
+    await new ExportService(ctx).export();
+    expect(host.download).toHaveBeenCalledTimes(1);
+    const [, name] = host.download.mock.calls[0];
+    expect(name).toBe('m.3mf');
+  });
+
+  it('renders a format conversion for non-passthrough formats (e.g. stl)', async () => {
+    const { ctx, host } = makeCtx({
+      is2D: false,
+      exportFormat3D: 'stl',
+      output: fileOutput('m.off'),
+    });
+    await new ExportService(ctx).export();
+    expect(mockRender).toHaveBeenCalledTimes(1);
+    expect(host.download).toHaveBeenCalledWith('blob:new', 'model.stl');
+  });
+
+  it('clears exporting and surfaces an error when there is no output to convert', async () => {
+    const { ctx, getState } = makeCtx({ is2D: false, exportFormat3D: 'stl', output: undefined });
+    await new ExportService(ctx).export();
+    expect(getState().exporting).toBe(false);
+    expect(getState().error).toBeTruthy();
+  });
+});

--- a/src/state/services/export-service.ts
+++ b/src/state/services/export-service.ts
@@ -1,0 +1,140 @@
+import chroma from 'chroma-js';
+
+import { export3MF } from '../../io/export_3mf.ts';
+import { parseOff } from '../../io/import_off.ts';
+import { render, type RenderOutput } from '../../runner/actions.ts';
+import type { ProcessStreams } from '../../runner/openscad-runner.ts';
+import { isUserFacingOperationError } from '../../user-facing-errors.ts';
+import { formatBytes, formatMillis } from '../../utils.ts';
+import { applyUserFacingError } from '../apply-user-facing-error.ts';
+import type { ServiceContext } from './service-context.ts';
+
+/**
+ * Owns export orchestration: pass-through of an already-rendered file, the 3MF
+ * color/extruder conversion, format conversion via a fresh render, and the
+ * browser download. It reads state and writes results through the shared
+ * ServiceContext; it never touches the DOM directly (downloads/object URLs go
+ * through the host adapter).
+ */
+export class ExportService {
+  constructor(private ctx: ServiceContext) {}
+
+  private rawStreamsCallback(ps: ProcessStreams) {
+    this.ctx.mutate((s) => {
+      if ('stdout' in ps) {
+        s.currentRunLogs?.push(['stdout', ps.stdout]);
+      } else {
+        s.currentRunLogs?.push(['stderr', ps.stderr]);
+      }
+    });
+  }
+
+  async export() {
+    const { mutate, host } = this.ctx;
+    // Snapshot is safe: export never mutates output/params/is2D, only the
+    // export/exporting/error/log/view fields it writes via the mutate callback.
+    const state = this.ctx.getState();
+    if (state.output) {
+      const normalPassThrough =
+        (state.is2D && state.params.exportFormat2D === 'svg') ||
+        (!state.is2D && state.params.exportFormat3D === 'off');
+
+      const glbPassThrough =
+        !state.is2D &&
+        state.params.exportFormat3D === 'glb' &&
+        (state.output.displayFile?.name.endsWith('.glb') ?? false) &&
+        state.output.displayFileURL != null;
+
+      if (normalPassThrough || glbPassThrough) {
+        mutate((s) => (s.export = s.output));
+        if (glbPassThrough) {
+          host.download(state.output.displayFileURL!, state.output.displayFile!.name);
+        } else {
+          host.download(state.output.outFileURL, state.output.outFile.name);
+        }
+        return;
+      }
+    }
+    if (!state.is2D && state.params.exportFormat3D == '3mf' && !state.params.extruderColors) {
+      if (!state.params.skipMultimaterialPrompt) {
+        mutate((_s) => (state.view.extruderPickerVisibility = 'exporting'));
+        return;
+      }
+    }
+    mutate((s) => {
+      s.currentRunLogs ??= [];
+      s.exporting = true;
+      s.error = undefined;
+      s.errorDetails = undefined;
+    });
+
+    try {
+      if (!state.output?.outFile || !state.output?.outFileURL) {
+        throw new Error('No output file to export');
+      }
+
+      const { features, exportFormat2D, exportFormat3D } = state.params;
+      const exportFormat = state.is2D ? exportFormat2D : exportFormat3D;
+      let output: RenderOutput;
+      if (exportFormat === '3mf') {
+        const start = performance.now();
+        const data = parseOff(await state.output.outFile.text());
+        const exportedData = export3MF(
+          data,
+          state.params.extruderColors?.map((c) => chroma(c)),
+        );
+        const elapsedMillis = performance.now() - start;
+        output = {
+          outFile: new File([exportedData], state.output.outFile.name.replace('.off', '.3mf')),
+          elapsedMillis,
+          logText: '',
+          markers: [],
+        };
+      } else {
+        output = await render({
+          mountArchives: false,
+          scadPath: '/export.scad',
+          sources: [
+            {
+              path: '/export.scad',
+              content: `import("${state.output?.outFile.name}");`,
+            },
+            {
+              path: state.output?.outFile.name,
+              url: state.output?.outFileURL,
+            },
+          ],
+          extraArgs: [],
+          isPreview: false,
+          features,
+          renderFormat: exportFormat,
+          streamsCallback: this.rawStreamsCallback.bind(this),
+        })({ now: true });
+      }
+
+      const outFileURL = host.createObjectURL(output.outFile);
+      mutate((s) => {
+        s.exporting = false;
+        if (s.export?.outFileURL?.startsWith('blob:') ?? false) {
+          host.revokeObjectURL(s.export!.outFileURL);
+        }
+        s.export = {
+          outFile: output.outFile,
+          outFileURL,
+          elapsedMillis: output.elapsedMillis,
+          formattedElapsedMillis: formatMillis(output.elapsedMillis),
+          formattedOutFileSize: formatBytes(output.outFile.size),
+        };
+        host.download(s.export.outFileURL, output.outFile.name);
+      });
+    } catch (err) {
+      mutate((s) => {
+        s.exporting = false;
+        if (!isUserFacingOperationError(err)) {
+          console.error('Error while exporting:', err);
+        }
+        applyUserFacingError(s, err, 'export');
+      });
+    }
+  }
+}

--- a/src/state/services/service-context.ts
+++ b/src/state/services/service-context.ts
@@ -1,0 +1,30 @@
+import type { ProjectFileSystem } from '../../fs/project-filesystem.ts';
+import type { State } from '../app-state.ts';
+import type { HostAdapter } from '../web-host-adapter.ts';
+
+/**
+ * The slice of `Model` that extracted domain services depend on. Model wires
+ * every service to a single shared context so services read state and route all
+ * writes through `mutate` (the central funnel that fires the `'state'` event,
+ * schedules persistence, and bumps the source revision) — never touching those
+ * concerns directly.
+ */
+export interface ServiceContext {
+  /**
+   * The current app state. Each `mutate` replaces the top-level state identity
+   * (deep-mutate bubbles new identities along the changed spine), so a held
+   * reference goes stale across a mutation — call `getState()` again, or only
+   * snapshot fields no subsequent mutation in scope will touch.
+   */
+  getState(): State;
+  /** Apply a mutation; returns true if state changed. */
+  mutate(f: (state: State) => void): boolean;
+  /** Monotonic source/project revision (bumped centrally on source change). */
+  getSourceRevision(): number;
+  /** Content of the active source ('' if absent or not yet loaded). */
+  getActiveSource(): string;
+  /** Browser side effects (object URLs, downloads, completion chime, base URL). */
+  readonly host: HostAdapter;
+  /** The project filesystem (narrow read/write surface). */
+  readonly fs: ProjectFileSystem;
+}


### PR DESCRIPTION
First service extraction of the #59 Model decomposition.

## What
- New **`ExportService`** holds `Model.export()` verbatim (svg/off + glb pass-through, the 3MF color conversion, format-conversion render, download, error path).
- New **`ServiceContext`** seam — `getState` / `mutate` / `getSourceRevision` / `getActiveSource` + `host` / `fs`. Model builds it (arrow accessors over live `this`) and passes it to the service. Every write still routes through `Model.mutate`, so the `'state'` event, persistence, and source-revision funnel are untouched.
- `Model.export()` is now a one-line delegation; the four callers (export-button, embed-shell, multimaterial-dialog, app-commands) are unchanged.

## Behavior preservation
- The unchanged `model.test.ts` oracle still passes — the façade behaves identically.
- New `export-service.test.ts` covers each export branch, **driven through the real `bubbleUpDeepMutations`** so the once-snapshotted-`state` invariant the extraction relies on is genuinely guarded (not masked by an in-place fake).
- Adversarial review confirmed the move is line-for-line verbatim and the single-snapshot is provably safe (export never mutates the `output`/`params`/`is2D` fields it reads after a mutate). Its SHOULD-FIX (test couldn't catch staleness) is addressed.
- `npm run verify` green; 351 unit + 20 assembly tests pass.

Refs #59 (CompileCoordinator extraction + façade tidy follow.)