### PR TITLE
refactor(state): extract CompileCoordinator from Model

### DIFF
--- a/src/state/model.ts
+++ b/src/state/model.ts
@@ -1,6 +1,5 @@
 // Portions of this file are Copyright 2021 Google LLC, and licensed under GPL2+. See COPYING.
 
-import { checkSyntax, render, RenderArgs } from '../runner/actions.ts';
 import {
   MultiLayoutComponentId,
   SingleLayoutComponentId,
@@ -9,16 +8,13 @@ import {
 } from './app-state.ts';
 import { VALID_EXPORT_FORMATS_2D, VALID_EXPORT_FORMATS_3D } from './formats.ts';
 import { bubbleUpDeepMutations } from './deep-mutate.ts';
-import { fetchSource, formatBytes, formatMillis, readFileAsDataURL } from '../utils.ts';
 import { openLocalFile, saveViaHandle } from '../fs/filesystem.ts';
 import { ProjectFileSystem } from '../fs/project-filesystem.ts';
 import { contentOf } from './project-source.ts';
 import { ProjectStore } from './project-store.ts';
 import { HostAdapter, WebHostAdapter } from './web-host-adapter.ts';
-import { isExpectedJobCancellation, ProcessStreams } from '../runner/openscad-runner.ts';
-import { is2DFormatExtension } from './formats.ts';
-import { isUserFacingOperationError } from '../user-facing-errors.ts';
 import { applyUserFacingError } from './apply-user-facing-error.ts';
+import { CompileCoordinator } from './services/compile-coordinator.ts';
 import { ExportService } from './services/export-service.ts';
 import type { ServiceContext } from './services/service-context.ts';
 
@@ -40,6 +36,7 @@ export class Model extends EventTarget {
   private readonly projectStore: ProjectStore;
   private readonly serviceCtx: ServiceContext;
   private readonly exportService: ExportService;
+  private readonly compile: CompileCoordinator;
 
   constructor(
     private fs: ProjectFileSystem,
@@ -54,6 +51,7 @@ export class Model extends EventTarget {
     this._lastPersistedJson = JSON.stringify(durableSlice(state));
     this.serviceCtx = this.buildServiceContext();
     this.exportService = new ExportService(this.serviceCtx);
+    this.compile = new CompileCoordinator(this.serviceCtx);
   }
 
   /** The shared surface the extracted services read state and mutate through. */
@@ -67,15 +65,6 @@ export class Model extends EventTarget {
       fs: this.fs,
     };
   }
-
-  // Sequence counters identifying the latest in-flight operation of each kind.
-  // checkSyntax/render debounce and supersede one another (turnIntoDelayableExecution),
-  // so a superseded call settles (rejects) while a newer one owns the shared UI
-  // flags — these guards stop the stale call from clobbering the newer call's
-  // previewing/rendering/checkingSyntax state.
-  private _previewSeq = 0;
-  private _renderSeq = 0;
-  private _syntaxSeq = 0;
 
   // Monotonic source/project revision (#56). Bumped centrally in setState
   // whenever params.sources changes identity, stamped onto each compile request,
@@ -110,7 +99,7 @@ export class Model extends EventTarget {
       !this.state.checkingSyntax &&
       !this.state.rendering
     ) {
-      this.processSource({ immediatePreview: true });
+      this.compile.processSource({ immediatePreview: true });
     }
   }
 
@@ -304,7 +293,7 @@ export class Model extends EventTarget {
       s.errorDetails = undefined;
       s.is2D = undefined;
     });
-    this.processSource();
+    this.compile.processSource();
   }
 
   get source(): string {
@@ -320,127 +309,13 @@ export class Model extends EventTarget {
         );
       })
     ) {
-      this.processSource();
+      this.compile.processSource();
     }
   }
 
