### PR TITLE
fix(export): schedule exports on their own channel, not preview/render's

### DIFF
--- a/src/runner/actions.ts
+++ b/src/runner/actions.ts
@@ -1,7 +1,12 @@
 // Portions of this file are Copyright 2021 Google LLC, and licensed under GPL2+. See COPYING.
 
 import type { Diagnostic } from '../diagnostics.ts';
-import { ProcessStreams, isExpectedJobCancellation, spawnOpenSCAD } from './openscad-runner.ts';
+import {
+  ProcessStreams,
+  isExpectedJobCancellation,
+  spawnOpenSCAD,
+  type JobPriority,
+} from './openscad-runner.ts';
 import { processMergedOutputs } from './output-parser.ts';
 import { AbortablePromise, turnIntoDelayableExecution } from '../utils.ts';
 import { Source } from '../state/app-state.ts';
@@ -101,6 +106,12 @@ export type RenderArgs = {
   streamsCallback: (ps: ProcessStreams) => void;
   backend?: 'manifold' | 'cgal';
   revision?: number;
+  /**
+   * Host-side scheduling priority. Defaults to preview/render by `isPreview`;
+   * export passes `'export'` so it preempts background work and is not preempted
+   * by it. (See the separate `renderExport` delayable below.)
+   */
+  priority?: JobPriority;
 };
 
 /** Maximum array-nesting depth accepted for a customizer value. */
@@ -176,7 +187,7 @@ export function buildOpenScadArgs(request: OpenScadArgsRequest): string[] {
   return args;
 }
 
