### PR TITLE
refactor(state): extract LayoutController, completing the Model decomposition

### DIFF
--- a/src/state/model.ts
+++ b/src/state/model.ts
@@ -16,6 +16,7 @@ import { HostAdapter, WebHostAdapter } from './web-host-adapter.ts';
 import { applyUserFacingError } from './apply-user-facing-error.ts';
 import { CompileCoordinator } from './services/compile-coordinator.ts';
 import { ExportService } from './services/export-service.ts';
+import { LayoutController } from './services/layout-controller.ts';
 import type { ServiceContext } from './services/service-context.ts';
 
 /** Debounce window for durable-state persistence (coalesces rapid edits/drags). */
@@ -37,6 +38,7 @@ export class Model extends EventTarget {
   private readonly serviceCtx: ServiceContext;
   private readonly exportService: ExportService;
   private readonly compile: CompileCoordinator;
+  private readonly layout: LayoutController;
 
   constructor(
     private fs: ProjectFileSystem,
@@ -52,6 +54,7 @@ export class Model extends EventTarget {
     this.serviceCtx = this.buildServiceContext();
     this.exportService = new ExportService(this.serviceCtx);
     this.compile = new CompileCoordinator(this.serviceCtx);
+    this.layout = new LayoutController(this.serviceCtx);
   }
 
   /** The shared surface the extracted services read state and mutate through. */
@@ -205,73 +208,23 @@ export class Model extends EventTarget {
   }
 
   set logsVisible(value: boolean) {
-    if (value) {
-      if (this.state.view.layout.mode === 'single') {
-        this.changeSingleVisibility('editor');
-      } else {
-        this.changeMultiVisibility('editor', true);
-      }
-    }
-    this.mutate((s) => (s.view.logs = value));
+    this.layout.setLogsVisible(value);
   }
 
   isComponentFullyVisible(id: SingleLayoutComponentId) {
-    if (this.state.view.layout.mode === 'multi') {
-      return this.state.view.layout[id];
-    } else {
-      return this.state.view.layout.focus === id;
-    }
+    return this.layout.isComponentFullyVisible(id);
   }
 
   changeLayout(mode: 'multi' | 'single') {
-    if (this.state.view.layout.mode === mode) return;
-    this.mutate((s) => {
-      s.view.layout =
-        s.view.layout.mode === 'multi'
-          ? {
-              mode: 'single',
-              focus: s.view.layout.editor
-                ? 'editor'
-                : s.view.layout.viewer
-                  ? 'viewer'
-                  : 'customizer',
-            }
-          : {
-              mode: 'multi',
-              editor: s.view.layout.focus === 'editor',
-              viewer: s.view.layout.focus === 'viewer',
-              customizer: s.view.layout.focus === 'customizer',
-            };
-    });
+    this.layout.changeLayout(mode);
   }
+
   changeSingleVisibility(focus: SingleLayoutComponentId) {
-    this.mutate((s) => {
-      if (s.view.layout.mode !== 'single') throw new Error('Wrong mode');
-      s.view.layout.focus = focus;
-      if (focus !== 'editor') {
-        s.view.logs = false;
-      }
-    });
+    this.layout.changeSingleVisibility(focus);
   }
 
   changeMultiVisibility(target: MultiLayoutComponentId, visible: boolean) {
-    this.mutate((s) => {
-      if (s.view.layout.mode !== 'multi') throw new Error('Wrong mode');
-      s.view.layout[target] = visible;
-      if (
-        (s.view.layout.customizer ? 1 : 0) +
-          (s.view.layout.editor ? 1 : 0) +
-          (s.view.layout.viewer ? 1 : 0) ==
-        0
-      ) {
-        // Select at least one panel
-        // s.view.layout.editor = true;
-        s.view.layout[target] = !visible;
-        if (target === 'editor' && !visible) {
-          s.view.logs = false;
-        }
-      }
-    });
+    this.layout.changeMultiVisibility(target, visible);
   }
 
   openFile(path: string) {

--- a/src/state/services/__tests__/layout-controller.test.ts
+++ b/src/state/services/__tests__/layout-controller.test.ts
@@ -1,0 +1,106 @@
+import { describe, expect, it } from 'vitest';
+
+import type { State } from '../../app-state.ts';
+import { bubbleUpDeepMutations } from '../../deep-mutate.ts';
+import { LayoutController } from '../layout-controller.ts';
+import type { ServiceContext } from '../service-context.ts';
+
+function makeCtx(layout: State['view']['layout'], logs = false) {
+  let state: State = {
+    params: {
+      activePath: '/a.scad',
+      sources: [{ kind: 'text', path: '/a.scad', content: '' }],
+      features: [],
+      exportFormat2D: 'svg',
+      exportFormat3D: 'off',
+    },
+    view: { layout, color: '#000', logs },
+  };
+  const ctx: ServiceContext = {
+    getState: () => state,
+    mutate: (f) => {
+      const next = bubbleUpDeepMutations(state, f);
+      const changed = next !== state;
+      state = next;
+      return changed;
+    },
+    getSourceRevision: () => 0,
+    getActiveSource: () => '',
+    host: {
+      createObjectURL: () => '',
+      revokeObjectURL: () => {},
+      download: () => {},
+      playCompletionChime: () => {},
+      baseUrl: () => '',
+    },
+    fs: { readFileSync: () => new Uint8Array(), writeFile: () => {} },
+  };
+  return { ctx, getState: () => state };
+}
+
+const multi = (over: Partial<{ editor: boolean; viewer: boolean; customizer: boolean }> = {}) =>
+  ({
+    mode: 'multi',
+    editor: true,
+    viewer: true,
+    customizer: false,
+    ...over,
+  }) as State['view']['layout'];
+
+describe('LayoutController', () => {
+  it('isComponentFullyVisible reflects per-panel flags in multi and focus in single', () => {
+    expect(
+      new LayoutController(makeCtx(multi({ viewer: false })).ctx).isComponentFullyVisible('viewer'),
+    ).toBe(false);
+    const single = { mode: 'single', focus: 'editor' } as State['view']['layout'];
+    expect(new LayoutController(makeCtx(single).ctx).isComponentFullyVisible('editor')).toBe(true);
+    expect(new LayoutController(makeCtx(single).ctx).isComponentFullyVisible('viewer')).toBe(false);
+  });
+
+  it('changeLayout maps multi→single focus to the first visible panel', () => {
+    const { ctx, getState } = makeCtx(multi({ editor: false, viewer: true }));
+    new LayoutController(ctx).changeLayout('single');
+    expect(getState().view.layout).toEqual({ mode: 'single', focus: 'viewer' });
+  });
+
+  it('changeLayout maps single→multi visibility from focus', () => {
+    const { ctx, getState } = makeCtx({
+      mode: 'single',
+      focus: 'customizer',
+    } as State['view']['layout']);
+    new LayoutController(ctx).changeLayout('multi');
+    expect(getState().view.layout).toEqual({
+      mode: 'multi',
+      editor: false,
+      viewer: false,
+      customizer: true,
+    });
+  });
+
+  it('changeMultiVisibility keeps at least one panel visible', () => {
+    const { ctx, getState } = makeCtx(multi({ editor: true, viewer: false, customizer: false }));
+    new LayoutController(ctx).changeMultiVisibility('editor', false);
+    // Hiding the last visible panel is reverted.
+    const l = getState().view.layout as { editor: boolean };
+    expect(l.editor).toBe(true);
+  });
+
+  it('changeSingleVisibility clears logs when focusing a non-editor panel', () => {
+    const { ctx, getState } = makeCtx(
+      { mode: 'single', focus: 'editor' } as State['view']['layout'],
+      true,
+    );
+    new LayoutController(ctx).changeSingleVisibility('viewer');
+    expect(getState().view.logs).toBe(false);
+  });
+
+  it('setLogsVisible reveals the editor first in single mode', () => {
+    const { ctx, getState } = makeCtx({
+      mode: 'single',
+      focus: 'viewer',
+    } as State['view']['layout']);
+    new LayoutController(ctx).setLogsVisible(true);
+    expect((getState().view.layout as { focus: string }).focus).toBe('editor');
+    expect(getState().view.logs).toBe(true);
+  });
+});

--- a/src/state/services/layout-controller.ts
+++ b/src/state/services/layout-controller.ts
@@ -1,0 +1,82 @@
+import type { MultiLayoutComponentId, SingleLayoutComponentId } from '../app-state.ts';
+import type { ServiceContext } from './service-context.ts';
+
+/**
+ * Owns view-layout state: single/multi mode, per-panel visibility, focus, and
+ * the logs panel. Pure view-state transitions through the shared context — no
+ * compile, persistence, or DOM coupling.
+ */
+export class LayoutController {
+  constructor(private ctx: ServiceContext) {}
+
+  setLogsVisible(value: boolean) {
+    if (value) {
+      if (this.ctx.getState().view.layout.mode === 'single') {
+        this.changeSingleVisibility('editor');
+      } else {
+        this.changeMultiVisibility('editor', true);
+      }
+    }
+    this.ctx.mutate((s) => (s.view.logs = value));
+  }
+
+  isComponentFullyVisible(id: SingleLayoutComponentId) {
+    const layout = this.ctx.getState().view.layout;
+    if (layout.mode === 'multi') {
+      return layout[id];
+    } else {
+      return layout.focus === id;
+    }
+  }
+
+  changeLayout(mode: 'multi' | 'single') {
+    if (this.ctx.getState().view.layout.mode === mode) return;
+    this.ctx.mutate((s) => {
+      s.view.layout =
+        s.view.layout.mode === 'multi'
+          ? {
+              mode: 'single',
+              focus: s.view.layout.editor
+                ? 'editor'
+                : s.view.layout.viewer
+                  ? 'viewer'
+                  : 'customizer',
+            }
+          : {
+              mode: 'multi',
+              editor: s.view.layout.focus === 'editor',
+              viewer: s.view.layout.focus === 'viewer',
+              customizer: s.view.layout.focus === 'customizer',
+            };
+    });
+  }
+
+  changeSingleVisibility(focus: SingleLayoutComponentId) {
+    this.ctx.mutate((s) => {
+      if (s.view.layout.mode !== 'single') throw new Error('Wrong mode');
+      s.view.layout.focus = focus;
+      if (focus !== 'editor') {
+        s.view.logs = false;
+      }
+    });
+  }
+
+  changeMultiVisibility(target: MultiLayoutComponentId, visible: boolean) {
+    this.ctx.mutate((s) => {
+      if (s.view.layout.mode !== 'multi') throw new Error('Wrong mode');
+      s.view.layout[target] = visible;
+      if (
+        (s.view.layout.customizer ? 1 : 0) +
+          (s.view.layout.editor ? 1 : 0) +
+          (s.view.layout.viewer ? 1 : 0) ==
+        0
+      ) {
+        // Select at least one panel
+        s.view.layout[target] = !visible;
+        if (target === 'editor' && !visible) {
+          s.view.logs = false;
+        }
+      }
+    });
+  }
+}


### PR DESCRIPTION
Final slice of the #59 decomposition — **Closes #59.**

## What
Moves the view-layout methods (`logsVisible`, `isComponentFullyVisible`, `changeLayout`, `changeSingleVisibility`, `changeMultiVisibility`) into a **`LayoutController`** behind the shared `ServiceContext`. Pure view-state transitions, no compile/persistence/DOM coupling. Model keeps the public methods as one-line delegations. (`setFormats`/`setVar` stay on Model — they touch params and trigger a render.)

## #59 outcome
Model's heavy responsibilities now live in focused, independently-tested, **DOM-free** services:
- `ProjectStore` (#57) — project file ops
- `WebHostAdapter` (#90) — DOM/window side effects
- `ExportService` (#103) — export orchestration
- `CompileCoordinator` (#104) — the compile lifecycle
- `LayoutController` (this PR) — view layout

Model is a **376-line façade** (from ~770), holding the state-mutation funnel (`mutate`/`setState`), persistence scheduling, the source-revision bump, and file-op orchestration — the things that genuinely belong to the central controller. This satisfies #59's criteria: responsibilities in named testable services, no direct DOM access from domain/service code, and Model reduced to a thin façade.

## Safety
- The unchanged `model.test.ts` oracle passes; new `layout-controller.test.ts` covers the mode/visibility/logs transitions directly (driven through the real deep-mutate).
- `npm run verify` green; 357 unit + 20 assembly tests pass.

Closes #59