### PR TITLE
fix(compile): recheck render staleness after data-url read; revoke leaked blob

### DIFF
--- a/src/state/services/__tests__/compile-coordinator.test.ts
+++ b/src/state/services/__tests__/compile-coordinator.test.ts
@@ -1,0 +1,119 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { CompileCoordinator } from '../compile-coordinator.ts';
+import type { ServiceContext } from '../service-context.ts';
+import type { State } from '../../app-state.ts';
+
+// render() is `factory(renderArgs)({ now })` → Promise<RenderOutput>; we drive the
+// promise it returns. readFileAsDataURL is the async artifact step whose await is
+// where a source change can sneak in — we control it to exercise the recheck.
+const renderImpl = vi.fn();
+const readFileAsDataURL = vi.fn();
+
+vi.mock('../../../runner/actions.ts', () => ({
+  render: (renderArgs: unknown) => (opts: unknown) => renderImpl(renderArgs, opts),
+  checkSyntax: vi.fn(),
+}));
+
+vi.mock('../../../utils.ts', async (importActual) => ({
+  ...(await importActual<typeof import('../../../utils.ts')>()),
+  readFileAsDataURL: (file: unknown) => readFileAsDataURL(file),
+}));
+
+function makeContext(revision: number) {
+  const state = {
+    params: {
+      sources: [{ kind: 'text', path: '/main.scad', content: 'cube();' }],
+      activePath: '/main.scad',
+      vars: {},
+      features: [],
+      exportFormat2D: 'svg',
+      backend: 'manifold',
+    },
+    is2D: false,
+    currentRunLogs: [],
+  } as unknown as State;
+
+  const host = {
+    createObjectURL: vi.fn(() => 'blob:fake-url'),
+    revokeObjectURL: vi.fn(),
+    playCompletionChime: vi.fn(),
+    baseUrl: () => 'http://localhost/',
+  };
+
+  let rev = revision;
+  const ctx: ServiceContext = {
+    getState: () => state,
+    mutate: (f) => {
+      f(state);
+      return true;
+    },
+    getSourceRevision: () => rev,
+    getActiveSource: () => 'cube();',
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    host: host as any,
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    fs: {} as any,
+  };
+
+  return { ctx, state, host, setRevision: (n: number) => (rev = n) };
+}
+
+function renderOutput(revision: number) {
+  return {
+    outFile: new File(['solid'], 'out.off', { type: 'text/plain' }),
+    logText: '',
+    markers: [],
+    elapsedMillis: 1,
+    revision,
+  };
+}
+
+describe('CompileCoordinator render staleness', () => {
+  beforeEach(() => {
+    renderImpl.mockReset();
+    readFileAsDataURL.mockReset();
+  });
+
+  it('commits the result and revokes nothing on the happy path', async () => {
+    const { ctx, state, host } = makeContext(1);
+    renderImpl.mockResolvedValue(renderOutput(1));
+    readFileAsDataURL.mockResolvedValue('data:text/plain;base64,c29saWQ=');
+
+    await new CompileCoordinator(ctx).render({ isPreview: false, now: true });
+
+    expect(state.output?.outFileURL).toBe('blob:fake-url');
+    expect(host.revokeObjectURL).not.toHaveBeenCalled();
+    expect(host.playCompletionChime).toHaveBeenCalledTimes(1);
+    expect(state.rendering).toBe(false);
+  });
+
+  it('drops a result gone stale during readFileAsDataURL and revokes the blob URL', async () => {
+    const { ctx, state, host, setRevision } = makeContext(1);
+    renderImpl.mockResolvedValue(renderOutput(1));
+    // The source changes while the data URL is being read: bump the revision
+    // mid-await so the recheck after readFileAsDataURL sees a newer revision.
+    readFileAsDataURL.mockImplementation(async () => {
+      setRevision(2);
+      return 'data:text/plain;base64,c29saWQ=';
+    });
+
+    await new CompileCoordinator(ctx).render({ isPreview: false, now: true });
+
+    expect(state.output).toBeUndefined();
+    expect(host.revokeObjectURL).toHaveBeenCalledWith('blob:fake-url');
+    expect(host.playCompletionChime).not.toHaveBeenCalled();
+    expect(state.rendering).toBe(false);
+  });
+
+  it('revokes the blob URL when readFileAsDataURL throws', async () => {
+    const { ctx, state, host } = makeContext(1);
+    renderImpl.mockResolvedValue(renderOutput(1));
+    readFileAsDataURL.mockRejectedValue(new Error('read failed'));
+
+    await new CompileCoordinator(ctx).render({ isPreview: false, now: true });
+
+    expect(state.output).toBeUndefined();
+    expect(host.revokeObjectURL).toHaveBeenCalledWith('blob:fake-url');
+  });
+});

