### PR TITLE
fix(diagnostics): carry the source file path; route markers per model

### DIFF
--- a/src/__tests__/diagnostics.test.ts
+++ b/src/__tests__/diagnostics.test.ts
@@ -5,7 +5,7 @@ import {
   hasErrorDiagnostic,
   type Diagnostic,
 } from '../diagnostics.ts';
-import { toMonacoMarkers } from '../language/diagnostic-markers.ts';
+import { groupMarkersByPath, toMonacoMarkers } from '../language/diagnostic-markers.ts';
 
 function diag(severity: Diagnostic['severity'], line = 1): Diagnostic {
   return {
@@ -57,5 +57,29 @@ describe('toMonacoMarkers adapter (#55)', () => {
   it('round-trips the optional source field', () => {
     const [marker] = toMonacoMarkers([{ ...diag('warning'), source: 'openscad' }]);
     expect(marker.source).toBe('openscad');
+  });
+});
+
+describe('groupMarkersByPath', () => {
+  const withPath = (p: string | undefined, line: number): Diagnostic => ({
+    ...diag('error', line),
+    path: p,
+  });
+
+  it('groups markers by file path, preserving per-file order', () => {
+    const groups = groupMarkersByPath([
+      withPath('/home/a.scad', 1),
+      withPath('/home/b.scad', 2),
+      withPath('/home/a.scad', 3),
+    ]);
+    expect([...groups.keys()]).toEqual(['/home/a.scad', '/home/b.scad']);
+    expect(groups.get('/home/a.scad')!.map((m) => m.startLineNumber)).toEqual([1, 3]);
+    expect(groups.get('/home/b.scad')!.map((m) => m.startLineNumber)).toEqual([2]);
+  });
+
+  it('collects path-less diagnostics under the undefined key', () => {
+    const groups = groupMarkersByPath([withPath(undefined, 9), withPath('/home/a.scad', 1)]);
+    expect(groups.get(undefined)!.map((m) => m.startLineNumber)).toEqual([9]);
+    expect(groups.get('/home/a.scad')!).toHaveLength(1);
   });
 });

--- a/src/__tests__/output-parser.test.ts
+++ b/src/__tests__/output-parser.test.ts
@@ -29,3 +29,44 @@ describe('parseMergedOutputs – skipLines shifts marker line numbers (BUG-3)', 
     expect(markers[0].startLineNumber).toBe(4);
   });
 });
+
+describe('parseMergedOutputs – diagnostics carry the source file path', () => {
+  it('populates path from a parser-error line', () => {
+    const markers = parseMergedOutputs(mockOutputs(3), {
+      shiftSourceLines: { sourcePath: '/playground.scad', skipLines: 0 },
+    });
+    expect(markers[0].path).toBe('/playground.scad');
+    expect(markers[0].severity).toBe('error');
+  });
+
+  it('populates path for a different (non-active) file so it can route there', () => {
+    const markers = parseMergedOutputs(
+      [
+        {
+          stderr: 'ERROR: Parser error in file "/home/lib.scad", line 7: bad token',
+          stdout: undefined,
+          error: undefined,
+        },
+      ],
+      { shiftSourceLines: { sourcePath: '/home/main.scad', skipLines: 2 } },
+    );
+    // Not the active file, so the line is NOT shifted by skipLines.
+    expect(markers[0].path).toBe('/home/lib.scad');
+    expect(markers[0].startLineNumber).toBe(7);
+  });
+
+  it('populates path on warnings', () => {
+    const markers = parseMergedOutputs(
+      [
+        {
+          stderr: 'WARNING: Ignoring unknown variable, in file /home/main.scad, line 4',
+          stdout: undefined,
+          error: undefined,
+        },
+      ],
+      { shiftSourceLines: { sourcePath: '/home/main.scad', skipLines: 0 } },
+    );
+    expect(markers[0].severity).toBe('warning');
+    expect(markers[0].path).toBe('/home/main.scad');
+  });
+});

--- a/src/components/elements/osc-editor-panel.ts
+++ b/src/components/elements/osc-editor-panel.ts
@@ -13,8 +13,9 @@ import { getParentDir, join } from '../../fs/filesystem.ts';
 import { defaultSourcePath, getBlankProjectState } from '../../state/initial-state.ts';
 import { buildUrlForStateParams } from '../../state/fragment-state.ts';
 import { registerOpenSCADLanguage } from '../../language/openscad-register-language.ts';
-import { toMonacoMarkers } from '../../language/diagnostic-markers.ts';
+import { groupMarkersByPath } from '../../language/diagnostic-markers.ts';
 import { markPerf, measurePerf } from '../../perf/runtime-performance.ts';
+import type { Diagnostic } from '../../diagnostics.ts';
 import type { State } from '../../state/app-state.ts';
 import type { Model } from '../../state/model.ts';
 
