### PR TITLE
fix(fragment): round-trip backend, autoCompile, camera and friends

### DIFF
--- a/src/__tests__/fragment-state.test.ts
+++ b/src/__tests__/fragment-state.test.ts
@@ -127,6 +127,96 @@ describe('round-trip: encodeStateParamsAsFragment → readStateFromFragment', ()
   });
 });
 
+// ---------------------------------------------------------------------------
+// Durable round-trip for previously-dropped fields: backend, autoCompile,
+// skipMultimaterialPrompt (params) and customizerGroupsCollapsed, camera (view).
+// The decoder used to silently drop these even though the encoder wrote them.
+// ---------------------------------------------------------------------------
+
+describe('round-trip: previously-dropped durable fields', () => {
+  function mockMatchMedia() {
+    Object.defineProperty(window, 'matchMedia', {
+      writable: true,
+      configurable: true,
+      value: vi.fn().mockImplementation((query: string) => ({
+        matches: false,
+        media: query,
+        onchange: null,
+        addListener: vi.fn(),
+        removeListener: vi.fn(),
+        addEventListener: vi.fn(),
+        removeEventListener: vi.fn(),
+        dispatchEvent: vi.fn(),
+      })),
+    });
+  }
+
+  it('round-trips backend, autoCompile, skipMultimaterialPrompt, customizerGroupsCollapsed, camera', async () => {
+    mockMatchMedia();
+    const createInitialState = (await import('../state/initial-state.ts')).createInitialState;
+    const state = createInitialState(null, { content: 'cube(10);' });
+    state.params.backend = 'cgal';
+    state.params.autoCompile = false;
+    state.params.skipMultimaterialPrompt = true;
+    state.view.customizerGroupsCollapsed = true;
+    state.view.camera = { position: [1, 2, 3], target: [4, 5, 6], zoom: 1.5 };
+
+    history.replaceState(null, '', '#' + (await encodeStateParamsAsFragment(state)));
+    const restored = await readStateFromFragment();
+
+    expect(restored?.params.backend).toBe('cgal');
+    expect(restored?.params.autoCompile).toBe(false);
+    expect(restored?.params.skipMultimaterialPrompt).toBe(true);
+    expect(restored?.view.customizerGroupsCollapsed).toBe(true);
+    expect(restored?.view.camera).toEqual({ position: [1, 2, 3], target: [4, 5, 6], zoom: 1.5 });
+  });
+
+  it('preserves tri-state: an absent autoCompile stays undefined (not coerced to false)', async () => {
+    mockMatchMedia();
+    const createInitialState = (await import('../state/initial-state.ts')).createInitialState;
+    const state = createInitialState(null, { content: 'cube(10);' });
+    // Leave autoCompile/backend/camera unset.
+    expect(state.params.autoCompile).toBeUndefined();
+
+    history.replaceState(null, '', '#' + (await encodeStateParamsAsFragment(state)));
+    const restored = await readStateFromFragment();
+
+    // undefined means "auto-compile on by default"; coercing to false would
+    // silently disable it for every shared URL that never set the flag.
+    expect(restored?.params.autoCompile).toBeUndefined();
+    expect(restored?.params.backend).toBeUndefined();
+    expect(restored?.view.camera).toBeUndefined();
+    expect(restored?.view.customizerGroupsCollapsed).toBeUndefined();
+  });
+
+  it('rejects a malformed camera (drops to undefined rather than storing junk)', async () => {
+    window.location.hash =
+      '#' +
+      encodeURIComponent(
+        JSON.stringify({
+          params: {
+            activePath: '/test.scad',
+            features: [],
+            sources: [{ path: '/test.scad', content: 'cube(10);' }],
+            exportFormat2D: 'svg',
+            exportFormat3D: 'stl',
+          },
+          view: {
+            logs: false,
+            layout: { mode: 'multi', editor: true, viewer: true, customizer: false },
+            color: '#aabbcc',
+            showAxes: true,
+            lineNumbers: false,
+            camera: { position: [1, 2], target: 'nope', zoom: 'x' },
+          },
+        }),
+      );
+
+    const state = await readStateFromFragment();
+    expect(state?.view.camera).toBeUndefined();
+  });
+});
+
 describe('buildUrlForStateParams – must be async (BUG-6)', () => {
   it('returns a Promise (not a string with "[object Promise]" in it)', async () => {
     // Mock matchMedia so createInitialState doesn't throw

--- a/src/state/fragment-state.ts
+++ b/src/state/fragment-state.ts
@@ -16,6 +16,30 @@ function validateVars(v: unknown): State['params']['vars'] {
   );
 }
 
+// Preserve tri-state: an absent boolean stays `undefined` (its "use the default"
+// meaning) rather than collapsing to `false`. validateBoolean() coerces absent to
+// false, which would, e.g., wrongly disable autoCompile (default-on) for any
+// shared URL that never set it.
+function validateOptionalBoolean(value: unknown): boolean | undefined {
+  return typeof value === 'boolean' ? value : undefined;
+}
+
+function validateCamera(value: unknown): State['view']['camera'] {
+  if (value == null || typeof value !== 'object') return undefined;
+  const c = value as Record<string, unknown>;
+  const triple = (t: unknown): [number, number, number] | undefined =>
+    Array.isArray(t) &&
+    t.length === 3 &&
+    t.every((n) => typeof n === 'number' && Number.isFinite(n))
+      ? [t[0] as number, t[1] as number, t[2] as number]
+      : undefined;
+  const position = triple(c.position);
+  const target = triple(c.target);
+  const zoom = typeof c.zoom === 'number' && Number.isFinite(c.zoom) ? c.zoom : undefined;
+  if (!position || !target || zoom === undefined) return undefined;
+  return { position, target, zoom };
+}
+
 function validateSourceUrl(value: unknown): string | undefined {
   if (typeof value !== 'string') return undefined;
   return resolveExternalSourceUrl(value, {
@@ -42,7 +66,10 @@ export async function buildUrlForStateParams(state: State) {
   return `${location.protocol}//${location.host}${location.pathname}#${await encodeStateParamsAsFragment(state)}`;
 }
 export async function writeStateInFragment(state: State) {
-  history.replaceState(state, '', '#' + (await encodeStateParamsAsFragment(state)));
+  // Pass null, not `state`: nothing reads history.state, and `state` carries
+  // non-serializable runtime fields (output File/blob handles) that would bloat
+  // or break the structured clone on every fragment write.
+  history.replaceState(null, '', '#' + (await encodeStateParamsAsFragment(state)));
 }
 async function compressString(input: string): Promise<string> {
   return btoa(
@@ -139,6 +166,9 @@ export async function readStateFromFragment(): Promise<State | null> {
           extruderColors: Array.isArray(params?.extruderColors)
             ? validateArray(params.extruderColors, validateString)
             : undefined,
+          backend: validateStringEnum(params?.backend, ['manifold', 'cgal'], (_s) => undefined),
+          autoCompile: validateOptionalBoolean(params?.autoCompile),
+          skipMultimaterialPrompt: validateOptionalBoolean(params?.skipMultimaterialPrompt),
         },
         preview: preview
           ? {
@@ -165,6 +195,8 @@ export async function readStateFromFragment(): Promise<State | null> {
             customizer: validateBoolean(view?.layout['customizer']),
           },
           collapsedCustomizerTabs: validateArray(view?.collapsedCustomizerTabs, validateString),
+          customizerGroupsCollapsed: validateOptionalBoolean(view?.customizerGroupsCollapsed),
+          camera: validateCamera(view?.camera),
           color: validateString(view?.color, () => defaultModelColor),
           showAxes: validateBoolean(view?.showAxes, () => true),
           lineNumbers: validateBoolean(view?.lineNumbers, () => false),


### PR DESCRIPTION
## Audit P1 — fragment durable round-trip

`readStateFromFragment` rebuilt state through an allowlist that silently
**dropped five durable fields** the encoder (`encodeStateParamsAsFragment`,
which serializes the full `params`/`view`/`preview`) writes:

- `params.backend` (`manifold` | `cgal`)
- `params.autoCompile`
- `params.skipMultimaterialPrompt`
- `view.customizerGroupsCollapsed`
- `view.camera`

So a shared or bookmarked URL lost the chosen render backend, the
auto-compile toggle, the multimaterial-prompt opt-out, the customizer
collapse state, and the saved camera.

### Fix
- Decode all five fields.
- **Tri-state preserved** for the optional booleans via a
  `validateOptionalBoolean` helper: an absent flag stays `undefined` rather
  than collapsing to `false`. This matters most for `autoCompile`, whose
  default is on (`undefined`); coercing it to `false` would silently disable
  auto-compile for every URL that never set the flag. (`validateBoolean`
  without a fallback coerces absent→false, which is why it can't be used here.)
- `validateCamera` validates against the `CameraState` shape (length-3
  finite-number triples + finite zoom); malformed input drops to `undefined`.
- `history.replaceState(null, …)` instead of passing the full `state`:
  nothing reads `history.state`, and the state carries non-serializable
  runtime `File`/blob handles that would bloat or break the structured clone
  on every fragment write.

`persisted-state.ts` (standalone localStorage path) returns
`{view, params, preview}` verbatim, so it had no equivalent gap.

### Tests
`src/__tests__/fragment-state.test.ts`: round-trips all five fields;
asserts tri-state (absent `autoCompile` stays `undefined`); rejects a
malformed camera. Full `npm run verify` green. Adversarial review: no
MUST-FIX, round-trip confirmed complete (no remaining asymmetry).

Refs #69 (post-epic audit: P1 fragment durable round-trip)