--- a/src/state/services/compile-coordinator.ts
+++ b/src/state/services/compile-coordinator.ts
@@ -213,6 +213,9 @@ export class CompileCoordinator {
       backend: this.ctx.getState().params.backend,
       revision: this.ctx.getSourceRevision(),
     };
+    // Hoisted so the catch can revoke it if readFileAsDataURL throws after the
+    // blob URL was created (otherwise the object URL would leak).
+    let outFileURL: string | undefined;
     try {
       const output = await render(renderArgs)({ now });
       if (!isCurrent()) return; // a newer render/preview superseded this one
@@ -230,8 +233,20 @@ export class CompileCoordinator {
       } else {
         is2D = false;
       }
-      const outFileURL = this.ctx.host.createObjectURL(output.outFile);
+      outFileURL = this.ctx.host.createObjectURL(output.outFile);
       const displayFileURL = displayFile && (await readFileAsDataURL(displayFile));
+      // readFileAsDataURL is asynchronous; the sources may have changed while it
+      // ran. Re-check before committing so a stale artifact never lands in state,
+      // and revoke the blob URL we created if we bail.
+      if (!isCurrent()) {
+        this.ctx.host.revokeObjectURL(outFileURL);
+        return; // a newer render/preview superseded this one — it owns the spinner
+      }
+      if (output.revision !== undefined && output.revision !== this.ctx.getSourceRevision()) {
+        this.ctx.host.revokeObjectURL(outFileURL);
+        this.ctx.mutate((s) => setRendering(s, false));
+        return;
+      }
       this.ctx.mutate((s) => {
         setRendering(s, false);
         s.error = undefined;
@@ -251,7 +266,7 @@ export class CompileCoordinator {
         s.output = {
           isPreview: isPreview,
           outFile: output.outFile,
-          outFileURL,
+          outFileURL: outFileURL!, // assigned above before any path reaching here
           displayFile,
           displayFileURL,
           elapsedMillis: output.elapsedMillis,
@@ -264,6 +279,9 @@ export class CompileCoordinator {
         }
       });
     } catch (err) {
+      // If the blob URL was created before the failure (readFileAsDataURL threw),
+      // revoke it so it doesn't leak.
+      if (outFileURL) this.ctx.host.revokeObjectURL(outFileURL);
       if (!isCurrent()) return; // superseded — the newer call owns the spinner state
       this.ctx.mutate((s) => {
         setRendering(s, false);


### PR DESCRIPTION
## Audit P1 — render staleness after asynchronous artifact processing

The render success path in `CompileCoordinator.render` created a blob
object URL (`createObjectURL`), then `await readFileAsDataURL(...)` before
committing the artifact to state. Two defects:

1. **Stale commit:** no recheck of `isCurrent()` / source-revision after
   the `await`, so if the sources changed while the data URL was being
   read, a stale artifact could land in `s.output`.
2. **Blob URL leak:** the created object URL was unrevoked on an early
   return or on a throw from `readFileAsDataURL`.

### Fix
- Recheck `isCurrent()` and the source revision after `readFileAsDataURL`,
  mirroring the pre-await guards; revoke the blob URL and bail when stale.
- Hoist `outFileURL` so the `catch` revokes it if `readFileAsDataURL` throws.

### Tests
New `src/state/services/__tests__/compile-coordinator.test.ts` (3 cases):
happy-path commit (no revoke, chime plays); stale-during-data-url-read
(result dropped, blob revoked); read throws (blob revoked).

Full `npm run verify` green (lint, tsc, unit, assembly, build, budgets,
publish archive). Adversarial subagent review: no MUST-FIX.

Refs #69 (post-epic audit: P1 render staleness)