### PR TITLE
fix(sw): exclude wasm and library zips from precache; fix route order

### DIFF
--- a/scripts/__tests__/build-sw.test.mjs
+++ b/scripts/__tests__/build-sw.test.mjs
@@ -1,0 +1,57 @@
+// @vitest-environment node
+
+import { describe, expect, it } from 'vitest';
+
+import { buildWorkboxConfig } from '../build-sw.mjs';
+
+const config = buildWorkboxConfig({ distDir: '/tmp/dist', swDest: '/tmp/dist/sw.js' });
+
+describe('buildWorkboxConfig precache excludes', () => {
+  it('keeps the WASM binary and library zips out of the precache', () => {
+    expect(config.globIgnores).toContain('**/*.wasm');
+    expect(config.globIgnores).toContain('libraries/**');
+  });
+});
+
+describe('buildWorkboxConfig runtime route order', () => {
+  // The first route whose urlPattern matches wins. The large-asset CacheFirst
+  // rule must precede the broad same-origin StaleWhileRevalidate, or the latter
+  // would swallow .wasm / library requests and re-validate them every load.
+  const firstMatch = (url) =>
+    config.runtimeCaching.find((route) => route.urlPattern({ url })) ?? null;
+
+  it('routes the WASM binary through CacheFirst (large-assets)', () => {
+    const route = firstMatch(new URL('https://example.com/assets/openscad-abc.wasm'));
+    expect(route?.handler).toBe('CacheFirst');
+    expect(route?.options.cacheName).toBe('large-assets');
+  });
+
+  it('routes a library zip through CacheFirst (large-assets)', () => {
+    const route = firstMatch(new URL('https://example.com/libraries/BOSL2.zip'));
+    expect(route?.handler).toBe('CacheFirst');
+    expect(route?.options.cacheName).toBe('large-assets');
+  });
+
+  it('places the CacheFirst large-asset rule before the broad SWR rule', () => {
+    const cacheFirstIdx = config.runtimeCaching.findIndex((r) => r.handler === 'CacheFirst');
+    const swrIdx = config.runtimeCaching.findIndex((r) => r.handler === 'StaleWhileRevalidate');
+    expect(cacheFirstIdx).toBeGreaterThanOrEqual(0);
+    expect(swrIdx).toBeGreaterThanOrEqual(0);
+    expect(cacheFirstIdx).toBeLessThan(swrIdx);
+  });
+
+  it('still routes other same-origin assets through StaleWhileRevalidate', () => {
+    // self.location.origin is undefined in this node env; match on origin equality
+    // against a same-origin URL by constructing one relative to that origin.
+    const sameOrigin = new URL('https://app.example/assets/index-abc.js');
+    // Force the SWR predicate to see a matching origin.
+    globalThis.self = { location: { origin: 'https://app.example' } };
+    try {
+      const route = firstMatch(sameOrigin);
+      expect(route?.handler).toBe('StaleWhileRevalidate');
+      expect(route?.options.cacheName).toBe('same-origin-assets');
+    } finally {
+      delete globalThis.self;
+    }
+  });
+});

--- a/scripts/build-sw.mjs
+++ b/scripts/build-sw.mjs
@@ -2,15 +2,64 @@
 
 import fs from 'node:fs/promises';
 import path from 'node:path';
+import { fileURLToPath } from 'node:url';
 import workboxBuild from 'workbox-build';
 
 const { generateSW } = workboxBuild;
 
-const distDir = path.resolve('dist');
-const swDest = path.join(distDir, 'sw.js');
 const obsoleteArtifacts = ['openscad.js', 'openscad.wasm', 'fonts/InterVariable.woff2'];
 