-export const render = turnIntoDelayableExecution(renderDelay, (renderArgs: RenderArgs) => {
+const renderJob = (renderArgs: RenderArgs) => {
   const {
     scadPath,
     sources,
@@ -189,6 +200,7 @@ export const render = turnIntoDelayableExecution(renderDelay, (renderArgs: Rende
     streamsCallback,
     backend,
     revision,
+    priority,
   } = renderArgs;
 
   const prefixLines: string[] = [];
@@ -230,7 +242,7 @@ export const render = turnIntoDelayableExecution(renderDelay, (renderArgs: Rende
       revision,
     },
     streamsCallback,
-    isPreview ? 'preview' : 'render',
+    priority ?? (isPreview ? 'preview' : 'render'),
   );
 
   return AbortablePromise<RenderOutput>((resolve, reject) => {
@@ -292,4 +304,14 @@ export const render = turnIntoDelayableExecution(renderDelay, (renderArgs: Rende
 
     return () => job.kill();
   });
-});
+};
+
+// Preview and full render share one delayable instance: they debounce and
+// supersede each other (only one geometry compile should be live at a time).
+export const render = turnIntoDelayableExecution(renderDelay, renderJob);
+
+// Export gets its OWN delayable instance so it does not share the supersession
+// signal with preview/render — an auto-preview must not cancel an in-flight
+// export, nor an export an in-flight preview. Callers pass `priority: 'export'`
+// for host-side scheduling precedence.
+export const renderExport = turnIntoDelayableExecution(renderDelay, renderJob);

--- a/src/state/services/__tests__/export-service.test.ts
+++ b/src/state/services/__tests__/export-service.test.ts
@@ -2,7 +2,7 @@ import { beforeEach, describe, expect, it, vi } from 'vitest';
 
 // Mock the heavy compile/IO deps the format-conversion + 3MF paths touch.
 vi.mock('../../../runner/actions.ts', () => ({
-  render: vi.fn().mockReturnValue(
+  renderExport: vi.fn().mockReturnValue(
     vi.fn().mockResolvedValue({
       outFile: new File(['converted'], 'model.stl'),
       logText: '',
@@ -17,14 +17,14 @@ vi.mock('../../../io/export_3mf.ts', () => ({
 }));
 vi.mock('chroma-js', () => ({ default: vi.fn((c: string) => c) }));
 
-import { render as _mockRender } from '../../../runner/actions.ts';
+import { renderExport as _mockRenderExport, type RenderOutput } from '../../../runner/actions.ts';
 import type { State } from '../../app-state.ts';
 import { bubbleUpDeepMutations } from '../../deep-mutate.ts';
 import type { HostAdapter } from '../../web-host-adapter.ts';
 import { ExportService } from '../export-service.ts';
 import type { ServiceContext } from '../service-context.ts';
 
-const mockRender = _mockRender as ReturnType<typeof vi.fn>;
+const mockRenderExport = _mockRenderExport as ReturnType<typeof vi.fn>;
 
 function fileOutput(name: string, url = 'blob:out'): State['output'] {
   const f = new File(['x'], name);
@@ -94,7 +94,7 @@ describe('ExportService', () => {
     });
     await new ExportService(ctx).export();
     expect(host.download).toHaveBeenCalledWith('blob:out', 'm.svg');
-    expect(mockRender).not.toHaveBeenCalled();
+    expect(mockRenderExport).not.toHaveBeenCalled();
   });
 
   it('downloads the display file on a glb pass-through', async () => {
@@ -105,7 +105,7 @@ describe('ExportService', () => {
     });
     await new ExportService(ctx).export();
     expect(host.download).toHaveBeenCalledWith('blob:glb', 'm.glb');
-    expect(mockRender).not.toHaveBeenCalled();
+    expect(mockRenderExport).not.toHaveBeenCalled();
   });
 
   it('opens the multimaterial picker for 3mf without extruder colors', async () => {
@@ -116,7 +116,7 @@ describe('ExportService', () => {
     });
     await new ExportService(ctx).export();
     expect(getState().view.extruderPickerVisibility).toBe('exporting');
-    expect(mockRender).not.toHaveBeenCalled();
+    expect(mockRenderExport).not.toHaveBeenCalled();
   });
 
   it('converts to 3mf when extruder colors are set, then downloads', async () => {
@@ -139,8 +139,63 @@ describe('ExportService', () => {
       output: fileOutput('m.off'),
     });
     await new ExportService(ctx).export();
-    expect(mockRender).toHaveBeenCalledTimes(1);
+    expect(mockRenderExport).toHaveBeenCalledTimes(1);
+    // Export runs on its own scheduling priority (preempts background compiles).
+    expect(mockRenderExport.mock.calls[0][0].priority).toBe('export');
     expect(host.download).toHaveBeenCalledWith('blob:new', 'model.stl');
+  });
+
+  it('drops a superseded export result instead of clobbering the newer one', async () => {
+    const { ctx, host, getState } = makeCtx({
+      is2D: false,
+      exportFormat3D: 'stl',
+      output: fileOutput('m.off'),
+    });
+    const svc = new ExportService(ctx);
+
+    // First export's conversion hangs; the second resolves immediately.
+    let resolveFirst!: (v: RenderOutput) => void;
+    const firstInner = vi.fn(() => new Promise<RenderOutput>((r) => (resolveFirst = r)));
+    const secondInner = vi.fn().mockResolvedValue({
+      outFile: new File(['second'], 'second.stl'),
+      logText: '',
+      markers: [],
+      elapsedMillis: 1,
+    });
+    mockRenderExport.mockReturnValueOnce(firstInner).mockReturnValueOnce(secondInner);
+
+    const p1 = svc.export(); // token 1 — awaits the hanging conversion
+    const p2 = svc.export(); // token 2 — resolves and commits
+    await p2;
+    // Now let the first (superseded) export finish; its token is stale.
+    resolveFirst({
+      outFile: new File(['first'], 'first.stl'),
+      logText: '',
+      markers: [],
+      elapsedMillis: 1,
+    });
+    await p1;
+
+    // Only the newer export downloaded; the stale one was dropped.
+    expect(host.download.mock.calls.map((c) => c[1])).toEqual(['second.stl']);
+    expect(getState().exporting).toBe(false);
+  });
+
+  it('treats a superseded (cancelled) export as supersession, not a user-facing error', async () => {
+    const { ctx, host, getState } = makeCtx({
+      is2D: false,
+      exportFormat3D: 'stl',
+      output: fileOutput('m.off'),
+    });
+    // The delayable rejects a superseded call with DELAYABLE_CANCELLED_MESSAGE.
+    mockRenderExport.mockReturnValueOnce(vi.fn().mockRejectedValue(new Error('Cancelled')));
+
+    await new ExportService(ctx).export();
+
+    // No spurious error surfaced and nothing downloaded — the newer export owns
+    // the outcome.
+    expect(getState().error).toBeUndefined();
+    expect(host.download).not.toHaveBeenCalled();
   });
 
   it('clears exporting and surfaces an error when there is no output to convert', async () => {

--- a/src/state/services/export-service.ts
+++ b/src/state/services/export-service.ts
@@ -2,8 +2,8 @@ import chroma from 'chroma-js';
 
 import { export3MF } from '../../io/export_3mf.ts';
 import { parseOff } from '../../io/import_off.ts';
-import { render, type RenderOutput } from '../../runner/actions.ts';
-import type { ProcessStreams } from '../../runner/openscad-runner.ts';
+import { renderExport, type RenderOutput } from '../../runner/actions.ts';
+import { isExpectedJobCancellation, type ProcessStreams } from '../../runner/openscad-runner.ts';
 import { isUserFacingOperationError } from '../../user-facing-errors.ts';
 import { formatBytes, formatMillis } from '../../utils.ts';
 import { applyUserFacingError } from '../apply-user-facing-error.ts';
@@ -18,6 +18,11 @@ import type { ServiceContext } from './service-context.ts';
  */
 export class ExportService {
   constructor(private ctx: ServiceContext) {}
+
+  // Identifies the latest export. A superseded export (e.g. a second click, or
+  // the 3MF path which does not run through the delayable) must not clobber the
+  // newer one's result/download when its async work finally settles.
+  private _exportSeq = 0;
 
   private rawStreamsCallback(ps: ProcessStreams) {
     this.ctx.mutate((s) => {
@@ -61,6 +66,7 @@ export class ExportService {
         return;
       }
     }
+    const token = ++this._exportSeq;
     mutate((s) => {
       s.currentRunLogs ??= [];
       s.exporting = true;
@@ -91,7 +97,7 @@ export class ExportService {
           markers: [],
         };
       } else {
-        output = await render({
+        output = await renderExport({
           mountArchives: false,
           scadPath: '/export.scad',
           sources: [
@@ -108,9 +114,14 @@ export class ExportService {
           isPreview: false,
           features,
           renderFormat: exportFormat,
+          priority: 'export',
           streamsCallback: this.rawStreamsCallback.bind(this),
         })({ now: true });
       }
+
+      // A newer export superseded this one while its conversion ran; it owns the
+      // exporting flag and will commit/download its own result. Drop this one.
+      if (this._exportSeq !== token) return;
 
       const outFileURL = host.createObjectURL(output.outFile);
       mutate((s) => {
@@ -128,6 +139,9 @@ export class ExportService {
         host.download(s.export.outFileURL, output.outFile.name);
       });
     } catch (err) {
+      // A superseded export rejects with the delayable's cancellation; that is
+      // expected supersession, not a failure — the newer export owns the spinner.
+      if (isExpectedJobCancellation(err)) return;
       mutate((s) => {
         s.exporting = false;
         if (!isUserFacingOperationError(err)) {


### PR DESCRIPTION
## Audit P1 — separate export scheduling from preview/render

Export reused the module-level `render` delayable
(`turnIntoDelayableExecution`), so it shared one `cancelLive` supersession
signal with preview/render. Consequences:

- An auto-preview (fired by any state change) could **cancel an in-flight
  export**, silently producing no download.
- An export could cancel a live preview.
- Export spawned at `render` priority, so `PRIORITY.export` (3) was dead.

### Fix
- Extract the render factory into `renderJob` and build **two** independent
  delayable instances from it: `render` (preview/render) and `renderExport`
  (export). Independent instances → independent `cancelLive`, so the two no
  longer cancel each other at the debounce layer.
- Add optional `priority` to `RenderArgs`, threaded into `spawnOpenSCAD`
  (`priority ?? (isPreview ? 'preview' : 'render')`). Export passes
  `'export'`, so it preempts lower-priority pending compiles and is not
  preempted by them. Export's input is the already-rendered `state.output`
  geometry, so preempting a pending preview never starves it.
- Monotonic `_exportSeq` token: a superseded export (a second click, or the
  non-delayable 3MF path) drops its result **before** creating an object
  URL / committing / downloading — no leak, no stale clobber, no
  double-download.
- The catch treats the delayable's expected cancellation
  (`isExpectedJobCancellation`, message `'Cancelled'`) as supersession, not
  a user-facing error (previously a superseded export showed a spurious
  error).

### Note on the audit's "revision check"
The audit also suggested a source-revision check on export results. I
deliberately used a supersession **token** instead of a source-revision
*drop*: export converts a snapshot of the already-rendered geometry
(`state.output`), so a later source change does not invalidate the file the
user explicitly asked to export — dropping on source-change would discard a
valid export. The token correctly guards against a newer export clobbering
(the real identity concern).

### Tests
`export-service.test.ts`: asserts `priority: 'export'`; a superseded export
drops its result (only the newer downloads, `exporting` clears); a
cancelled export surfaces no error and downloads nothing. Pass-throughs
still don't invoke the renderer. Full `npm run verify` green. Adversarial
review: no MUST-FIX (independent `cancelLive`, no leak, `exporting` can't
stick, cancel-message strings confirmed matching).

Refs #69 (post-epic audit: P1 export scheduling)