### PR TITLE
feat(export): implement OFF to GLB export via Three.js GLTFExporter

### DIFF
--- a/src/io/__tests__/export_glb.test.ts
+++ b/src/io/__tests__/export_glb.test.ts
@@ -1,0 +1,81 @@
+import { describe, expect, it } from 'vitest';
+
+import { exportGLB } from '../export_glb.ts';
+import type { IndexedPolyhedron } from '../common.ts';
+
+// A unit tetrahedron: 4 vertices, 4 triangular faces.
+function tetrahedron(colors: IndexedPolyhedron['colors']): IndexedPolyhedron {
+  return {
+    vertices: [
+      { x: 0, y: 0, z: 0 },
+      { x: 1, y: 0, z: 0 },
+      { x: 0, y: 1, z: 0 },
+      { x: 0, y: 0, z: 1 },
+    ],
+    faces: [
+      { vertices: [0, 1, 2], colorIndex: 0 },
+      { vertices: [0, 1, 3], colorIndex: 0 },
+      { vertices: [0, 2, 3], colorIndex: 0 },
+      { vertices: [1, 2, 3], colorIndex: 0 },
+    ],
+    colors,
+  };
+}
+
+// Parse the JSON chunk (chunk 0) out of a GLB container.
+// Layout: 12-byte header, then [uint32 chunkLength][uint32 chunkType='JSON'][bytes].
+function readGlbJson(buffer: ArrayBuffer): {
+  nodes: Array<{ rotation?: number[]; matrix?: number[] }>;
+} {
+  const view = new DataView(buffer);
+  const jsonLength = view.getUint32(12, true);
+  const jsonBytes = new Uint8Array(buffer, 20, jsonLength);
+  return JSON.parse(new TextDecoder().decode(jsonBytes));
+}
+
+// GLB header: magic 'glTF' (0x46546C67 LE), version, total length.
+function readGlbHeader(buffer: ArrayBuffer) {
+  const bytes = new Uint8Array(buffer);
+  const view = new DataView(buffer);
+  return {
+    magic: String.fromCharCode(bytes[0], bytes[1], bytes[2], bytes[3]),
+    version: view.getUint32(4, true),
+    length: view.getUint32(8, true),
+  };
+}
+
+describe('exportGLB', () => {
+  it('produces a valid binary glTF (GLB) for a single-color mesh', async () => {
+    const glb = await exportGLB(tetrahedron([[0.9, 0.2, 0.1, 1]]));
+    expect(glb).toBeInstanceOf(ArrayBuffer);
+    const header = readGlbHeader(glb);
+    expect(header.magic).toBe('glTF');
+    expect(header.version).toBe(2);
+    // The declared length must match the actual byte length.
+    expect(header.length).toBe(glb.byteLength);
+  });
+
+  it('produces a valid GLB for a multi-color mesh (per-vertex colors)', async () => {
+    const glb = await exportGLB(
+      tetrahedron([
+        [0.9, 0.2, 0.1, 1],
+        [0.1, 0.2, 0.9, 1],
+      ]),
+    );
+    const header = readGlbHeader(glb);
+    expect(header.magic).toBe('glTF');
+    expect(header.version).toBe(2);
+    expect(glb.byteLength).toBeGreaterThan(12);
+  });
+
+  it('rotates Z-up OpenSCAD geometry to glTF Y-up via the node transform', async () => {
+    const glb = await exportGLB(tetrahedron([[0.5, 0.5, 0.5, 1]]));
+    const { nodes } = readGlbJson(glb);
+    // GLTFExporter writes the node transform as a column-major matrix. A −90°
+    // rotation about X maps local +Z (OpenSCAD up) to world +Y (glTF up).
+    const matrix = nodes?.[0]?.matrix;
+    expect(matrix).toBeDefined();
+    const expected = [1, 0, 0, 0, 0, 0, -1, 0, 0, 1, 0, 0, 0, 0, 0, 1];
+    for (let i = 0; i < 16; i++) expect(matrix![i]).toBeCloseTo(expected[i], 5);
+  });
+});

