### PR TITLE
fix(worker): serialize compile jobs and route output per-job

### DIFF
--- a/src/runner/__tests__/serial-queue.test.ts
+++ b/src/runner/__tests__/serial-queue.test.ts
@@ -1,0 +1,116 @@
+import { describe, expect, it } from 'vitest';
+
+import { createSerialQueue } from '../serial-queue.ts';
+
+const tick = () => new Promise<void>((r) => setTimeout(r, 0));
+const defer = () => {
+  let resolve!: () => void;
+  const promise = new Promise<void>((r) => (resolve = r));
+  return { promise, resolve };
+};
+
+describe('createSerialQueue', () => {
+  it('runs jobs one at a time — no two overlap (the worker concurrency fix, P0)', async () => {
+    let active = 0;
+    let maxActive = 0;
+    const order: number[] = [];
+    const q = createSerialQueue<number>(async (n) => {
+      active++;
+      maxActive = Math.max(maxActive, active);
+      await tick();
+      await tick();
+      order.push(n);
+      active--;
+    });
+
+    // Enqueue while the first is still in its async section — the bug scenario.
+    q.enqueue(1);
+    q.enqueue(2);
+    q.enqueue(3);
+
+    await tick();
+    await tick();
+    await tick();
+    await tick();
+    await tick();
+    await tick();
+
+    expect(maxActive).toBe(1); // never two jobs in flight at once
+    expect(order).toEqual([1, 2, 3]); // FIFO
+  });
+
+  it('does not start a later job until the active job settles', async () => {
+    const gate = defer();
+    const ran: string[] = [];
+    const q = createSerialQueue<string>(async (id) => {
+      ran.push(`start:${id}`);
+      if (id === 'a') await gate.promise;
+      ran.push(`end:${id}`);
+    });
+
+    q.enqueue('a');
+    q.enqueue('b');
+    await tick();
+
+    // 'a' is blocked on the gate; 'b' must not have started.
+    expect(ran).toEqual(['start:a']);
+
+    gate.resolve();
+    await tick();
+    await tick();
+    expect(ran).toEqual(['start:a', 'end:a', 'start:b', 'end:b']);
+  });
+
+  it('skips a still-queued job that is cancelled', async () => {
+    const gate = defer();
+    const ran: string[] = [];
+    const q = createSerialQueue<{ id: string }>(async (job) => {
+      ran.push(job.id);
+      if (job.id === 'a') await gate.promise;
+    });
+
+    q.enqueue({ id: 'a' }); // starts, blocks on gate
+    q.enqueue({ id: 'b' }); // queued
+    q.enqueue({ id: 'c' }); // queued
+    await tick();
+
+    q.cancel((job) => job.id === 'b'); // cancel while still queued
+    gate.resolve();
+    await tick();
+    await tick();
+
+    expect(ran).toEqual(['a', 'c']); // 'b' skipped
+  });
+
+  it('does not cancel the actively-running job', async () => {
+    const gate = defer();
+    const ran: string[] = [];
+    const q = createSerialQueue<{ id: string }>(async (job) => {
+      ran.push(`run:${job.id}`);
+      if (job.id === 'a') await gate.promise;
+    });
+
+    q.enqueue({ id: 'a' });
+    await tick();
+    q.cancel((job) => job.id === 'a'); // a is already active — cancel is a no-op
+    gate.resolve();
+    await tick();
+
+    expect(ran).toContain('run:a');
+  });
+
+  it('keeps draining after a job throws', async () => {
+    const ran: string[] = [];
+    const q = createSerialQueue<string>(async (id) => {
+      ran.push(id);
+      if (id === 'boom') throw new Error('job failed');
+    });
+
+    q.enqueue('boom');
+    q.enqueue('next');
+    await tick();
+    await tick();
+
+    expect(ran).toEqual(['boom', 'next']);
+  });
+});

--- a/src/runner/openscad-worker.ts
+++ b/src/runner/openscad-worker.ts
@@ -4,6 +4,7 @@
 
 import { createEditorFS, symlinkLibraries, type EditorFs } from '../fs/filesystem.ts';
 import { markPerf, measurePerf } from '../perf/runtime-performance.ts';