-  private async processSource({
-    immediatePreview = false,
-  }: {
-    immediatePreview?: boolean;
-  } = {}) {
-    const src = this.state.params.sources.find((src) => src.path === this.state.params.activePath);
-    // A source needs its content materialized when it is not yet inline text: an
-    // unloaded remote (fetch its url) or an on-disk local file (read the fs).
-    if (src && src.kind !== 'archive' && contentOf(src) == null) {
-      const requestedPath = src.path;
-      const url = src.kind === 'remote' ? src.url : undefined;
-      try {
-        const content = new TextDecoder().decode(
-          await fetchSource(
-            this.fs,
-            { path: requestedPath, url },
-            { baseUrl: this.host.baseUrl() },
-          ),
-        );
-        // The active file may have changed while the fetch was in flight. Write
-        // the content back to the source it was actually fetched for — never
-        // whichever file is active now — and only if that source still needs it.
-        let written = false;
-        this.mutate((s) => {
-          const target = s.params.sources.find((cur) => cur.path === requestedPath);
-          if (!target || contentOf(target) != null) return; // removed or already filled
-          s.params.sources = s.params.sources.map((cur) => {
-            if (cur.path !== requestedPath) return cur;
-            // A remote stays remote (now loaded, keeps its url); a local file's
-            // content is inlined as text.
-            return cur.kind === 'remote'
-              ? { ...cur, content }
-              : { kind: 'text', path: cur.path, content };
-          });
-          s.error = undefined;
-          s.errorDetails = undefined;
-          written = true;
-        });
-        // If the user has since switched away, a newer processSource owns the
-        // active file's compilation — don't drive a render for the file they left.
-        if (!written || requestedPath !== this.state.params.activePath) return;
-      } catch (err) {
-        // Only surface the error if this fetch is still for the active file.
-        if (requestedPath === this.state.params.activePath) {
-          this.mutate((s) => {
-            applyUserFacingError(s, err, 'source');
-          });
-        }
-        return;
-      }
-    }
-    // When autoCompile is explicitly disabled, skip automatic syntax check and render.
-    if (this.state.params.autoCompile === false) return;
-    if (this.source.trim() !== '') {
-      const shouldCheckSyntax = this.state.params.activePath.endsWith('.scad');
-      if (immediatePreview) {
-        // Keep the boot-time preview immediate and enqueue syntax only after the
-        // first visible render has settled so startup stays user-visible first.
-        await this.render({ isPreview: true, now: true });
-        if (shouldCheckSyntax) {
-          this.checkSyntax();
-        }
-        return;
-      }
-      if (shouldCheckSyntax) {
-        this.checkSyntax();
-      }
-      this.render({ isPreview: true, now: false });
-    }
-  }
-
-  async checkSyntax() {
-    const token = ++this._syntaxSeq;
-    const isCurrent = () => this._syntaxSeq === token;
-    this.mutate((s) => (s.checkingSyntax = true));
-    try {
-      const checkerRun = await checkSyntax({
-        activePath: this.state.params.activePath,
-        sources: this.state.params.sources,
-        revision: this._sourceRevision,
-      })({ now: false });
-      if (!isCurrent()) return; // a newer syntax check superseded this one
-      if (checkerRun?.revision !== undefined && checkerRun.revision !== this._sourceRevision) {
-        return; // sources changed since this check was requested — drop the stale result
-      }
-      this.mutate((s) => {
-        s.lastCheckerRun = checkerRun;
-        s.parameterSet = checkerRun?.parameterSet;
-        s.checkingSyntax = false;
-      });
-    } catch (err) {
-      if (!isCurrent()) return; // superseded — the newer check owns checkingSyntax
-      if (!isExpectedJobCancellation(err)) {
-        if (!isUserFacingOperationError(err)) {
-          console.error('Error while checking syntax:', err);
-        }
-        this.mutate((s) => {
-          applyUserFacingError(s, err, 'syntax');
-        });
-      }
-    } finally {
-      if (isCurrent()) {
-        this.mutate((s) => {
-          if (s.checkingSyntax) s.checkingSyntax = false;
-        });
-      }
-    }
-  }
-
-  rawStreamsCallback(ps: ProcessStreams) {
-    this.mutate((s) => {
-      if ('stdout' in ps) {
-        s.currentRunLogs?.push(['stdout', ps.stdout]);
-      } else {
-        s.currentRunLogs?.push(['stderr', ps.stderr]);
-      }
-    });
+  /** Run a syntax check on the active source (delegates to the coordinator). */
+  checkSyntax() {
+    return this.compile.checkSyntax();
   }
 
   export() {
@@ -478,7 +353,7 @@ export class Model extends EventTarget {
         s.error = undefined;
         s.errorDetails = undefined;
       });
-      this.processSource();
+      this.compile.processSource();
     } catch (err) {
       this.mutate((s) => {
         applyUserFacingError(s, err, 'model');
@@ -501,7 +376,7 @@ export class Model extends EventTarget {
       s.error = undefined;
       s.errorDetails = undefined;
     });
-    this.processSource();
+    this.compile.processSource();
     return true;
   }
 
@@ -536,155 +411,13 @@ export class Model extends EventTarget {
     }
   }
 