--- a/src/io/export_glb.ts
+++ b/src/io/export_glb.ts
@@ -1,0 +1,48 @@
+// OFF → GLB (binary glTF) export. Reuses the viewer's OFF→BufferGeometry
+// builder so exported geometry matches what is shown on screen, wraps it in a
+// scene, and serializes with Three.js' GLTFExporter.
+//
+// Three.js (and GLTFExporter) is heavy; this module is dynamically imported by
+// the export service only when GLB is requested, so it never loads on the eager
+// path.
+
+import * as THREE from 'three';
+import { GLTFExporter } from 'three/examples/jsm/exporters/GLTFExporter.js';
+
+import { DEFAULT_FACE_COLOR, type IndexedPolyhedron } from './common.ts';
+import { offToBufferGeometry } from '../components/viewer/off-loader.ts';
+
+/**
+ * Serialize a parsed OFF polyhedron to a binary glTF (.glb) byte array.
+ *
+ * Colors: a multi-color model carries per-vertex colors (the geometry's `color`
+ * attribute); a single-color model has none, so the material's base color is set
+ * from the model's one face color. The geometry is rotated −90° about X so the
+ * OpenSCAD Z-up model becomes glTF's Y-up convention, i.e. it stands upright in
+ * standard glTF viewers (Blender, model-viewer, three.js loaders).
+ */
+export async function exportGLB(data: IndexedPolyhedron): Promise<ArrayBuffer> {
+  const geometry = offToBufferGeometry(data);
+  const hasMultiColor = data.colors.length > 1;
+
+  const [r, g, b] = data.colors[0] ?? DEFAULT_FACE_COLOR;
+  const material = new THREE.MeshStandardMaterial({
+    vertexColors: hasMultiColor,
+    color: hasMultiColor ? 0xffffff : new THREE.Color(r, g, b),
+    metalness: 0,
+    roughness: 1,
+    side: THREE.DoubleSide,
+  });
+
+  const mesh = new THREE.Mesh(geometry, material);
+  // OpenSCAD is Z-up; glTF is Y-up. Bake the conversion into the node transform.
+  mesh.rotation.x = -Math.PI / 2;
+
+  const scene = new THREE.Scene();
+  scene.add(mesh);
+
+  const exporter = new GLTFExporter();
+  const result = await exporter.parseAsync(scene, { binary: true });
+  // With `binary: true`, GLTFExporter resolves to an ArrayBuffer (the .glb).
+  return result as ArrayBuffer;
+}

--- a/src/state/services/__tests__/export-service.test.ts
+++ b/src/state/services/__tests__/export-service.test.ts
@@ -15,6 +15,9 @@ vi.mock('../../../io/import_off.ts', () => ({ parseOff: vi.fn(() => ({})) }));
 vi.mock('../../../io/export_3mf.ts', () => ({
   export3MF: vi.fn(() => new Uint8Array([1, 2, 3])),
 }));
+vi.mock('../../../io/export_glb.ts', () => ({
+  exportGLB: vi.fn(async () => new Uint8Array([4, 5, 6]).buffer),
+}));
 vi.mock('chroma-js', () => ({ default: vi.fn((c: string) => c) }));
 
 import { renderExport as _mockRenderExport, type RenderOutput } from '../../../runner/actions.ts';
@@ -97,14 +100,16 @@ describe('ExportService', () => {
     expect(mockRenderExport).not.toHaveBeenCalled();
   });
 
