### PR TITLE
ci(lint): forbid window/document/navigator in the compile/state engine

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -32,6 +32,42 @@ export default tseslint.config(
     },
   },
 
+  // The compile/state engine must not reach the DOM directly (#67). Browser
+  // side effects go through the host adapter; URL/viewport reads live in the
+  // explicit boundary modules excluded below (the adapters), keeping the engine
+  // portable and unit-testable without a DOM.
+  {
+    files: ['src/state/**/*.ts', 'src/runner/**/*.ts'],
+    ignores: [
+      '**/__tests__/**',
+      '**/*.test.ts',
+      'src/state/web-host-adapter.ts', // sanctioned DOM/window adapter (#90)
+      'src/state/fragment-state.ts', // URL <-> state adapter
+      'src/state/url-mode.ts', // URL-mode parsing/resolution adapter
+      'src/state/initial-state.ts', // viewport-derived layout defaults
+    ],
+    rules: {
+      'no-restricted-globals': [
+        'error',
+        {
+          name: 'window',
+          message:
+            'The compile/state engine must not touch window — route DOM/window access through the host adapter or a boundary module.',
+        },
+        {
+          name: 'document',
+          message:
+            'The compile/state engine must not touch document — route DOM access through the host adapter or a boundary module.',
+        },
+        {
+          name: 'navigator',
+          message:
+            'The compile/state engine must not touch navigator — route platform reads through the host adapter or a boundary module.',
+        },
+      ],
+    },
+  },
+
   // Architectural import boundaries (#67). The domain/engine layer must stay
   // free of UI, Monaco, and Three.js so it remains portable and testable; the
   // viewer must not pull in the editor/Monaco. src/language is intentionally


### PR DESCRIPTION
Completes #67 (the window/document half) — **Closes #67**.

## What
A `no-restricted-globals` rule forbidding `window`/`document`/`navigator` in the compile/state **engine** — `src/state/**` (minus the boundary adapters) and `src/runner/**`. The engine is already DOM-free after the host-adapter (#90) and Model decomposition (#59) work, so this locks it in.

**Explicitly excluded as the sanctioned browser-boundary adapter layer** (the same pattern as `web-host-adapter` being the DOM adapter):
- `web-host-adapter.ts` — DOM/window side effects (#90)
- `fragment-state.ts` — URL ⇄ state serialization
- `url-mode.ts` — URL-mode parsing/resolution
- `initial-state.ts` — viewport-derived default layout

Fully injecting `window.location`/`matchMedia` into those URL/viewport adapters was considered and **deliberately not done**: it's high churn through the deploy-sensitive fragment-state code (just hardened in #56) for a purity-only gain, and they are legitimately the browser boundary. They stay narrow and documented rather than threading browser context through every signature.

## #67 status
- **Import boundaries** — enforced (#106): domain ⊥ UI/Monaco/Three; viewer ⊥ editor.
- **DOM-in-engine** — enforced (this PR).
- **Core coverage thresholds** — done (#96).

## Verification
- `npm run lint` clean today.
- Enforcement proven: an injected `document` access in `model.ts` is rejected with the boundary message; reverting restores clean.

Closes #67