-async function removeObsoleteArtifacts() {
+/**
+ * Build the Workbox `generateSW` config. Pure (no I/O) so it can be asserted in
+ * tests — the precache excludes and runtime-route order are correctness-critical.
+ */
+export function buildWorkboxConfig({ distDir, swDest }) {
+  return {
+    mode: 'production',
+    globDirectory: distDir,
+    globPatterns: ['**/*'],
+    swDest,
+    // The WASM binary (~9.6 MB) and the library zips (~tens of MB total) are
+    // deliberately kept OUT of the precache: precaching them would force the
+    // whole bundle to re-download atomically on every deploy (a new precache
+    // revision invalidates the lot), even when only an app chunk changed. They
+    // are instead fetched lazily and persisted by the CacheFirst runtime rule
+    // below, so they survive deploys and only download when first needed.
+    globIgnores: ['**/.*', '**/*.map', 'manifest*.js', '**/*.wasm', 'libraries/**'],
+    maximumFileSizeToCacheInBytes: 200 * 1024 * 1024,
+    // A new worker WAITS instead of taking over the open page: skipWaiting/
+    // clientsClaim would swap the controller mid-session (risking 404s on hashed
+    // chunks removed by the new deploy). The app surfaces an "update available"
+    // signal instead, and the new worker activates on the next load. See #53.
+    clientsClaim: false,
+    skipWaiting: false,
+    // Order matters: Workbox uses the FIRST matching route. The CacheFirst rule
+    // for the large WASM/library assets must come before the broad same-origin
+    // StaleWhileRevalidate, or the latter would swallow every same-origin request
+    // and the large assets would be re-validated (re-fetched) on every load.
+    runtimeCaching: [
+      {
+        urlPattern: ({ url }) =>
+          url.pathname.endsWith('.wasm') || url.pathname.includes('/libraries/'),
+        handler: 'CacheFirst',
+        options: {
+          cacheName: 'large-assets',
+          expiration: { maxEntries: 50, purgeOnQuotaError: true },
+        },
+      },
+      {
+        urlPattern: ({ url }) => url.origin === self.location.origin,
+        handler: 'StaleWhileRevalidate',
+        options: {
+          cacheName: 'same-origin-assets',
+          expiration: { maxEntries: 200, purgeOnQuotaError: true },
+        },
+      },
+    ],
+  };
+}
+
+async function removeObsoleteArtifacts(distDir) {
   for (const artifact of obsoleteArtifacts) {
     try {
       await fs.rm(path.join(distDir, artifact), { force: true });
@@ -26,43 +75,11 @@ async function removeObsoleteArtifacts() {
   }
 }
 
-try {
-  await removeObsoleteArtifacts();
+export async function runBuildSW({ distDir = path.resolve('dist') } = {}) {
+  const swDest = path.join(distDir, 'sw.js');
+  await removeObsoleteArtifacts(distDir);
 
-  const result = await generateSW({
-    mode: 'production',
-    globDirectory: distDir,
-    globPatterns: ['**/*'],
-    swDest,
-    globIgnores: ['**/.*', '**/*.map', 'manifest*.js'],
-    maximumFileSizeToCacheInBytes: 200 * 1024 * 1024,
-    // A new worker WAITS instead of taking over the open page: skipWaiting/
-    // clientsClaim would swap the controller mid-session (risking 404s on hashed
-    // chunks removed by the new deploy). The app surfaces an "update available"
-    // signal instead, and the new worker activates on the next load. See #53.
-    clientsClaim: false,
-    skipWaiting: false,
-    // Preserve the established runtime-caching rule order to avoid behavior drift.
-    runtimeCaching: [
-      {
-        urlPattern: ({ url }) => url.origin === self.location.origin,
-        handler: 'StaleWhileRevalidate',
-        options: {
-          cacheName: 'same-origin-assets',
-          expiration: { maxEntries: 200, purgeOnQuotaError: true },
-        },
-      },
-      {
-        urlPattern: ({ url }) =>
-          url.pathname.endsWith('.wasm') || url.pathname.includes('/libraries/'),
-        handler: 'CacheFirst',
-        options: {
-          cacheName: 'large-assets',
-          expiration: { maxEntries: 50, purgeOnQuotaError: true },
-        },
-      },
-    ],
-  });
+  const result = await generateSW(buildWorkboxConfig({ distDir, swDest }));
 
   // generateSW already emits a `SKIP_WAITING` message listener in the worker,
   // so the app can let the user apply a waiting update on demand (see
@@ -84,7 +101,17 @@ try {
   console.log(
     `[build-sw] Generated ${swDest} with ${result.count} precached entries (${result.size} bytes).`,
   );
-} catch (error) {
-  console.error(error);
-  process.exitCode = 1;
+  return result;
+}
+
+const isEntrypoint =
+  process.argv[1] != null && path.resolve(process.argv[1]) === fileURLToPath(import.meta.url);
+
+if (isEntrypoint) {
+  try {
+    await runBuildSW();
+  } catch (error) {
+    console.error(error);
+    process.exitCode = 1;
+  }
 }


### PR DESCRIPTION
## Audit P1 — service-worker precache bloat and unreachable runtime route

`scripts/build-sw.mjs` had two defects:

1. **Over-broad precache.** `globPatterns: ['**/*']` with a 200 MB size
   cap pulled the ~9.6 MB WASM binary and ~21 library zips into the
   install-time precache. Because a precache revision invalidates the
   whole manifest atomically, every deploy forced a full re-download of
   tens of MB even when only one app chunk changed.
2. **Unreachable CacheFirst route.** The broad same-origin
   `StaleWhileRevalidate` rule was listed *before* the `CacheFirst` rule
   for the large assets. Workbox uses the first matching route, so
   CacheFirst never ran and the large assets were re-validated every load.

### Fix
- Add `'**/*.wasm'` and `'libraries/**'` to `globIgnores`: those assets are
  now fetched lazily and persisted by the `CacheFirst` runtime route, so
  they survive deploys and only download when first needed.
- Move the `CacheFirst` large-asset route ahead of the broad
  `StaleWhileRevalidate` route.
- Extract the Workbox config into a pure `buildWorkboxConfig()` and guard
  the run logic behind an entrypoint check so the config is unit-testable.

### Verification
- Precache dropped from the full bundle to **22 entries / 4.56 MB**; the
  generated `dist/sw.js` precache manifest contains no `.wasm` or
  `libraries/` entry.
- New assembly test `scripts/__tests__/build-sw.test.mjs` (5 cases):
  asserts the globIgnores excludes and that the CacheFirst route precedes
  (and wins over) the SWR route for `.wasm` and library URLs.
- Full `npm run verify` green.

Refs #69 (post-epic audit: P1 service-worker precache)