### PR TITLE
refactor(fs): own per-thread library-mount state in a LibraryMounter

### DIFF
--- a/src/fs/__tests__/library-mounter.test.ts
+++ b/src/fs/__tests__/library-mounter.test.ts
@@ -1,0 +1,98 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+// Mock the BrowserFS + asset boundary so the mounter can be exercised in
+// isolation, with no real filesystem or network (criterion 3 of #62).
+vi.mock('../../runtime/browserfs-runtime.ts', () => ({
+  getBrowserFS: () => ({
+    FileSystem: {
+      // createBFSBackend('ZipFS', …) resolves to this fake backend.
+      ZipFS: { Create: (_opts: unknown, cb: (e: unknown, i: unknown) => void) => cb(null, {}) },
+    },
+    BFSRequire: () => ({ Buffer: { from: (b: unknown) => b } }),
+  }),
+}));
+vi.mock('../../runtime/asset-urls.ts', () => ({
+  resolveRuntimeAssetUrl: (s: string) => `/${s}`,
+}));
+vi.mock('../../runtime/fetch-asset.ts', () => ({
+  fetchAssetBytes: vi.fn(async () => new Uint8Array([1])),
+}));
+vi.mock('../zip-archives.generated.ts', () => ({
+  zipArchives: [
+    { name: 'demo', zipPath: 'libraries/demo.zip', mountPath: '/libraries/demo' },
+    { name: 'extra', zipPath: 'libraries/extra.zip', mountPath: '/libraries/extra' },
+  ],
+}));
+
+import { fetchAssetBytes } from '../../runtime/fetch-asset.ts';
+import { LibraryMounter } from '../filesystem.ts';
+
+const mockFetch = fetchAssetBytes as ReturnType<typeof vi.fn>;
+const fakeRoot = () => ({ mount: vi.fn() });
+
+describe('LibraryMounter (#62 Slice D)', () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it('mounts a library referenced via a use<>/include<> directive', async () => {
+    const root = fakeRoot();
+    const mounted = await new LibraryMounter(root).mountDemandLibraries(['use <demo/foo.scad>']);
+    expect(mounted).toEqual(['demo']);
+    expect(root.mount).toHaveBeenCalledTimes(1);
+    expect(root.mount).toHaveBeenCalledWith('/libraries/demo', expect.anything());
+  });
+
+  it('does not re-fetch or re-mount an already-mounted library (instance cache)', async () => {
+    const root = fakeRoot();
+    const m = new LibraryMounter(root);
+    await m.mountDemandLibraries(['use <demo>']);
+    await m.mountDemandLibraries(['use <demo>']);
+    expect(root.mount).toHaveBeenCalledTimes(1);
+    expect(mockFetch).toHaveBeenCalledTimes(1);
+  });
+
+  it('dedupes concurrent mounts of the same library to one fetch + mount', async () => {
+    const root = fakeRoot();
+    const m = new LibraryMounter(root);
+    await Promise.all([
+      m.mountDemandLibraries(['use <demo>']),
+      m.mountDemandLibraries(['include <demo>']),
+    ]);
+    expect(mockFetch).toHaveBeenCalledTimes(1);
+    expect(root.mount).toHaveBeenCalledTimes(1);
+  });
+
+  it('force-mounts extraNames and skips unknown libraries silently', async () => {
+    const root = fakeRoot();
+    const mounted = await new LibraryMounter(root).mountDemandLibraries(['use <nope>'], ['extra']);
+    expect(mounted).toEqual(['extra']);
+    expect(root.mount).toHaveBeenCalledTimes(1);
+    expect(root.mount).toHaveBeenCalledWith('/libraries/extra', expect.anything());
+  });
+
+  it('preloadAll mounts every registered archive', async () => {
+    const root = fakeRoot();
+    await new LibraryMounter(root).preloadAll();
+    expect(root.mount).toHaveBeenCalledTimes(2);
+  });
+
+  it('treats an "already taken" mount (racing thread) as success', async () => {
+    const root = {
+      mount: vi.fn(() => {
+        throw new Error('Mount point /libraries/demo is already taken');
+      }),
+    };
+    const mounted = await new LibraryMounter(root).mountDemandLibraries(['use <demo>']);
+    expect(mounted).toEqual(['demo']);
+  });
+
+  it('rethrows a non-"already taken" mount error', async () => {
+    const root = {
+      mount: vi.fn(() => {
+        throw new Error('disk full');
+      }),
+    };
+    await expect(new LibraryMounter(root).mountDemandLibraries(['use <demo>'])).rejects.toThrow(
+      'disk full',
+    );
+  });
+});

--- a/src/fs/filesystem.ts
+++ b/src/fs/filesystem.ts
@@ -45,9 +45,16 @@ function createBFSBackend(fsName: string, options?: Record<string, unknown>): Pr
 // Canonical mount layout + IndexedDB persistence
 // ---------------------------------------------------------------------------
 
