### PR TITLE
fix(files): show nested project files; mkdir -p before writing them

### DIFF
--- a/src/__tests__/filesystem.test.ts
+++ b/src/__tests__/filesystem.test.ts
@@ -1,6 +1,7 @@
 // Unit tests for Phase 2 filesystem layer — F2/F3/F7 exit criteria
 
 import {
+  ancestorDirsOf,
   clearHomeDirectory,
   extractLibraryNames,
   getParentDir,
@@ -22,6 +23,12 @@ describe('filesystem path helpers', () => {
     expect(join('.', 'file.scad')).toBe('file.scad');
     expect(join('/home/', 'project')).toBe('/home/project');
     expect(join('/home/project', '.')).toBe('/home/project');
+  });
+
+  it('ancestorDirsOf returns each parent directory outermost-first, excluding root', () => {
+    expect(ancestorDirsOf('/home/lib/sub/x.scad')).toEqual(['/home', '/home/lib', '/home/lib/sub']);
+    expect(ancestorDirsOf('/home/x.scad')).toEqual(['/home']);
+    expect(ancestorDirsOf('/x.scad')).toEqual([]);
   });
 });
 

--- a/src/components/elements/osc-editor-panel.ts
+++ b/src/components/elements/osc-editor-panel.ts
@@ -246,9 +246,14 @@ export class OscEditorPanel extends LitElement {
     const items: Array<{ path: string; label: string; group: string }> = [];
 
     for (const { path } of st.params.sources) {
-      const parent = getParentDir(path);
-      if (parent === '/' || parent === '/home') {
-        items.push({ path, label: path.split('/').pop() ?? path, group: 'My Files' });
+      if (path.endsWith('/')) continue; // archive/dir mount, not an editable file
+      const underHome = path.startsWith('/home/');
+      // Include every project file under /home (at any depth) plus top-level
+      // files. Nested files keep a relative label (e.g. `lib/part.scad`) so they
+      // are distinguishable in the dropdown.
+      if (underHome || getParentDir(path) === '/') {
+        const label = underHome ? path.slice('/home/'.length) : (path.split('/').pop() ?? path);
+        items.push({ path, label, group: 'My Files' });
       }
     }
 

--- a/src/fs/filesystem.ts
+++ b/src/fs/filesystem.ts
@@ -19,6 +19,25 @@ export function join(a: string, b: string): string {
   return b === '.' ? a : `${a}/${b}`;
 }
 
+/**
+ * The absolute ancestor directories of an absolute file path, outermost first
+ * and excluding the filesystem root. For `/home/lib/sub/x.scad` →
+ * `['/home', '/home/lib', '/home/lib/sub']`. Used to `mkdir -p` before writing a
+ * nested file (each `mkdir` is idempotent on an existing dir). A top-level file
+ * like `/x.scad` yields `[]` (only root, which always exists).
+ */
+export function ancestorDirsOf(filePath: string): string[] {
+  const segments = filePath.split('/').filter(Boolean);
+  segments.pop(); // drop the filename
+  const dirs: string[] = [];
+  let cur = '';
+  for (const seg of segments) {
+    cur += '/' + seg;
+    dirs.push(cur);
+  }
+  return dirs;
+}
+
 // ---------------------------------------------------------------------------
 // Low-level BrowserFS backend factory
 // ---------------------------------------------------------------------------

--- a/src/fs/project-filesystem.ts
+++ b/src/fs/project-filesystem.ts
@@ -11,4 +11,10 @@
 export interface ProjectFileSystem {
   readFileSync(path: string): BufferSource;
   writeFile(path: string, content: string): void;
+  /**
+   * Create a single directory. Optional because most consumers never need it;
+   * the real BrowserFS-backed `FS` provides it. Callers create parents in order
+   * (mkdir -p) and ignore an already-exists error.
+   */
+  mkdirSync?(path: string): void;
 }

--- a/src/runner/openscad-worker.ts
+++ b/src/runner/openscad-worker.ts
@@ -2,7 +2,12 @@
 
 /// <reference lib="webworker" />
 
-import { createEditorFS, symlinkLibraries, type EditorFs } from '../fs/filesystem.ts';
+import {
+  ancestorDirsOf,
+  createEditorFS,
+  symlinkLibraries,
+  type EditorFs,
+} from '../fs/filesystem.ts';
 import { markPerf, measurePerf } from '../perf/runtime-performance.ts';
 import { createSerialQueue } from './serial-queue.ts';
 import { ensureWorkerBrowserFSLoaded } from '../runtime/browserfs-runtime.ts';
@@ -164,6 +169,9 @@ async function runCompile(msg: CompileRequest): Promise<void> {
         } else {
           // eslint-disable-next-line @typescript-eslint/no-explicit-any
           const content = await fetchSource(rt.FS, source as any, { baseUrl: appBaseUrl });
+          // A nested source (e.g. /home/lib/x.scad) needs its parent dirs to
+          // exist before writeFile; mkdir is idempotent on existing dirs.
+          for (const dir of ancestorDirsOf(source.path)) rt.mkdir(dir);
           rt.writeFile(source.path, content);
         }
       } catch (err) {

--- a/src/state/__tests__/zip-import.test.ts
+++ b/src/state/__tests__/zip-import.test.ts
@@ -39,6 +39,7 @@ function makeMockFs() {
   return {
     readFileSync: vi.fn(() => new Uint8Array(0)),
     writeFile: vi.fn(),
+    mkdirSync: vi.fn(),
     isFile: vi.fn(() => false),
   };
 }
@@ -90,6 +91,20 @@ describe('importProjectZip validation (#50)', () => {
     expect(mockFs.writeFile).toHaveBeenCalledWith('/home/main.scad', 'cube(2);');
     expect(mockFs.writeFile).toHaveBeenCalledWith('/home/lib/util.scad', 'x');
     expect(model.state.params.activePath).toBe('/home/main.scad');
+  });
+
+  it('creates parent directories (mkdir -p) for nested archive entries', async () => {
+    mockLoadAsync.mockResolvedValue(fakeZip({ 'a/b/c.scad': 'x' }));
+
+    await model.importProjectZip(new ArrayBuffer(0));
+
+    // Parents created outermost-first before the nested file is written.
+    expect(mockFs.mkdirSync).toHaveBeenCalledWith('/home');
+    expect(mockFs.mkdirSync).toHaveBeenCalledWith('/home/a');
+    expect(mockFs.mkdirSync).toHaveBeenCalledWith('/home/a/b');
+    expect(mockFs.writeFile).toHaveBeenCalledWith('/home/a/b/c.scad', 'x');
+    const dirOrder = mockFs.mkdirSync.mock.calls.map((c) => c[0]);
+    expect(dirOrder).toEqual(['/home', '/home/a', '/home/a/b']);
     expect(model.state.error).toBeUndefined();
   });
 

--- a/src/state/project-store.ts
+++ b/src/state/project-store.ts
@@ -1,4 +1,5 @@
 import JSZip from 'jszip';
+import { ancestorDirsOf } from '../fs/filesystem.ts';
 import { ProjectFileSystem } from '../fs/project-filesystem.ts';
 import { contentOf, type SerializableSource } from './project-source.ts';
 import { fetchSource } from '../utils.ts';
@@ -125,12 +126,23 @@ export class ProjectStore {
       }
       files.push([safePath, content]);
     }
-    // Paths are validated above; FS write failures (e.g. a missing parent dir in
-    // the worker VFS) are best-effort and must not abort the import — the file
-    // content is still surfaced via the returned sources.
+    // Paths are validated above; FS write failures are best-effort and must not
+    // abort the import — the file content is still surfaced via the returned
+    // sources. Create each nested file's parent dirs first (mkdir -p) so a file
+    // like lib/x.scad doesn't fail to write for want of /home/lib.
     for (const [safePath, content] of files) {
+      const fullPath = `/home/${safePath}`;
       try {
-        this.fs.writeFile(`/home/${safePath}`, content);
+        if (this.fs.mkdirSync) {
+          for (const dir of ancestorDirsOf(fullPath)) {
+            try {
+              this.fs.mkdirSync(dir);
+            } catch {
+              /* already exists */
+            }
+          }
+        }
+        this.fs.writeFile(fullPath, content);
       } catch {
         /* best-effort */
       }


### PR DESCRIPTION
## Audit P1 — nested project files in selector + create imported dirs

Multi-file projects can hold files at any depth under `/home`, but:
- **Selector:** `_buildFileOptions` only listed sources whose parent was
  exactly `/` or `/home`, so a nested file like `/home/lib/part.scad` was
  invisible and unselectable.
- **Writes:** nested files were written without their parent dirs.
  `importZip` wrote `/home/lib/x.scad` without `/home/lib` (silently
  best-effort, so it never materialized), and the worker source-write loop
  would error on the missing parent — so nested files failed to compile.

### Fix
- New pure helper **`ancestorDirsOf(path)`** → ancestor dirs outermost-first.
- **Worker**: `mkdir -p` each ancestor (idempotent) before writing a
  writable source — never over the read-only `/libraries`/`/fonts` mounts.
- **importZip**: `mkdir -p` (via a new optional `mkdirSync` on the narrow
  `ProjectFileSystem`) before each nested write.
- **Selector**: include every source under `/home` at any depth plus
  top-level files, skip directory mounts, label nested files relative to
  `/home` (e.g. `lib/part.scad`).

### Tests
`filesystem.test.ts` (`ancestorDirsOf` edge cases); `zip-import.test.ts`
(parents created outermost-first before the nested write). Full
`npm run verify` green. Adversarial review: no MUST-FIX (production `fs` has
`mkdirSync`; selector filter is a strict superset; worker mkdir never
disturbs a mount).

Refs #69 (post-epic audit: P1 nested project files)