@@ -48,13 +49,8 @@ export class OscEditorPanel extends LitElement {
     // Sync editor content when active path changes or source is externally modified
     if (this._editor && this._monaco) {
       const checkerRun = st.lastCheckerRun;
-      const editorModel = this._editor.getModel();
-      if (editorModel && checkerRun) {
-        this._monaco.editor.setModelMarkers(
-          editorModel,
-          'openscad',
-          toMonacoMarkers(checkerRun.markers),
-        );
+      if (checkerRun) {
+        this._applyDiagnosticMarkers(checkerRun.markers);
       }
 
       // If path changed, update the editor model
@@ -80,6 +76,39 @@ export class OscEditorPanel extends LitElement {
       }
     }
   };
+
+  /**
+   * Route each diagnostic to the editor model for its file, so a multi-file
+   * project shows each file's markers on its own model instead of dumping them
+   * all on the active one. Diagnostics with no path — or whose file has no open
+   * model — fall back to the active model. Every model is cleared first so a file
+   * whose diagnostics were resolved doesn't keep stale markers.
+   */
+  private _applyDiagnosticMarkers(diagnostics: Diagnostic[]) {
+    const monaco = this._monaco;
+    const editor = this._editor;
+    if (!monaco || !editor) return;
+    const activeModel = editor.getModel();
+
+    const byModel = new Map<monacoTypes.editor.ITextModel, monacoTypes.editor.IMarkerData[]>();
+    const route = (
+      model: monacoTypes.editor.ITextModel,
+      markers: monacoTypes.editor.IMarkerData[],
+    ) => {
+      const existing = byModel.get(model);
+      if (existing) existing.push(...markers);
+      else byModel.set(model, [...markers]);
+    };
+    for (const [path, markers] of groupMarkersByPath(diagnostics)) {
+      const model =
+        (path ? monaco.editor.getModel(monaco.Uri.parse(`file://${path}`)) : null) ?? activeModel;
+      if (model) route(model, markers);
+    }
+
+    for (const model of monaco.editor.getModels()) {
+      monaco.editor.setModelMarkers(model, 'openscad', byModel.get(model) ?? []);
+    }
+  }
 
   private _closeMenu = (e: MouseEvent) => {
     if (!e.composedPath().includes(this)) this._menuOpen = false;
@@ -191,13 +220,8 @@ export class OscEditorPanel extends LitElement {
 
     // Apply initial markers
     const checkerRun = st.lastCheckerRun;
-    const editorModelInstance = editor.getModel();
-    if (editorModelInstance && checkerRun) {
-      monaco.editor.setModelMarkers(
-        editorModelInstance,
-        'openscad',
-        toMonacoMarkers(checkerRun.markers),
-      );
+    if (checkerRun) {
+      this._applyDiagnosticMarkers(checkerRun.markers);
     }
 
     // ResizeObserver to keep Monaco sized correctly

--- a/src/diagnostics.ts
+++ b/src/diagnostics.ts
@@ -14,6 +14,12 @@ export interface Diagnostic {
   endColumn: number;
   /** Optional source/tool that produced the diagnostic. */
   source?: string;
+  /**
+   * File the diagnostic belongs to, as reported by the compiler (e.g.
+   * `/home/playground.scad`). Lets a host route the marker to the right editor
+   * model instead of dumping every file's diagnostics on the active one.
+   */
+  path?: string;
 }
 
 const SEVERITY_RANK: Record<DiagnosticSeverity, number> = { info: 0, warning: 1, error: 2 };

--- a/src/language/diagnostic-markers.ts
+++ b/src/language/diagnostic-markers.ts
@@ -21,3 +21,22 @@ export function toMonacoMarkers(diagnostics: Diagnostic[]): monaco.editor.IMarke
     source: d.source,
   }));
 }
+
+/**
+ * Group diagnostics into Monaco markers keyed by their file path, preserving
+ * order within each file. The `undefined` key holds diagnostics with no path
+ * (the host applies those to the active model). Lets a multi-file project show
+ * each file's markers on its own editor model instead of all on the active one.
+ */
+export function groupMarkersByPath(
+  diagnostics: Diagnostic[],
+): Map<string | undefined, monaco.editor.IMarkerData[]> {
+  const groups = new Map<string | undefined, monaco.editor.IMarkerData[]>();
+  for (const d of diagnostics) {
+    const [marker] = toMonacoMarkers([d]);
+    const list = groups.get(d.path);
+    if (list) list.push(marker);
+    else groups.set(d.path, [marker]);
+  }
+  return groups;
+}

--- a/src/runner/output-parser.ts
+++ b/src/runner/output-parser.ts
@@ -45,6 +45,7 @@ export function parseMergedOutputs(
       endColumn: 1000,
       message: error,
       severity: 'error',
+      path: file,
     });
   };
   const shiftSourceName = opts.shiftSourceLines && opts.shiftSourceLines.sourcePath;
@@ -85,6 +86,7 @@ export function parseMergedOutputs(
           endColumn: 1000,
           message: warning,
           severity: 'warning',
+          path: file,
         });
         continue;
       }


### PR DESCRIPTION
## Audit P1 — diagnostics carry a file path; per-file Monaco markers

The output parser extracted the file each error/warning belonged to
(`ERROR: Parser error in file "/home/lib.scad", line N: …`) and then
**discarded** it, and the editor applied every diagnostic to the **active**
editor model. So in a multi-file project, an error in a non-active file
showed up on the wrong file at the wrong line.

### Fix
- `Diagnostic` gains an optional `path`; the parser populates it from the
  captured file (errors and warnings).
- New pure `groupMarkersByPath(diagnostics)` buckets markers by file
  (`undefined` key = no path).
- The editor's `_applyDiagnosticMarkers` routes each group to the Monaco
  model for its file (`file://<path>`), falling back to the active model
  when a diagnostic has no path or its file isn't open. It clears markers
  (owner `openscad`) on every model first, so a file whose errors were
  fixed doesn't keep stale markers.

Only the active source is prefix-wrapped (`actions.ts`), so non-active
files' line numbers are already accurate and route as-is. Single-file
behavior is unchanged: the parser's path equals `activePath`, which is the
exact URI the active model is created with; any mismatch falls back to the
active model (the previous behavior).

### Tests
- `output-parser.test.ts`: `path` populated for active/non-active errors
  and warnings (and non-active lines are not shifted).
- `diagnostics.test.ts`: `groupMarkersByPath` grouping order + `undefined`
  bucket.

Full `npm run verify` green. Adversarial review: no MUST-FIX (single-file
no-regression, stale-clear, and line-shift-vs-routing all confirmed).

Refs #69 (post-epic audit: P1 diagnostics file path)