### PR TITLE
fix(source): make fetchSource byte-correct for binary content and fs reads

### DIFF
--- a/src/__tests__/utils.test.ts
+++ b/src/__tests__/utils.test.ts
@@ -285,3 +285,46 @@ describe('fetchSource external URL policy', () => {
     ).rejects.toThrow('source URL must be same-origin relative/absolute.');
   });
 });
+
+describe('fetchSource byte handling', () => {
+  it('passes Uint8Array content through unchanged (no text corruption)', async () => {
+    const bytes = new Uint8Array([0, 1, 2, 255, 128, 10]);
+    const fsStub = { readFileSync: vi.fn() } as unknown as FS;
+    const out = await fetchSource(fsStub, { path: '/home/asset.bin', content: bytes });
+    // Same bytes, byte-for-byte — not stringified/encoded.
+    expect(Array.from(out)).toEqual([0, 1, 2, 255, 128, 10]);
+  });
+
+  it('encodes string content as UTF-8', async () => {
+    const fsStub = { readFileSync: vi.fn() } as unknown as FS;
+    const out = await fetchSource(fsStub, { path: '/home/a.scad', content: 'cube();' });
+    expect(new TextDecoder().decode(out)).toBe('cube();');
+  });
+
+  it('preserves byteOffset/byteLength when reading a subarray view from the fs', async () => {
+    // A backing buffer where the file's bytes are a window in the middle.
+    const backing = new Uint8Array([99, 99, 10, 20, 30, 99]);
+    const view = backing.subarray(2, 5); // [10,20,30], byteOffset 2, length 3
+    const fsStub = { readFileSync: vi.fn(() => view) } as unknown as FS;
+
+    const out = await fetchSource(fsStub, { path: '/home/asset.bin' });
+
+    // Must be exactly the window, not the whole backing buffer.
+    expect(Array.from(out)).toEqual([10, 20, 30]);
+  });
+
+  it('reads a non-Uint8Array view (DataView) at its exact window', async () => {
+    const backing = new Uint8Array([7, 8, 9, 10]).buffer;
+    const fsStub = { readFileSync: vi.fn(() => new DataView(backing, 1, 2)) } as unknown as FS;
+    const out = await fetchSource(fsStub, { path: '/home/asset.bin' });
+    expect(Array.from(out)).toEqual([8, 9]);
+  });
+
+  it('wraps a bare ArrayBuffer from the fs', async () => {
+    const fsStub = {
+      readFileSync: vi.fn(() => new Uint8Array([1, 2, 3]).buffer),
+    } as unknown as FS;
+    const out = await fetchSource(fsStub, { path: '/home/asset.bin' });
+    expect(Array.from(out)).toEqual([1, 2, 3]);
+  });
+});