-// Module-level reference to the root MountableFileSystem for dynamic mounting
-// eslint-disable-next-line @typescript-eslint/no-explicit-any
-let _rootMFS: any = null;
+/**
+ * The filesystem owned by a single thread: the Node-compat FS API plus the
+ * library mounter that holds this thread's mount state. BrowserFS's `install`
+ * is an irreducibly per-thread global, so there is one of these per thread
+ * (main and the OpenSCAD worker each create their own).
+ */
+export interface EditorFs {
+  fs: FS;
+  libraries: LibraryMounter;
+}
 
 /**
  * Initialises BrowserFS with the canonical four-partition VFS:
@@ -56,13 +63,14 @@ let _rootMFS: any = null;
  *   /tmp       — per-compile scratch space (InMemory, discarded per job)
  *   /fonts     — font archive (ZipFS from fonts.zip, mounted once at init)
  *
- * Returns the Node-compat FS API (`BFSRequire('fs')`).
+ * Returns the Node-compat FS API plus a LibraryMounter that owns this thread's
+ * mount state (no module-level singletons).
  */
 export async function createEditorFS({
   allowPersistence,
 }: {
   allowPersistence: boolean;
-}): Promise<FS> {
+}): Promise<EditorFs> {
   const browserFS = getBrowserFS();
   // Fonts are always pre-loaded — needed for any text() call in OpenSCAD
   const fontsBuf = await fetchAssetBytes(resolveRuntimeAssetUrl('libraries/fonts.zip'));
@@ -78,7 +86,7 @@ export async function createEditorFS({
   const libsFS = await createBFSBackend('InMemory');
   const tmpFS = await createBFSBackend('InMemory');
 
-  _rootMFS = await createBFSBackend('MountableFileSystem', {
+  const rootMFS = await createBFSBackend('MountableFileSystem', {
     '/': rootFS,
     '/home': homeFS,
     '/libraries': libsFS,
@@ -88,7 +96,7 @@ export async function createEditorFS({
 
   const ctx = typeof window === 'object' ? window : self;
   browserFS.install(ctx);
-  await browserFS.initialize(_rootMFS);
+  await browserFS.initialize(rootMFS);
 
   // storage budget warning for standalone mode
   if (allowPersistence && 'storage' in navigator) {
@@ -98,7 +106,7 @@ export async function createEditorFS({
     }
   }
 
-  return browserFS.BFSRequire('fs');
+  return { fs: browserFS.BFSRequire('fs'), libraries: new LibraryMounter(rootMFS) };
 }
 
 // ---------------------------------------------------------------------------
@@ -117,73 +125,77 @@ export function extractLibraryNames(source: string): string[] {
   return [...names];
 }
 
-// Per-thread cache of already-mounted library ZIPs
-const mountedLibraryZips = new Set<string>();
-const mountingLibraryZips = new Map<string, Promise<void>>();
-
 /**
- * Fetches and mounts a single library ZIP into BrowserFS's /libraries partition.
- * No-op if already mounted (session cache). Throws if BrowserFS is not yet initialised.
+ * Owns one thread's library-mount state: the root MountableFileSystem to mount
+ * into, plus the set of already-mounted ZIPs and the in-flight mount promises
+ * (which dedupe concurrent requests). Instance-owned and unit-testable in
+ * isolation — created by createEditorFS and held by the thread (main or worker)
+ * for its lifetime so the cache persists across compiles.
  */
-async function fetchAndMountLibrary(name: string): Promise<void> {
-  if (mountedLibraryZips.has(name)) return;
-  const inFlight = mountingLibraryZips.get(name);
-  if (inFlight) return inFlight;
+export class LibraryMounter {
+  private readonly mounted = new Set<string>();
+  private readonly mounting = new Map<string, Promise<void>>();
 
-  const mountPromise = (async () => {
-    const archive = zipArchives.find((a) => a.name === name);
-    if (!archive) return; // unknown library — skip silently
-    if (!_rootMFS)
-      throw new Error('[filesystem] createEditorFS() must be called before mountDemandLibraries()');
-    const browserFS = getBrowserFS();
-    const buf = await fetchAssetBytes(resolveRuntimeAssetUrl(archive.zipPath));
-    const zipFS = await createBFSBackend('ZipFS', {
-      zipData: browserFS.BFSRequire('buffer').Buffer.from(buf),
-    });
-    if (mountedLibraryZips.has(name)) return;
-    try {
-      _rootMFS.mount(archive.mountPath, zipFS);
-    } catch (error) {
-      const message = error instanceof Error ? error.message : String(error);
-      if (!message.includes('Mount point') || !message.includes('already taken')) {
-        throw error;
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  constructor(private readonly rootMFS: any) {}
+
+  /**
+   * Fetches and mounts a single library ZIP into the /libraries partition.
+   * No-op if already mounted (session cache); concurrent calls share one mount.
+   */
+  private async fetchAndMount(name: string): Promise<void> {
+    if (this.mounted.has(name)) return;
+    const inFlight = this.mounting.get(name);
+    if (inFlight) return inFlight;
+
+    const mountPromise = (async () => {
+      const archive = zipArchives.find((a) => a.name === name);
+      if (!archive) return; // unknown library — skip silently
+      const browserFS = getBrowserFS();
+      const buf = await fetchAssetBytes(resolveRuntimeAssetUrl(archive.zipPath));
+      const zipFS = await createBFSBackend('ZipFS', {
+        zipData: browserFS.BFSRequire('buffer').Buffer.from(buf),
+      });
+      if (this.mounted.has(name)) return;
+      try {
+        this.rootMFS.mount(archive.mountPath, zipFS);
+      } catch (error) {
+        const message = error instanceof Error ? error.message : String(error);
+        if (!message.includes('Mount point') || !message.includes('already taken')) {
+          throw error;
+        }
       }
+      this.mounted.add(name);
+    })();
+
+    this.mounting.set(name, mountPromise);
+    try {
+      await mountPromise;
+    } finally {
+      this.mounting.delete(name);
     }
-    mountedLibraryZips.add(name);
-  })();
-
-  mountingLibraryZips.set(name, mountPromise);
-  try {
-    await mountPromise;
-  } finally {
-    mountingLibraryZips.delete(name);
   }
-}
 
-/**
- * Parses library names from SCAD source texts, fetches and mounts only those
- * referenced. `extraNames` allows the caller to force-mount additional libraries
- * (e.g. when the active source path itself lives inside a library directory).
- * Returns the resolved set of mounted library names.
- */
-export async function mountDemandLibraries(
-  sourceTexts: string[],
-  extraNames: string[] = [],
-): Promise<string[]> {
-  const needed = [...new Set([...sourceTexts.flatMap(extractLibraryNames), ...extraNames])];
-  await Promise.all(needed.map(fetchAndMountLibrary));
-  return needed.filter((n) => mountedLibraryZips.has(n));
-}
+  /**
+   * Parses library names from SCAD source texts, fetches and mounts only those
+   * referenced. `extraNames` force-mounts additional libraries (e.g. when the
+   * active source path itself lives inside a library directory). Returns the
+   * resolved set of mounted library names.
+   */
+  async mountDemandLibraries(sourceTexts: string[], extraNames: string[] = []): Promise<string[]> {
+    const needed = [...new Set([...sourceTexts.flatMap(extractLibraryNames), ...extraNames])];
+    await Promise.all(needed.map((n) => this.fetchAndMount(n)));
+    return needed.filter((n) => this.mounted.has(n));
+  }
 
-/**
- * Eagerly mounts all library archives on the main thread so the full editor UI
- * can browse and complete against the entire /libraries tree.
- *
- * This is intentionally only used by editor mode. Embed/customizer shells keep
- * using worker-side demand loading.
- */
-export async function preloadEditorLibraries(): Promise<void> {
-  await Promise.all(zipArchives.map((a) => fetchAndMountLibrary(a.name)));
+  /**
+   * Eagerly mounts all library archives so the full editor UI can browse and
+   * complete against the entire /libraries tree. Used by editor mode only;
+   * embed/customizer shells keep using worker-side demand loading.
+   */
+  async preloadAll(): Promise<void> {
+    await Promise.all(zipArchives.map((a) => this.fetchAndMount(a.name)));
+  }
 }
 
 // ---------------------------------------------------------------------------

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,6 +1,6 @@
 // Portions of this file are Copyright 2021 Google LLC, and licensed under GPL2+. See COPYING.
 
-import { createEditorFS, preloadEditorLibraries } from './fs/filesystem.ts';
+import { createEditorFS } from './fs/filesystem.ts';
 import {
   getBootstrapPrefetchSpecifiers,
   injectBootstrapPrefetchHints,
@@ -87,14 +87,14 @@ window.addEventListener('load', async () => {
   await ensureBrowserFSLoaded();
 
   markPerf('osc:main-fs-init-start');
-  const fs = await createEditorFS({ allowPersistence: isInStandaloneMode() });
+  const { fs, libraries } = await createEditorFS({ allowPersistence: isInStandaloneMode() });
   markPerf('osc:main-fs-init-end');
   measurePerf('osc:main-fs-init', 'osc:main-fs-init-start', 'osc:main-fs-init-end');
   setFS(fs);
 
   if (shouldPreloadEditorLibraries(urlModeResult.mode)) {
     markPerf('osc:libraries-preload-start');
-    await preloadEditorLibraries();
+    await libraries.preloadAll();
     markPerf('osc:libraries-preload-end');
     measurePerf(
       'osc:libraries-preload',

--- a/src/runner/openscad-worker.ts
+++ b/src/runner/openscad-worker.ts
@@ -2,7 +2,7 @@
 
 /// <reference lib="webworker" />
 
-import { createEditorFS, mountDemandLibraries, symlinkLibraries } from '../fs/filesystem.ts';
+import { createEditorFS, symlinkLibraries, type EditorFs } from '../fs/filesystem.ts';
 import { markPerf, measurePerf } from '../perf/runtime-performance.ts';
 import { ensureWorkerBrowserFSLoaded } from '../runtime/browserfs-runtime.ts';
 import { createRuntime, OpenSCADRuntime } from './openscad-runtime.ts';
@@ -52,9 +52,10 @@ function createJobRuntime(): Promise<OpenSCADRuntime> {
   });
 }
 
-// BrowserFS is initialized once per worker runtime.
+// BrowserFS is initialized once per worker runtime; this worker owns its
+// LibraryMounter for its lifetime so the mount cache persists across jobs.
 // The per-instance WASM FS mounts (mkdir + mount + symlinks) are re-done for every fresh WASM instance.
-let editorFSInitialized = false;
+let editorFs: EditorFs | null = null;
 
 /**
  * Mounts the BrowserFS canonical partitions into the given WASM FS instance:
@@ -109,14 +110,13 @@ self.addEventListener('message', async (e: MessageEvent<WorkerRequest>) => {
       // Demand-load only the libraries referenced in the source texts
       let libraryNames: string[] = [];
       if (mountArchives) {
-        if (!editorFSInitialized) {
+        if (!editorFs) {
           markPerf('osc:worker-fs-init-start');
           const fsStart = performance.now();
-          await createEditorFS({ allowPersistence: false });
+          editorFs = await createEditorFS({ allowPersistence: false });
           markPerf('osc:worker-fs-init-end');
           perf.workerFsInitMillis = performance.now() - fsStart;
           measurePerf('osc:worker-fs-init', 'osc:worker-fs-init-start', 'osc:worker-fs-init-end');
-          editorFSInitialized = true;
         }
         const sourceTexts = sources.map((s) => s.content).filter((c): c is string => c != null);
         // Also ensure the library is mounted if the active source path is inside /libraries/<name>/
@@ -126,7 +126,7 @@ self.addEventListener('message', async (e: MessageEvent<WorkerRequest>) => {
           .map((p) => p.split('/')[2])
           .filter(Boolean);
         const libraryMountStart = performance.now();
-        libraryNames = await mountDemandLibraries(sourceTexts, extraNames);
+        libraryNames = await editorFs.libraries.mountDemandLibraries(sourceTexts, extraNames);
         perf.workerLibraryMountMillis = performance.now() - libraryMountStart;
       }
 


### PR DESCRIPTION
Slice D of #62 — **Closes #62.** Removes the last module-level FS singletons.

## What
`filesystem.ts` no longer has module globals `_rootMFS`, `mountedLibraryZips`, `mountingLibraryZips`. Instead `createEditorFS` returns `{ fs, libraries: LibraryMounter }`, where `LibraryMounter` owns the root MountableFileSystem + the mount caches and exposes `mountDemandLibraries`/`preloadAll`. Each thread (main + the OpenSCAD worker) creates and holds its own mounter for its lifetime, so the cache still persists across compiles. `browserFS.install/initialize` stay in `createEditorFS` as the one sanctioned per-thread global; `extractLibraryNames`/`symlinkLibraries` remain stateless.

Satisfies #62 criterion 3 (*"FS state is instance-owned and unit-testable in isolation"*); criteria 1 (#97) and 2 (#91) were already done.

## Why this was the careful one
This touches the live worker/WASM library-mount path, which isn't fully provable by deterministic tests. Mitigations:
- **Mount logic moved verbatim** (cache early-return, in-flight dedup, unknown-archive skip, the "already taken" swallow) — adversarial line-by-line review confirmed identical behavior and correct worker cache-persistence.
- **New `LibraryMounter` unit tests** (faked BrowserFS/asset boundary) cover the instance cache, concurrent dedup, force-mount, unknown-skip, and both error paths.
- **Full local e2e passes — including real library compiles** (`include <BOSL2/std.scad>`, `<NopSCADlib/...>`, and a `/libraries/` file load), which exercise exactly this worker mount path.
- Deploy-frozen constants untouched (IndexedDB `storeName: 'openscad-home'`, mount layout, `/home/state.json`).

## Verification
- `npm run verify` green (364 unit + 20 assembly); 26/26 e2e local; tsc + lint clean.
- Adversarial review: behavior-preserving, safe to auto-deploy, no required fixes.

Closes #62