### PR TITLE
ci(lint): enforce architectural import boundaries

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -32,6 +32,59 @@ export default tseslint.config(
     },
   },
 
+  // Architectural import boundaries (#67). The domain/engine layer must stay
+  // free of UI, Monaco, and Three.js so it remains portable and testable; the
+  // viewer must not pull in the editor/Monaco. src/language is intentionally
+  // excluded — it is the Monaco language-integration layer.
+  {
+    files: ['src/state/**/*.ts', 'src/runner/**/*.ts', 'src/fs/**/*.ts', 'src/embed/**/*.ts'],
+    ignores: ['**/__tests__/**', '**/*.test.ts'],
+    rules: {
+      'no-restricted-imports': [
+        'error',
+        {
+          patterns: [
+            {
+              group: ['**/components/**'],
+              message: 'Domain/engine code must not import UI components.',
+            },
+            {
+              group: ['monaco-editor', 'monaco-editor/**'],
+              message: 'Domain/engine code must not import Monaco.',
+            },
+            {
+              group: ['three', 'three/**'],
+              message: 'Domain/engine code must not import Three.js.',
+            },
+          ],
+        },
+      ],
+    },
+  },
+
+  // The viewer must not depend on the editor or Monaco (keeps it a clean,
+  // independently-loadable surface — see the boot split in #68).
+  {
+    files: [
+      'src/components/elements/osc-geometry-viewer.ts',
+      'src/components/elements/osc-viewer-panel.ts',
+      'src/components/viewer/**/*.ts',
+    ],
+    rules: {
+      'no-restricted-imports': [
+        'error',
+        {
+          patterns: [
+            {
+              group: ['monaco-editor', 'monaco-editor/**', '**/osc-editor-panel*'],
+              message: 'The viewer must not import the editor or Monaco.',
+            },
+          ],
+        },
+      ],
+    },
+  },
+
   // JavaScript/ESM rules applied to Node scripts and root JS config files
   {
     files: ['scripts/**/*.mjs', '*.js'],


### PR DESCRIPTION
The import-boundary half of #67. Config-only — no code changes.

## What
`no-restricted-imports` rules:
- **Domain/engine** (`src/state`, `src/runner`, `src/fs`, `src/embed`) may not import `**/components/**`, `monaco-editor`, or `three`.
- **Viewer** (`osc-geometry-viewer`, `osc-viewer-panel`, `src/components/viewer/**`) may not import Monaco or the editor panel.
- `src/language` is excluded — it's the Monaco language-integration layer.

## Why now / why clean
These boundaries **already hold** after the Model decomposition (#59, which moved all DOM/compile concerns into services) and the FS-interface work (#62-B). So this just locks the architecture in so it can't silently regress — lint passes with zero violations today.

## Verification
- `npm run lint` clean on the current tree.
- Enforcement proven: injecting `import 'three'` + a component import into a `src/state` file is rejected with the boundary-specific messages; reverting restores a clean lint.

Refs #67 — the remaining half (forbid `window`/`document` in domain) needs ~16 small refactors first and follows in a separate PR.