+import { createSerialQueue } from './serial-queue.ts';
 import { ensureWorkerBrowserFSLoaded } from '../runtime/browserfs-runtime.ts';
 import { createRuntime, OpenSCADRuntime } from './openscad-runtime.ts';
 import {
@@ -24,30 +25,25 @@ declare const self: DedicatedWorkerGlobalScope;
 // fixed-base (/openscad-web/) or relocatable (./).
 const appBaseUrl = new URL('../', import.meta.url).href;
 
-// WASM initializes exactly once per worker lifetime
-let currentJobId: string | null = null;
-// Points at the current job's mergedOutputs accumulator so print/printErr can push to it
-let currentMergedOutputs: MergedOutput[] | null = null;
-
 // NOTE: runtimePromise is NOT a singleton — Emscripten's callMain calls exit() internally,
 // setting Module.ABORT=true. A second callMain on the same instance throws
 // "program has already aborted!". We therefore create a fresh runtime per compile job.
 // The persistent-worker model still avoids worker-startup overhead; only the WASM
 // module instance is recreated. The compiled .wasm binary is cached by the browser's
 // WebAssembly module cache so subsequent instantiations are fast.
-function createJobRuntime(): Promise<OpenSCADRuntime> {
+//
+// print/printErr close over THIS job's id and output accumulator (no module
+// globals), so even if two jobs' setup overlapped their output could not cross —
+// and compile jobs are serialized by the queue below regardless.
+function createJobRuntime(jobId: string, mergedOutputs: MergedOutput[]): Promise<OpenSCADRuntime> {
   return createRuntime({
     print: (text: string) => {
-      if (currentJobId != null) {
-        self.postMessage({ type: 'stdout', id: currentJobId, text } satisfies CompileStdout);
-        currentMergedOutputs?.push({ stdout: text });
-      }
+      self.postMessage({ type: 'stdout', id: jobId, text } satisfies CompileStdout);
+      mergedOutputs.push({ stdout: text });
     },
     printErr: (text: string) => {
-      if (currentJobId != null) {
-        self.postMessage({ type: 'stderr', id: currentJobId, text } satisfies CompileStderr);
-        currentMergedOutputs?.push({ stderr: text });
-      }
+      self.postMessage({ type: 'stderr', id: jobId, text } satisfies CompileStderr);
+      mergedOutputs.push({ stderr: text });
     },
   });
 }
@@ -88,153 +84,156 @@ async function ensureArchivesMounted(rt: OpenSCADRuntime, libraryNames: string[]
   }
 }
 
-self.addEventListener('message', async (e: MessageEvent<WorkerRequest>) => {
-  const msg = e.data;
+// Compile jobs are serialized: the worker runs exactly one at a time. The async
+// setup of a job (FS init, library mount, WASM creation, source fetch) must not
+// interleave with another job's, or their output routing and one-time FS init
+// would race. A `cancel` drops a still-queued job; the actively-running
+// synchronous callMain cannot be interrupted (the host discards its result by id).
+const compileQueue = createSerialQueue<CompileRequest>((request) => runCompile(request));
 
+self.addEventListener('message', (e: MessageEvent<WorkerRequest>) => {
+  const msg = e.data;
   if (msg.type === 'cancel') {
-    // callMain is synchronous — true mid-execution cancel is not possible.
-    // The host discards the stale response by ID. Nothing to do here.
+    compileQueue.cancel((request) => request.id === msg.id);
     return;
   }
-
   if (msg.type === 'compile') {
-    const { id, sources, args, outputPaths, mountArchives, revision } = msg as CompileRequest;
-    currentJobId = id;
-    const mergedOutputs: MergedOutput[] = [];
-    currentMergedOutputs = mergedOutputs;
-    const start = performance.now();
-    const perf: CompilePerfStats = {};
-
-    try {
-      await ensureWorkerBrowserFSLoaded();
-      // Demand-load only the libraries referenced in the source texts
-      let libraryNames: string[] = [];
-      if (mountArchives) {
-        if (!editorFs) {
-          markPerf('osc:worker-fs-init-start');
-          const fsStart = performance.now();
-          editorFs = await createEditorFS({ allowPersistence: false });
-          markPerf('osc:worker-fs-init-end');
-          perf.workerFsInitMillis = performance.now() - fsStart;
-          measurePerf('osc:worker-fs-init', 'osc:worker-fs-init-start', 'osc:worker-fs-init-end');
-        }
-        const sourceTexts = sources.map((s) => s.content).filter((c): c is string => c != null);
-        // Also ensure the library is mounted if the active source path is inside /libraries/<name>/
-        const extraNames = sources
-          .map((s) => s.path)
-          .filter((p) => p.startsWith('/libraries/'))
-          .map((p) => p.split('/')[2])
-          .filter(Boolean);
-        const libraryMountStart = performance.now();
-        libraryNames = await editorFs.libraries.mountDemandLibraries(sourceTexts, extraNames);
-        perf.workerLibraryMountMillis = performance.now() - libraryMountStart;
-      }
-
-      markPerf('osc:wasm-init-start');
-      const wasmInitStart = performance.now();
-      const rt = await createJobRuntime();
-      markPerf('osc:wasm-init-end');
-      perf.workerWasmInitMillis = performance.now() - wasmInitStart;
-      measurePerf('osc:wasm-init', 'osc:wasm-init-start', 'osc:wasm-init-end');
-
-      if (mountArchives) {
-        await ensureArchivesMounted(rt, libraryNames);
-      }
-
-      // Fonts resolved from cwd/fonts (via /fonts mount point)
-      rt.FS.chdir('/');
-      rt.mkdir('/locale');
-
-      for (const source of sources) {
-        try {
-          // Files under /libraries/ are already accessible via the read-only ZipFS demand mount.
-          // Writing to them would fail (ZipFS is read-only), so we only verify existence.
-          const isReadOnlyMount =
-            source.path.startsWith('/libraries/') || source.path.startsWith('/fonts/');
-          if (isReadOnlyMount) {
-            // File is accessible via the demand-loaded ZipFS; no write needed.
-            // If somehow it's missing (unmounted lib), compilation will error naturally.
-          } else if (source.content == null && source.url == null) {
-            if (!rt.FS.isFile(source.path)) {
-              console.error(`File ${source.path} does not exist!`);
-            }
-          } else {
-            // eslint-disable-next-line @typescript-eslint/no-explicit-any
-            const content = await fetchSource(rt.FS, source as any, { baseUrl: appBaseUrl });
-            rt.writeFile(source.path, content);
-          }
-        } catch (err) {
-          console.trace(err);
-          throw new Error(`Error while trying to write ${source.path}: ${err}`);
-        }
-      }
-
-      // callMain wraps C++ exception formatting (see openscad-runtime.ts)
-      let exitCode: number;
-      try {
-        exitCode = rt.callMain(args);
-      } catch (e) {
-        if (e instanceof RangeError || (e instanceof Error && e.message?.includes('OOM'))) {
-          const elapsedMillis = performance.now() - start;
-          perf.workerJobMillis = elapsedMillis;
-          mergedOutputs.push({ error: 'Out of memory' });
-          self.postMessage({
-            type: 'error',
-            id,
-            message: 'Out of memory. The model is too large to compile in this browser.',
-            mergedOutputs,
-            elapsedMillis,
-            perf,
-            revision,
-          } satisfies CompileError);
-          return;
-        }
-        throw e;
-      }
-      const elapsedMillis = performance.now() - start;
-      perf.workerJobMillis = elapsedMillis;
-
-      const outputs: [string, Uint8Array][] = [];
-      if (exitCode === 0) {
-        for (const outPath of outputPaths ?? []) {
-          try {
-            outputs.push([outPath, rt.readFile(outPath)]);
-          } catch (err) {
-            console.trace(err);
-            throw new Error(`Failed to read output file ${outPath}: ${err}`);
-          }
-        }
-      }
-
-      self.postMessage({
-        type: 'result',
-        id,
-        exitCode,
-        outputs,
-        mergedOutputs,
-        elapsedMillis,
-        perf,
-        revision,
-      } satisfies CompileResult);
-    } catch (err) {
-      const elapsedMillis = performance.now() - start;
-      perf.workerJobMillis = elapsedMillis;
-      console.trace(err);
-      const errorMsg = `${err}`;
-      mergedOutputs.push({ error: errorMsg });
-      self.postMessage({
-        type: 'error',
-        id,
-        message: errorMsg,
-        mergedOutputs,
-        elapsedMillis,
-        perf,
-        revision,
-      } satisfies CompileError);
-    } finally {
-      currentJobId = null;
-      currentMergedOutputs = null;
-      // No cleanTmp needed — the WASM instance is discarded after each job
-    }
+    compileQueue.enqueue(msg);
   }
 });
+
+async function runCompile(msg: CompileRequest): Promise<void> {
+  const { id, sources, args, outputPaths, mountArchives, revision } = msg;
+  const mergedOutputs: MergedOutput[] = [];
+  const start = performance.now();
+  const perf: CompilePerfStats = {};
+
+  try {
+    await ensureWorkerBrowserFSLoaded();
+    // Demand-load only the libraries referenced in the source texts
+    let libraryNames: string[] = [];
+    if (mountArchives) {
+      if (!editorFs) {
+        markPerf('osc:worker-fs-init-start');
+        const fsStart = performance.now();
+        editorFs = await createEditorFS({ allowPersistence: false });
+        markPerf('osc:worker-fs-init-end');
+        perf.workerFsInitMillis = performance.now() - fsStart;
+        measurePerf('osc:worker-fs-init', 'osc:worker-fs-init-start', 'osc:worker-fs-init-end');
+      }
+      const sourceTexts = sources.map((s) => s.content).filter((c): c is string => c != null);
+      // Also ensure the library is mounted if the active source path is inside /libraries/<name>/
+      const extraNames = sources
+        .map((s) => s.path)
+        .filter((p) => p.startsWith('/libraries/'))
+        .map((p) => p.split('/')[2])
+        .filter(Boolean);
+      const libraryMountStart = performance.now();
+      libraryNames = await editorFs.libraries.mountDemandLibraries(sourceTexts, extraNames);
+      perf.workerLibraryMountMillis = performance.now() - libraryMountStart;
+    }
+
+    markPerf('osc:wasm-init-start');
+    const wasmInitStart = performance.now();
+    const rt = await createJobRuntime(id, mergedOutputs);
+    markPerf('osc:wasm-init-end');
+    perf.workerWasmInitMillis = performance.now() - wasmInitStart;
+    measurePerf('osc:wasm-init', 'osc:wasm-init-start', 'osc:wasm-init-end');
+
+    if (mountArchives) {
+      await ensureArchivesMounted(rt, libraryNames);
+    }
+
+    // Fonts resolved from cwd/fonts (via /fonts mount point)
+    rt.FS.chdir('/');
+    rt.mkdir('/locale');
+
+    for (const source of sources) {
+      try {
+        // Files under /libraries/ are already accessible via the read-only ZipFS demand mount.
+        // Writing to them would fail (ZipFS is read-only), so we only verify existence.
+        const isReadOnlyMount =
+          source.path.startsWith('/libraries/') || source.path.startsWith('/fonts/');
+        if (isReadOnlyMount) {
+          // File is accessible via the demand-loaded ZipFS; no write needed.
+          // If somehow it's missing (unmounted lib), compilation will error naturally.
+        } else if (source.content == null && source.url == null) {
+          if (!rt.FS.isFile(source.path)) {
+            console.error(`File ${source.path} does not exist!`);
+          }
+        } else {
+          // eslint-disable-next-line @typescript-eslint/no-explicit-any
+          const content = await fetchSource(rt.FS, source as any, { baseUrl: appBaseUrl });
+          rt.writeFile(source.path, content);
+        }
+      } catch (err) {
+        console.trace(err);
+        throw new Error(`Error while trying to write ${source.path}: ${err}`);
+      }
+    }
+
+    // callMain wraps C++ exception formatting (see openscad-runtime.ts)
+    let exitCode: number;
+    try {
+      exitCode = rt.callMain(args);
+    } catch (e) {
+      if (e instanceof RangeError || (e instanceof Error && e.message?.includes('OOM'))) {
+        const elapsedMillis = performance.now() - start;
+        perf.workerJobMillis = elapsedMillis;
+        mergedOutputs.push({ error: 'Out of memory' });
+        self.postMessage({
+          type: 'error',
+          id,
+          message: 'Out of memory. The model is too large to compile in this browser.',
+          mergedOutputs,
+          elapsedMillis,
+          perf,
+          revision,
+        } satisfies CompileError);
+        return;
+      }
+      throw e;
+    }
+    const elapsedMillis = performance.now() - start;
+    perf.workerJobMillis = elapsedMillis;
+
+    const outputs: [string, Uint8Array][] = [];
+    if (exitCode === 0) {
+      for (const outPath of outputPaths ?? []) {
+        try {
+          outputs.push([outPath, rt.readFile(outPath)]);
+        } catch (err) {
+          console.trace(err);
+          throw new Error(`Failed to read output file ${outPath}: ${err}`);
+        }
+      }
+    }
+
+    self.postMessage({
+      type: 'result',
+      id,
+      exitCode,
+      outputs,
+      mergedOutputs,
+      elapsedMillis,
+      perf,
+      revision,
+    } satisfies CompileResult);
+  } catch (err) {
+    const elapsedMillis = performance.now() - start;
+    perf.workerJobMillis = elapsedMillis;
+    console.trace(err);
+    const errorMsg = `${err}`;
+    mergedOutputs.push({ error: errorMsg });
+    self.postMessage({
+      type: 'error',
+      id,
+      message: errorMsg,
+      mergedOutputs,
+      elapsedMillis,
+      perf,
+      revision,
+    } satisfies CompileError);
+  }
+  // No cleanTmp needed — the WASM instance is discarded after each job.
+}

--- a/src/runner/serial-queue.ts
+++ b/src/runner/serial-queue.ts
@@ -1,0 +1,49 @@
+/**
+ * A FIFO queue that runs one async job at a time. Enqueued items never overlap:
+ * the next job starts only after the current one settles, so a job's async setup
+ * cannot interleave with another's. Used by the OpenSCAD worker to serialize
+ * compiles (their FS/WASM setup and output routing must not race).
+ */
+export interface SerialQueue<T> {
+  /** Append an item; it runs after all earlier non-cancelled items. */
+  enqueue(item: T): void;
+  /** Mark every still-queued item matching the predicate as cancelled (it is
+   *  skipped when dequeued). An item already running cannot be cancelled. */
+  cancel(matches: (item: T) => boolean): void;
+}
+
+export function createSerialQueue<T>(run: (item: T) => Promise<void>): SerialQueue<T> {
+  const queue: { item: T; cancelled: boolean }[] = [];
+  let draining = false;
+
+  async function drain(): Promise<void> {
+    if (draining) return;
+    draining = true;
+    try {
+      let entry: { item: T; cancelled: boolean } | undefined;
+      while ((entry = queue.shift())) {
+        if (entry.cancelled) continue;
+        try {
+          await run(entry.item);
+        } catch {
+          // A failing job must not stall the queue; `run` is expected to report
+          // its own errors. Continue with the next item.
+        }
+      }
+    } finally {
+      draining = false;
+    }
+  }
+
+  return {
+    enqueue(item) {
+      queue.push({ item, cancelled: false });
+      void drain();
+    },
+    cancel(matches) {
+      for (const entry of queue) {
+        if (matches(entry.item)) entry.cancelled = true;
+      }
+    },
+  };
+}


### PR DESCRIPTION
**Audit P0** — the highest-severity finding from the fresh static audit. Verified as a real concurrency bug.

## The bug
The worker's `async` message handler had no queue/active-job guard and routed compile `stdout`/`stderr` through module globals `currentJobId`/`currentMergedOutputs`. During the several awaits before the synchronous `callMain` (FS init, library mount, WASM creation, source fetch), a second `compile` message could enter the same handler, overwrite the globals, and cross-attribute output between jobs — or both first-time requests could observe `editorFs === null` and double-initialize BrowserFS.

## The fix
- New `createSerialQueue` runs compiles **one at a time, FIFO** (new `serial-queue.ts`).
- Each job's `print`/`printErr` now **close over that job's `id` + `mergedOutputs`** (no globals) via `createJobRuntime(jobId, mergedOutputs)`.
- `cancel` marks a still-queued job cancelled (skipped when dequeued); an actively-running synchronous `callMain` can't be interrupted — and the host already rejects+removes the job locally on cancel, so there's **no hang**.
- `runCompile(msg)` holds the former handler body verbatim.

## Safety
- Adversarial review: **correct, behavior-preserving, safe to auto-deploy, no required fixes** — specifically confirmed (a) no host-hang from the new cancel semantics and (b) no queue-stranding in the enqueue/drain microtask interleaving.
- New serial-queue unit tests: no-overlap (`maxActive===1`), FIFO, cancel-skips-queued, active-not-cancellable, fault-tolerance.
- `npm run verify` green (369 unit + 20 assembly); **full e2e (26 tests, real compiles through the refactored worker) passes**.

Refs #69 (post-epic audit: P0)