-  async render({
-    isPreview,
-    mountArchives,
-    now,
-    retryInOtherDim,
-  }: {
+  /** Run a preview or full render (delegates to the coordinator). */
+  render(args: {
     isPreview: boolean;
     mountArchives?: boolean;
     now: boolean;
     retryInOtherDim?: boolean;
   }) {
-    // console.log(JSON.stringify(this.state, null, 2));
-    mountArchives ??= true;
-    retryInOtherDim ??= true;
-    // A render and a preview own separate UI flags; track the latest of each so a
-    // superseded call cannot turn off the spinner a newer call is still driving.
-    const token = isPreview ? ++this._previewSeq : ++this._renderSeq;
-    const isCurrent = () => (isPreview ? this._previewSeq : this._renderSeq) === token;
-    const setRendering = (s: State, value: boolean) => {
-      if (isPreview) {
-        s.previewing = value;
-      } else {
-        s.rendering = value;
-      }
-    };
-    this.mutate((s) => {
-      s.currentRunLogs = [];
-      setRendering(s, true);
-      s.error = undefined;
-      s.errorDetails = undefined;
-    });
-
-    let { activePath, sources } = this.state.params;
-    const { vars, features } = this.state.params;
-
-    let is2D = this.state.is2D;
-
-    const extension = activePath.split('.').pop() ?? '';
-    if (!activePath.endsWith('.scad')) {
-      const resourcePath = activePath;
-      const loaderPath = '/load-resource.scad';
-      is2D = is2DFormatExtension(extension);
-
-      mountArchives = false;
-      activePath = loaderPath;
-      sources = [
-        {
-          kind: 'text',
-          path: activePath,
-          content: `${is2D ? 'linear_extrude(1) ' : ''} import("${resourcePath}");`,
-        },
-        ...sources.filter((s) => s.path === resourcePath),
-      ];
-    }
-
-    const renderArgs: RenderArgs = {
-      mountArchives,
-      scadPath: activePath,
-      sources,
-      vars,
-      features,
-      isPreview,
-      renderFormat: is2D ? this.state.params.exportFormat2D : 'off',
-      streamsCallback: this.rawStreamsCallback.bind(this),
-      backend: this.state.params.backend,
-      revision: this._sourceRevision,
-    };
-    try {
-      const output = await render(renderArgs)({ now });
-      if (!isCurrent()) return; // a newer render/preview superseded this one
-      if (output.revision !== undefined && output.revision !== this._sourceRevision) {
-        // Sources changed since this render was requested — drop the stale result.
-        // Unlike the supersession case above, no newer call owns this spinner
-        // flag, so we must clear it ourselves or it stays stuck (e.g. after
-        // newFile(), which bumps the revision without dispatching a new render).
-        this.mutate((s) => setRendering(s, false));
-        return;
-      }
-      const displayFile = output.outFile;
-      if (output.outFile.name.endsWith('.svg') || output.outFile.name.endsWith('.dxf')) {
-        is2D = true;
-      } else {
-        is2D = false;
-      }
-      const outFileURL = this.host.createObjectURL(output.outFile);
-      const displayFileURL = displayFile && (await readFileAsDataURL(displayFile));
-      this.mutate((s) => {
-        setRendering(s, false);
-        s.error = undefined;
-        s.errorDetails = undefined;
-        s.is2D = is2D;
-        s.lastCheckerRun = {
-          logText: output.logText,
-          markers: output.markers,
-        };
-        if (s.output?.outFileURL?.startsWith('blob:') ?? false) {
-          this.host.revokeObjectURL(s.output!.outFileURL);
-        }
-        if (s.output?.displayFileURL?.startsWith('blob:') ?? false) {
-          this.host.revokeObjectURL(s.output!.displayFileURL!);
-        }
-
-        s.output = {
-          isPreview: isPreview,
-          outFile: output.outFile,
-          outFileURL,
-          displayFile,
-          displayFileURL,
-          elapsedMillis: output.elapsedMillis,
-          formattedElapsedMillis: formatMillis(output.elapsedMillis),
-          formattedOutFileSize: formatBytes(output.outFile.size),
-        };
-
-        if (!isPreview) {
-          this.host.playCompletionChime();
-        }
-      });
-    } catch (err) {
-      if (!isCurrent()) return; // superseded — the newer call owns the spinner state
-      this.mutate((s) => {
-        setRendering(s, false);
-        if (!isExpectedJobCancellation(err)) {
-          if (!isUserFacingOperationError(err)) {
-            console.error('Error while doing ' + (isPreview ? 'preview' : 'rendering') + ':', err);
-          }
-          applyUserFacingError(s, err, isPreview ? 'preview' : 'render');
-        }
-      });
-    }
-    if (retryInOtherDim) {
-      let is2D: boolean | undefined;
-      let is3D: boolean | undefined;
-      for (const [, line] of this.state.currentRunLogs ?? []) {
-        if (line == 'Current top level object is not a 3D object.') {
-          is3D = false;
-        } else if (line == 'Top level object is a 3D object:') {
-          is3D = true;
-        } else if (line == 'Current top level object is not a 2D object.') {
-          is2D = false;
-        } else if (line == 'Top level object is a 2D object:') {
-          is2D = true;
-        }
-      }
-      if (is2D === false || is3D === false) {
-        //} || isMixed !== undefined) {
-        this.mutate((s) => (s.is2D = !(is2D === false)));
-        this.render({ isPreview, now: true, retryInOtherDim: false });
-        return;
-      }
-    }
+    return this.compile.render(args);
   }
 }

--- a/src/state/services/compile-coordinator.ts
+++ b/src/state/services/compile-coordinator.ts
@@ -1,0 +1,299 @@
+import { checkSyntax, render, type RenderArgs } from '../../runner/actions.ts';
+import { isExpectedJobCancellation, type ProcessStreams } from '../../runner/openscad-runner.ts';
+import { isUserFacingOperationError } from '../../user-facing-errors.ts';
+import { fetchSource, formatBytes, formatMillis, readFileAsDataURL } from '../../utils.ts';
+import { applyUserFacingError } from '../apply-user-facing-error.ts';
+import type { State } from '../app-state.ts';
+import { is2DFormatExtension } from '../formats.ts';
+import { contentOf } from '../project-source.ts';
+import type { ServiceContext } from './service-context.ts';
+
+/**
+ * Owns the compile lifecycle: materializing the active source, syntax checking,
+ * and preview/full rendering — including the supersession sequence guards, the
+ * source-revision stale-drop, and the dimension-retry. It reads state and writes
+ * results through the shared ServiceContext, and plays the completion chime via
+ * the host adapter; it never touches the DOM directly.
+ */
+export class CompileCoordinator {
+  constructor(private ctx: ServiceContext) {}
+
+  // Sequence counters identifying the latest in-flight operation of each kind.
+  // checkSyntax/render debounce and supersede one another (turnIntoDelayableExecution),
+  // so a superseded call settles (rejects) while a newer one owns the shared UI
+  // flags — these guards stop the stale call from clobbering the newer call's
+  // previewing/rendering/checkingSyntax state.
+  private _previewSeq = 0;
+  private _renderSeq = 0;
+  private _syntaxSeq = 0;
+
+  async processSource({ immediatePreview = false }: { immediatePreview?: boolean } = {}) {
+    const src = this.ctx
+      .getState()
+      .params.sources.find((src) => src.path === this.ctx.getState().params.activePath);
+    // A source needs its content materialized when it is not yet inline text: an
+    // unloaded remote (fetch its url) or an on-disk local file (read the fs).
+    if (src && src.kind !== 'archive' && contentOf(src) == null) {
+      const requestedPath = src.path;
+      const url = src.kind === 'remote' ? src.url : undefined;
+      try {
+        const content = new TextDecoder().decode(
+          await fetchSource(
+            this.ctx.fs,
+            { path: requestedPath, url },
+            { baseUrl: this.ctx.host.baseUrl() },
+          ),
+        );
+        // The active file may have changed while the fetch was in flight. Write
+        // the content back to the source it was actually fetched for — never
+        // whichever file is active now — and only if that source still needs it.
+        let written = false;
+        this.ctx.mutate((s) => {
+          const target = s.params.sources.find((cur) => cur.path === requestedPath);
+          if (!target || contentOf(target) != null) return; // removed or already filled
+          s.params.sources = s.params.sources.map((cur) => {
+            if (cur.path !== requestedPath) return cur;
+            // A remote stays remote (now loaded, keeps its url); a local file's
+            // content is inlined as text.
+            return cur.kind === 'remote'
+              ? { ...cur, content }
+              : { kind: 'text', path: cur.path, content };
+          });
+          s.error = undefined;
+          s.errorDetails = undefined;
+          written = true;
+        });
+        // If the user has since switched away, a newer processSource owns the
+        // active file's compilation — don't drive a render for the file they left.
+        if (!written || requestedPath !== this.ctx.getState().params.activePath) return;
+      } catch (err) {
+        // Only surface the error if this fetch is still for the active file.
+        if (requestedPath === this.ctx.getState().params.activePath) {
+          this.ctx.mutate((s) => {
+            applyUserFacingError(s, err, 'source');
+          });
+        }
+        return;
+      }
+    }
+    // When autoCompile is explicitly disabled, skip automatic syntax check and render.
+    if (this.ctx.getState().params.autoCompile === false) return;
+    if (this.ctx.getActiveSource().trim() !== '') {
+      const shouldCheckSyntax = this.ctx.getState().params.activePath.endsWith('.scad');
+      if (immediatePreview) {
+        // Keep the boot-time preview immediate and enqueue syntax only after the
+        // first visible render has settled so startup stays user-visible first.
+        await this.render({ isPreview: true, now: true });
+        if (shouldCheckSyntax) {
+          this.checkSyntax();
+        }
+        return;
+      }
+      if (shouldCheckSyntax) {
+        this.checkSyntax();
+      }
+      this.render({ isPreview: true, now: false });
+    }
+  }
+
+  async checkSyntax() {
+    const token = ++this._syntaxSeq;
+    const isCurrent = () => this._syntaxSeq === token;
+    this.ctx.mutate((s) => (s.checkingSyntax = true));
+    try {
+      const checkerRun = await checkSyntax({
+        activePath: this.ctx.getState().params.activePath,
+        sources: this.ctx.getState().params.sources,
+        revision: this.ctx.getSourceRevision(),
+      })({ now: false });
+      if (!isCurrent()) return; // a newer syntax check superseded this one
+      if (
+        checkerRun?.revision !== undefined &&
+        checkerRun.revision !== this.ctx.getSourceRevision()
+      ) {
+        return; // sources changed since this check was requested — drop the stale result
+      }
+      this.ctx.mutate((s) => {
+        s.lastCheckerRun = checkerRun;
+        s.parameterSet = checkerRun?.parameterSet;
+        s.checkingSyntax = false;
+      });
+    } catch (err) {
+      if (!isCurrent()) return; // superseded — the newer check owns checkingSyntax
+      if (!isExpectedJobCancellation(err)) {
+        if (!isUserFacingOperationError(err)) {
+          console.error('Error while checking syntax:', err);
+        }
+        this.ctx.mutate((s) => {
+          applyUserFacingError(s, err, 'syntax');
+        });
+      }
+    } finally {
+      if (isCurrent()) {
+        this.ctx.mutate((s) => {
+          if (s.checkingSyntax) s.checkingSyntax = false;
+        });
+      }
+    }
+  }
+
+  rawStreamsCallback(ps: ProcessStreams) {
+    this.ctx.mutate((s) => {
+      if ('stdout' in ps) {
+        s.currentRunLogs?.push(['stdout', ps.stdout]);
+      } else {
+        s.currentRunLogs?.push(['stderr', ps.stderr]);
+      }
+    });
+  }
+
+  async render({
+    isPreview,
+    mountArchives,
+    now,
+    retryInOtherDim,
+  }: {
+    isPreview: boolean;
+    mountArchives?: boolean;
+    now: boolean;
+    retryInOtherDim?: boolean;
+  }) {
+    mountArchives ??= true;
+    retryInOtherDim ??= true;
+    // A render and a preview own separate UI flags; track the latest of each so a
+    // superseded call cannot turn off the spinner a newer call is still driving.
+    const token = isPreview ? ++this._previewSeq : ++this._renderSeq;
+    const isCurrent = () => (isPreview ? this._previewSeq : this._renderSeq) === token;
+    const setRendering = (s: State, value: boolean) => {
+      if (isPreview) {
+        s.previewing = value;
+      } else {
+        s.rendering = value;
+      }
+    };
+    this.ctx.mutate((s) => {
+      s.currentRunLogs = [];
+      setRendering(s, true);
+      s.error = undefined;
+      s.errorDetails = undefined;
+    });
+
+    let { activePath, sources } = this.ctx.getState().params;
+    const { vars, features } = this.ctx.getState().params;
+
+    let is2D = this.ctx.getState().is2D;
+
+    const extension = activePath.split('.').pop() ?? '';
+    if (!activePath.endsWith('.scad')) {
+      const resourcePath = activePath;
+      const loaderPath = '/load-resource.scad';
+      is2D = is2DFormatExtension(extension);
+
+      mountArchives = false;
+      activePath = loaderPath;
+      sources = [
+        {
+          kind: 'text',
+          path: activePath,
+          content: `${is2D ? 'linear_extrude(1) ' : ''} import("${resourcePath}");`,
+        },
+        ...sources.filter((s) => s.path === resourcePath),
+      ];
+    }
+
+    const renderArgs: RenderArgs = {
+      mountArchives,
+      scadPath: activePath,
+      sources,
+      vars,
+      features,
+      isPreview,
+      renderFormat: is2D ? this.ctx.getState().params.exportFormat2D : 'off',
+      streamsCallback: this.rawStreamsCallback.bind(this),
+      backend: this.ctx.getState().params.backend,
+      revision: this.ctx.getSourceRevision(),
+    };
+    try {
+      const output = await render(renderArgs)({ now });
+      if (!isCurrent()) return; // a newer render/preview superseded this one
+      if (output.revision !== undefined && output.revision !== this.ctx.getSourceRevision()) {
+        // Sources changed since this render was requested — drop the stale result.
+        // Unlike the supersession case above, no newer call owns this spinner
+        // flag, so we must clear it ourselves or it stays stuck (e.g. after
+        // newFile(), which bumps the revision without dispatching a new render).
+        this.ctx.mutate((s) => setRendering(s, false));
+        return;
+      }
+      const displayFile = output.outFile;
+      if (output.outFile.name.endsWith('.svg') || output.outFile.name.endsWith('.dxf')) {
+        is2D = true;
+      } else {
+        is2D = false;
+      }
+      const outFileURL = this.ctx.host.createObjectURL(output.outFile);
+      const displayFileURL = displayFile && (await readFileAsDataURL(displayFile));
+      this.ctx.mutate((s) => {
+        setRendering(s, false);
+        s.error = undefined;
+        s.errorDetails = undefined;
+        s.is2D = is2D;
+        s.lastCheckerRun = {
+          logText: output.logText,
+          markers: output.markers,
+        };
+        if (s.output?.outFileURL?.startsWith('blob:') ?? false) {
+          this.ctx.host.revokeObjectURL(s.output!.outFileURL);
+        }
+        if (s.output?.displayFileURL?.startsWith('blob:') ?? false) {
+          this.ctx.host.revokeObjectURL(s.output!.displayFileURL!);
+        }
+
+        s.output = {
+          isPreview: isPreview,
+          outFile: output.outFile,
+          outFileURL,
+          displayFile,
+          displayFileURL,
+          elapsedMillis: output.elapsedMillis,
+          formattedElapsedMillis: formatMillis(output.elapsedMillis),
+          formattedOutFileSize: formatBytes(output.outFile.size),
+        };
+
+        if (!isPreview) {
+          this.ctx.host.playCompletionChime();
+        }
+      });
+    } catch (err) {
+      if (!isCurrent()) return; // superseded — the newer call owns the spinner state
+      this.ctx.mutate((s) => {
+        setRendering(s, false);
+        if (!isExpectedJobCancellation(err)) {
+          if (!isUserFacingOperationError(err)) {
+            console.error('Error while doing ' + (isPreview ? 'preview' : 'rendering') + ':', err);
+          }
+          applyUserFacingError(s, err, isPreview ? 'preview' : 'render');
+        }
+      });
+    }
+    if (retryInOtherDim) {
+      let is2D: boolean | undefined;
+      let is3D: boolean | undefined;
+      for (const [, line] of this.ctx.getState().currentRunLogs ?? []) {
+        if (line == 'Current top level object is not a 3D object.') {
+          is3D = false;
+        } else if (line == 'Top level object is a 3D object:') {
+          is3D = true;
+        } else if (line == 'Current top level object is not a 2D object.') {
+          is2D = false;
+        } else if (line == 'Top level object is a 2D object:') {
+          is2D = true;
+        }
+      }
+      if (is2D === false || is3D === false) {
+        this.ctx.mutate((s) => (s.is2D = !(is2D === false)));
+        this.render({ isPreview, now: true, retryInOtherDim: false });
+        return;
+      }
+    }
+  }
+}


### PR DESCRIPTION
Second service extraction of the #59 Model decomposition — the compile lifecycle.

## What
Moves into a new **`CompileCoordinator`** (behind the shared `ServiceContext`):
- `processSource()` — active-source materialization + the #49 source-fetch race fix
- `checkSyntax()` — syntax debounce/supersession
- `render()` — preview/full render, the preview-vs-render spinner supersession guards, the #56 revision stale-drop (+ #99 spinner clear), the dimension-retry
- `rawStreamsCallback()` and the `_previewSeq`/`_renderSeq`/`_syntaxSeq` counters

`Model.render()`/`Model.checkSyntax()` are now one-line delegations; `init()` and the source/file-op paths call `this.compile.processSource()`.

The source-revision bump stays in `Model.setState` (it must fire for source changes that originate in file-ops, not just compiles); the coordinator reads it via `ctx.getSourceRevision()`. The `'state'` event and persistence funnel are untouched.

## Behavior preservation
- The unchanged `model.test.ts` / `source-fetch-race.test.ts` / `model-checkingSyntax.test.ts` oracles still pass (supersession, cancellation, the #56 revision drop, the #49 race, the `newFile()` spinner clear).
- Adversarial line-by-line review vs `HEAD` confirmed every moved statement/branch/ordering is verbatim, the `this.state→ctx.getState()` reads stay **live** (the dimension-retry sees streamed logs; the #49 guard reads the current active path), the counters are instance-isolated, and there's no init-order/TDZ hazard. **No required fixes.**
- `npm run verify` green; 351 unit + 20 assembly tests pass.

**Model drops from ~690 to 423 lines.** Combined with the earlier ExportService + ProjectStore + WebHostAdapter + persistence extractions, the compile and export responsibilities now live in named, independently-tested services with no direct DOM access.

Refs #59