--- a/src/runner/openscad-worker.ts
+++ b/src/runner/openscad-worker.ts
@@ -167,8 +167,9 @@ async function runCompile(msg: CompileRequest): Promise<void> {
             console.error(`File ${source.path} does not exist!`);
           }
         } else {
-          // eslint-disable-next-line @typescript-eslint/no-explicit-any
-          const content = await fetchSource(rt.FS, source as any, { baseUrl: appBaseUrl });
+          // `source` is a flat WireSource ({ path, content?: string | Uint8Array,
+          // url? }) — exactly what fetchSource accepts, so no cast is needed.
+          const content = await fetchSource(rt.FS, source, { baseUrl: appBaseUrl });
           // A nested source (e.g. /home/lib/x.scad) needs its parent dirs to
           // exist before writeFile; mkdir is idempotent on existing dirs.
           for (const dir of ancestorDirsOf(source.path)) rt.mkdir(dir);

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -2,7 +2,7 @@
 
 import { fetchExternalSourceBytes } from './external-source.ts';
 import { ProjectFileSystem } from './fs/project-filesystem.ts';
-import { Source } from './state/app-state.ts';
+import type { WireSource } from './state/project-source.ts';
 
 export function mapObject<T, R>(
   o: Record<string, T>,
@@ -183,22 +183,39 @@ export function downloadUrl(url: string, filename: string) {
   link.parentNode?.removeChild(link);
 }
 
+/**
+ * View a BufferSource as a Uint8Array without copying, preserving its exact
+ * window. `new Uint8Array(view.buffer)` is wrong for a view with a non-zero
+ * byteOffset or a byteLength shorter than its backing buffer (e.g. a Buffer
+ * slice from BrowserFS) — it would expose the whole underlying buffer.
+ *
+ * The result may alias the input's memory, so callers must treat fetchSource's
+ * bytes as read-only (every current consumer does: worker FS write, zip, decode).
+ */
+function asUint8Array(data: BufferSource): Uint8Array {
+  if (data instanceof Uint8Array) return data; // already a correctly-bounded view
+  if (ArrayBuffer.isView(data))
+    return new Uint8Array(data.buffer, data.byteOffset, data.byteLength);
+  return new Uint8Array(data); // ArrayBuffer
+}
+
 export async function fetchSource(
   fs: ProjectFileSystem,
-  { content, path, url }: Source,
+  { content, path, url }: WireSource,
   { baseUrl }: { baseUrl?: string } = {},
 ): Promise<Uint8Array> {
   const isText = path.endsWith('.scad') || path.endsWith('.json');
   if (content != null) {
-    return new TextEncoder().encode(content);
+    // Bytes are canonical: pass binary content through unchanged. Encoding it as
+    // text (the previous behaviour) stringified the array and corrupted it.
+    return content instanceof Uint8Array ? content : new TextEncoder().encode(content);
   } else if (url) {
     const data = await fetchExternalSourceBytes(url, { baseUrl });
     if (!isText) return data;
-    content = new TextDecoder().decode(data);
-    return new TextEncoder().encode(content.replace(/\r\n/g, '\n'));
+    const text = new TextDecoder().decode(data);
+    return new TextEncoder().encode(text.replace(/\r\n/g, '\n'));
   } else if (path) {
-    const data = fs.readFileSync(path);
-    return new Uint8Array('buffer' in data ? data.buffer : data);
+    return asUint8Array(fs.readFileSync(path));
   } else {
     throw new Error('Invalid source: ' + JSON.stringify({ path, content, url }));
   }


### PR DESCRIPTION
## Audit P1 — harden the byte path (binary-import feature deferred)

Investigation found that "binary end-to-end" is an **unimplemented feature**,
not a regression: nothing produces a `BinarySource` today (`openLocalFile`
reads `.text()`, `importZip` reads strings, the compile request never carries
`Uint8Array`, and the worker's fresh FS never receives a content-less local
source). The audit's `fetchSource` findings are therefore **latent**
correctness bugs. Per the chosen scope, this PR hardens the byte path and
**defers** the full binary-asset feature (import UI + binary in state +
worker byte-transfer) to a separate attended effort.

### Bugs fixed in `fetchSource`
1. **Binary content corruption** — `new TextEncoder().encode(content)` ran on
   *all* content; a `Uint8Array` would be stringified (`"1,2,3,…"`) and
   corrupted. Now binary content passes through unchanged; only text is
   encoded.
2. **byteOffset/byteLength drop** — `new Uint8Array(data.buffer)` exposed the
   whole backing buffer for a view with a non-zero offset (e.g. a BrowserFS
   `Buffer` slice). New `asUint8Array` helper returns the exact window.
3. **Hidden type mismatch** — the param is now typed `WireSource`
   (`content?: string | Uint8Array`), so the worker drops its `source as any`.

### Tests
`utils.test.ts`: `Uint8Array` passthrough (no corruption); string encode;
fs read preserving a subarray's byteOffset/byteLength; DataView and bare
ArrayBuffer windows. The text/`.scad` flow and the URL `\r\n`→`\n` path are
byte-for-byte unchanged.

Full `npm run verify` green. Adversarial review: no MUST-FIX — type
soundness confirmed (`SerializableSource`/`CompileRequest` source assignable
to `WireSource`; no new `fs`-type hole), the no-copy aliasing is safe (every
consumer is read-only; documented), and the byteOffset fix is correct for
`Buffer`/`DataView`/`ArrayBuffer`.

Refs #69 (post-epic audit: P1 canonical-byte source path; binary-import feature deferred)