### PR TITLE
fix(export): claim supersession token at entry; settle every terminal path

### DIFF
--- a/src/state/services/__tests__/export-service.test.ts
+++ b/src/state/services/__tests__/export-service.test.ts
@@ -203,6 +203,104 @@ describe('ExportService', () => {
     expect(host.download).not.toHaveBeenCalled();
   });
 
+  it('a pass-through export supersedes an in-flight async export (no stale download, spinner cleared)', async () => {
+    const { ctx, host, getState } = makeCtx({
+      is2D: false,
+      exportFormat3D: 'stl',
+      output: fileOutput('m.off'),
+    });
+    const svc = new ExportService(ctx);
+
+    let resolveFirst!: (v: RenderOutput) => void;
+    mockRenderExport.mockReturnValueOnce(
+      vi.fn(() => new Promise<RenderOutput>((r) => (resolveFirst = r))),
+    );
+
+    const p1 = svc.export(); // token 1 — STL conversion hangs, exporting=true
+    // User switches to a pass-through format (OFF) and exports again.
+    ctx.mutate((s) => {
+      s.params.exportFormat3D = 'off';
+    });
+    await svc.export(); // token 2 — pass-through downloads the OFF, supersedes token 1
+
+    resolveFirst({
+      outFile: new File(['x'], 'first.stl'),
+      logText: '',
+      markers: [],
+      elapsedMillis: 1,
+    });
+    await p1;
+
+    // Only the OFF pass-through downloaded; the stale STL was dropped.
+    expect(host.download.mock.calls.map((c) => c[1])).toEqual(['m.off']);
+    expect(getState().exporting).toBe(false);
+  });
+
+  it('the 3MF picker supersedes an in-flight async export (no stale download, spinner cleared)', async () => {
+    const { ctx, host, getState } = makeCtx({
+      is2D: false,
+      exportFormat3D: 'stl',
+      output: fileOutput('m.off'),
+    });
+    const svc = new ExportService(ctx);
+
+    let resolveFirst!: (v: RenderOutput) => void;
+    mockRenderExport.mockReturnValueOnce(
+      vi.fn(() => new Promise<RenderOutput>((r) => (resolveFirst = r))),
+    );
+
+    const p1 = svc.export(); // token 1 — exporting=true
+    // User switches to 3MF (no extruder colors) and exports → the picker shows.
+    ctx.mutate((s) => {
+      s.params.exportFormat3D = '3mf';
+    });
+    await svc.export(); // token 2 — picker branch
+
+    resolveFirst({
+      outFile: new File(['x'], 'first.stl'),
+      logText: '',
+      markers: [],
+      elapsedMillis: 1,
+    });
+    await p1;
+
+    expect(getState().view.extruderPickerVisibility).toBe('exporting');
+    expect(host.download).not.toHaveBeenCalled(); // stale async dropped; picker just shows
+    expect(getState().exporting).toBe(false);
+  });
+
+  it('a stale async failure does not clobber the current export', async () => {
+    const { ctx, host, getState } = makeCtx({
+      is2D: false,
+      exportFormat3D: 'stl',
+      output: fileOutput('m.off'),
+    });
+    const svc = new ExportService(ctx);
+
+    let rejectFirst!: (e: unknown) => void;
+    const secondInner = vi.fn().mockResolvedValue({
+      outFile: new File(['ok'], 'second.stl'),
+      logText: '',
+      markers: [],
+      elapsedMillis: 1,
+    });
+    mockRenderExport
+      .mockReturnValueOnce(vi.fn(() => new Promise<RenderOutput>((_r, rej) => (rejectFirst = rej))))
+      .mockReturnValueOnce(secondInner);
+
+    const p1 = svc.export(); // token 1 — hangs
+    const p2 = svc.export(); // token 2 — resolves and commits
+    await p2;
+    // The stale first export now fails with a non-cancellation error.
+    rejectFirst(new Error('boom'));
+    await p1;
+
+    // The current export's success is untouched: no error surfaced, only its download.
+    expect(getState().error).toBeUndefined();
+    expect(getState().exporting).toBe(false);
+    expect(host.download.mock.calls.map((c) => c[1])).toEqual(['second.stl']);
+  });
+
   it('clears exporting and surfaces an error when there is no output to convert', async () => {
     const { ctx, getState } = makeCtx({ is2D: false, exportFormat3D: 'stl', output: undefined });
     await new ExportService(ctx).export();

--- a/src/state/services/export-service.ts
+++ b/src/state/services/export-service.ts
@@ -36,6 +36,13 @@ export class ExportService {
 
   async export() {
     const { mutate, host } = this.ctx;
+    // Claim the export token at entry — before any early return — so that EVERY
+    // export (pass-through, picker, or async conversion) supersedes an in-flight
+    // one. Each terminal path below checks ownership and explicitly settles the
+    // `exporting` spinner so a superseded export can neither commit a stale
+    // result nor leave the spinner stuck.
+    const token = ++this._exportSeq;
+    const isCurrent = () => this._exportSeq === token;
     // Snapshot is safe: export never mutates output/params/is2D, only the
     // export/exporting/error/log/view fields it writes via the mutate callback.
     const state = this.ctx.getState();
@@ -47,18 +54,26 @@ export class ExportService {
         (!state.is2D && state.params.exportFormat3D === 'off');
 
       if (normalPassThrough) {
-        mutate((s) => (s.export = s.output));
+        // Synchronous, so this export stays current through commit. Clear
+        // `exporting` to take ownership from any async export it just superseded.
+        mutate((s) => {
+          s.exporting = false;
+          s.export = s.output;
+        });
         host.download(state.output.outFileURL, state.output.outFile.name);
         return;
       }
     }
     if (!state.is2D && state.params.exportFormat3D == '3mf' && !state.params.extruderColors) {
       if (!state.params.skipMultimaterialPrompt) {
-        mutate((_s) => (state.view.extruderPickerVisibility = 'exporting'));
+        // Showing the picker ends this export request; take spinner ownership.
+        mutate((s) => {
+          s.exporting = false;
+          s.view.extruderPickerVisibility = 'exporting';
+        });
         return;
       }
     }
-    const token = ++this._exportSeq;
     mutate((s) => {
       s.currentRunLogs ??= [];
       s.exporting = true;
@@ -127,7 +142,7 @@ export class ExportService {
 
       // A newer export superseded this one while its conversion ran; it owns the
       // exporting flag and will commit/download its own result. Drop this one.
-      if (this._exportSeq !== token) return;
+      if (!isCurrent()) return;
 
       const outFileURL = host.createObjectURL(output.outFile);
       mutate((s) => {
@@ -148,6 +163,9 @@ export class ExportService {
       // A superseded export rejects with the delayable's cancellation; that is
       // expected supersession, not a failure — the newer export owns the spinner.
       if (isExpectedJobCancellation(err)) return;
+      // A stale export that fails for any other reason must not clobber the
+      // current export's spinner or surface its obsolete error.
+      if (!isCurrent()) return;
       mutate((s) => {
         s.exporting = false;
         if (!isUserFacingOperationError(err)) {


### PR DESCRIPTION
## P1 (#125) — export state machine

Follow-up to #117. The supersession token (`_exportSeq`) was claimed **after** the pass-through and 3MF-picker early returns, so neither superseded an in-flight async export. Verified failing sequence: an STL conversion in flight, the user switches to OFF and re-exports → the pass-through returns without bumping the token → the stale STL still commits and downloads after the OFF. Two more gaps: the catch never checked the token (a stale non-cancellation failure clobbered the current export's spinner/error), and the picker mutated the **captured** `state` object instead of the `mutate` argument.

### Fix
- **Claim the token at method entry**, before any early return, with `isCurrent()`.
- **Every terminal path owns the spinner:** the synchronous pass-through and the picker `mutate` `exporting = false` (taking ownership from a superseded async export); the async success/failure paths drop stale results via `isCurrent()`.
- **Catch guards the token** — a stale non-cancellation failure returns instead of clobbering.
- **Picker writes through `s`**, not captured `state`.

### Tests (the 4 the re-review flagged as missing)
- Pass-through export supersedes an in-flight async export (no stale download; spinner cleared).
- 3MF picker supersedes an in-flight async export (picker shown; spinner cleared).
- A stale non-cancellation failure does not clobber the current export.
- Spinner ownership asserted in each. (All three fail against the pre-fix code.)

Full `npm run verify` green. Adversarial review traced all six interleavings (incl. single genuine failure and the unreachable single-cancellation case): no MUST-FIX; spinner never stuck; no blob-URL leak on stale-drop.

### Deferred (NIT, folded into #122)
When a *pass-through/picker* supersedes an in-flight async export, the async `renderExport` job isn't killed (those branches don't call `renderExport`, so the delayable's own `cancelLive` doesn't fire) — the worker finishes a render that's then dropped. Harmless but wasteful; the "service owns the abortable export job" optimization is tracked in #122.

Closes #125