-  it('downloads the display file on a glb pass-through', async () => {
+  it('converts to glb in-browser (no worker render) and downloads a .glb', async () => {
     const { ctx, host } = makeCtx({
       is2D: false,
       exportFormat3D: 'glb',
-      output: fileOutput('m.glb', 'blob:glb'),
+      output: fileOutput('m.off'),
     });
     await new ExportService(ctx).export();
-    expect(host.download).toHaveBeenCalledWith('blob:glb', 'm.glb');
+    expect(host.download).toHaveBeenCalledTimes(1);
+    expect(host.download.mock.calls[0][1]).toBe('m.glb');
+    // GLB is produced from the OFF in-browser, not via a worker render.
     expect(mockRenderExport).not.toHaveBeenCalled();
   });
 

--- a/src/state/services/export-service.ts
+++ b/src/state/services/export-service.ts
@@ -40,23 +40,15 @@ export class ExportService {
     // export/exporting/error/log/view fields it writes via the mutate callback.
     const state = this.ctx.getState();
     if (state.output) {
+      // The preview/render output is already in the target format (the SVG for a
+      // 2D model, the OFF for a 3D `off` export), so download it directly.
       const normalPassThrough =
         (state.is2D && state.params.exportFormat2D === 'svg') ||
         (!state.is2D && state.params.exportFormat3D === 'off');
 
-      const glbPassThrough =
-        !state.is2D &&
-        state.params.exportFormat3D === 'glb' &&
-        (state.output.displayFile?.name.endsWith('.glb') ?? false) &&
-        state.output.displayFileURL != null;
-
-      if (normalPassThrough || glbPassThrough) {
+      if (normalPassThrough) {
         mutate((s) => (s.export = s.output));
-        if (glbPassThrough) {
-          host.download(state.output.displayFileURL!, state.output.displayFile!.name);
-        } else {
-          host.download(state.output.outFileURL, state.output.outFile.name);
-        }
+        host.download(state.output.outFileURL, state.output.outFile.name);
         return;
       }
     }
@@ -92,6 +84,20 @@ export class ExportService {
         const elapsedMillis = performance.now() - start;
         output = {
           outFile: new File([exportedData], state.output.outFile.name.replace('.off', '.3mf')),
+          elapsedMillis,
+          logText: '',
+          markers: [],
+        };
+      } else if (exportFormat === 'glb') {
+        // GLB is produced in-browser from the rendered OFF (OpenSCAD's WASM build
+        // has no glTF writer). Three.js is heavy, so load the converter lazily.
+        const start = performance.now();
+        const data = parseOff(await state.output.outFile.text());
+        const { exportGLB } = await import('../../io/export_glb.ts');
+        const glb = await exportGLB(data);
+        const elapsedMillis = performance.now() - start;
+        output = {
+          outFile: new File([glb], state.output.outFile.name.replace(/\.off$/, '.glb')),
           elapsedMillis,
           logText: '',
           markers: [],


### PR DESCRIPTION
## Audit P1 — implement OFF→GLB export

Selecting **GLB** previously produced a broken download: OpenSCAD's WASM
build has no glTF writer, and the only GLB path was a dead `glbPassThrough`
that required an already-`.glb` display file (never produced) — so GLB
fell through and downloaded the OFF named `export.off`.

### Fix
- **New `src/io/export_glb.ts`** — `exportGLB(IndexedPolyhedron): Promise<ArrayBuffer>`:
  - Reuses the viewer's `offToBufferGeometry` so exported geometry matches
    what's on screen.
  - Material: per-vertex colors for multi-color models; the OFF's single
    face color on the material otherwise.
  - Rotates the mesh −90° about X so OpenSCAD's **Z-up** geometry becomes
    glTF's **Y-up** (stands upright in Blender / model-viewer / three.js).
  - Serializes a binary `.glb` via `GLTFExporter.parseAsync(scene, {binary:true})`.
- **`export-service.ts`** — adds an `exportFormat === 'glb'` branch that
  parses the rendered OFF and runs the converter, **dynamically importing**
  the module so Three.js stays out of the eager bundle. Removes the dead
  `glbPassThrough`. Integrates with the existing export token/staleness
  guard and error handling.

### Bundle impact
`export_glb` is its own 0.43 KB lazy chunk; the shared `three` chunk grew
~6 KB gzip (GLTFExporter) to 139 KB, **under the 160 KB budget**. Three.js
is not pulled into the eager path (no static import of the module).

### Tests
- `src/io/__tests__/export_glb.test.ts`: valid GLB header (magic/version/
  length); multi-color mesh; and the node transform matrix equals
  rotX(−90°) (verifies local +Z → world +Y, i.e. upright).
- `export-service.test.ts`: GLB converts in-browser (no worker render) and
  downloads a `.glb`.

Full `npm run verify` green (385 unit + 20 assembly, budgets ok).
Adversarial review independently re-derived the rotation matrix: correct
(upright, not inverted); no MUST-FIX.

Refs #69 (post-epic audit: P1 implement OFF->GLB)