### PR TITLE
docs(sw): explain why large assets are precached, not lazily cached

### DIFF
--- a/scripts/build-sw.mjs
+++ b/scripts/build-sw.mjs
@@ -32,6 +32,21 @@ try {
   const result = await generateSW({
     mode: 'production',
     globDirectory: distDir,
+    // Precache EVERYTHING in dist, including the ~9.6 MB WASM binary and the
+    // library zips under libraries/. This is deliberate, despite the apparent
+    // size: Workbox keys every precache entry by url + content-revision in one
+    // shared cache, so a new service-worker version (from any deploy) reuses the
+    // unchanged entries via cacheMatch with NO network and re-fetches ONLY the
+    // entries whose content actually changed — there is no "re-download the whole
+    // bundle on every deploy" behaviour. The payoff: the app (compile + bundled
+    // libraries) is fully offline-ready after the FIRST visit, warm loads serve
+    // these large assets from cache instead of refetching, and the unhashed
+    // library zips get correct content-revisioned invalidation when they change.
+    // (Excluding them in favour of a lazy runtime CacheFirst route was tried and
+    // reverted: it regressed warm-load bootstrap and left stale library zips
+    // served forever, in exchange for a per-deploy cost that does not exist.
+    // See PR #113.) The high maximumFileSizeToCacheInBytes below exists so the
+    // WASM binary clears Workbox's default 2 MB precache size limit.
     globPatterns: ['**/*'],
     swDest,
     globIgnores: ['**/.*', '**/*.map', 'manifest*.js'],
@@ -42,7 +57,9 @@ try {
     // signal instead, and the new worker activates on the next load. See #53.
     clientsClaim: false,
     skipWaiting: false,
-    // Preserve the established runtime-caching rule order to avoid behavior drift.
+    // Runtime caching only applies to requests NOT served by the precache above
+    // (which already covers the WASM binary and library zips). These rules are a
+    // fallback for any same-origin request that misses the precache.
     runtimeCaching: [
       {
         urlPattern: ({ url }) => url.origin === self.location.origin,


### PR DESCRIPTION
## Outcome of audit P1 #13 (service-worker precache)

The audit proposed excluding the WASM binary and library zips from the SW
precache (serving them via a lazy runtime `CacheFirst` route), on the
premise that precaching forces a full re-download on every deploy.

A multi-agent investigation (Workbox `workbox-precaching` source +
generated `dist/sw.js` + the perf harness) found that **premise is false**:

- Workbox keys each precache entry by `url + content-revision` in one
  shared cache. A new SW version (any deploy) reuses unchanged entries via
  `cacheMatch` with **no network**, and re-fetches **only** entries whose
  content changed. There is no atomic "invalidate the whole bundle."
- A hashed wasm therefore downloads **once per content-change, never per
  deploy**; unhashed library zips re-download only when their bytes change.

The exclusion (attempted in #113) was **reverted** because it:
- regressed warm-load bootstrap — `warmMetrics.appBootstrapMillis`
  192→281 ms (+47%, gating; median-of-3): the first SW-controlled load
  becomes the first `CacheFirst` miss for `fonts.zip` + the library zips;
- slipped offline-readiness from **1 visit to 2**;
- left **stale library zips** served indefinitely (`CacheFirst` never
  revalidates the unhashed `libraries/*.zip` URLs).

Status-quo precaching is the better long-term design: offline in one
visit, fast warm loads, and correct content-revisioned invalidation for
the unhashed zips.

### This PR
No behavior change — comments only. It documents the precache rationale
inline (so the strategy is not re-misdiagnosed) and corrects the
runtime-caching comment to reflect that those rules are a precache-miss
fallback.

Refs #69