### PR TITLE
refactor(compile): drop unused displayFile/displayFileURL and its base64 read

### DIFF
--- a/src/state/app-state.ts
+++ b/src/state/app-state.ts
@@ -24,8 +24,6 @@ export type Source = {
 export interface FileOutput {
   outFile: File;
   outFileURL: string;
-  displayFile?: File;
-  displayFileURL?: string;
   elapsedMillis: number;
   formattedElapsedMillis: string;
   formattedOutFileSize: string;

--- a/src/state/services/__tests__/compile-coordinator.test.ts
+++ b/src/state/services/__tests__/compile-coordinator.test.ts
@@ -5,19 +5,12 @@ import type { ServiceContext } from '../service-context.ts';
 import type { State } from '../../app-state.ts';
 
 // render() is `factory(renderArgs)({ now })` → Promise<RenderOutput>; we drive the
-// promise it returns. readFileAsDataURL is the async artifact step whose await is
-// where a source change can sneak in — we control it to exercise the recheck.
+// promise it returns and the source revision to exercise the staleness drop.
 const renderImpl = vi.fn();
-const readFileAsDataURL = vi.fn();
 
 vi.mock('../../../runner/actions.ts', () => ({
   render: (renderArgs: unknown) => (opts: unknown) => renderImpl(renderArgs, opts),
   checkSyntax: vi.fn(),
-}));
-
-vi.mock('../../../utils.ts', async (importActual) => ({
-  ...(await importActual<typeof import('../../../utils.ts')>()),
-  readFileAsDataURL: (file: unknown) => readFileAsDataURL(file),
 }));
 
 function makeContext(revision: number) {
@@ -72,13 +65,11 @@ function renderOutput(revision: number) {
 describe('CompileCoordinator render staleness', () => {
   beforeEach(() => {
     renderImpl.mockReset();
-    readFileAsDataURL.mockReset();
   });
 
   it('commits the result and revokes nothing on the happy path', async () => {
     const { ctx, state, host } = makeContext(1);
     renderImpl.mockResolvedValue(renderOutput(1));
-    readFileAsDataURL.mockResolvedValue('data:text/plain;base64,c29saWQ=');
 
     await new CompileCoordinator(ctx).render({ isPreview: false, now: true });
 
@@ -88,32 +79,39 @@ describe('CompileCoordinator render staleness', () => {
     expect(state.rendering).toBe(false);
   });
 
-  it('drops a result gone stale during readFileAsDataURL and revokes the blob URL', async () => {
-    const { ctx, state, host, setRevision } = makeContext(1);
+  it('drops a result whose revision is stale and never creates a blob URL', async () => {
+    // The render was requested at revision 1, but the sources moved to 2 by the
+    // time the result arrives (e.g. the user edited while rendering).
+    const { ctx, state, host } = makeContext(2);
     renderImpl.mockResolvedValue(renderOutput(1));
-    // The source changes while the data URL is being read: bump the revision
-    // mid-await so the recheck after readFileAsDataURL sees a newer revision.
-    readFileAsDataURL.mockImplementation(async () => {
-      setRevision(2);
-      return 'data:text/plain;base64,c29saWQ=';
-    });
 
     await new CompileCoordinator(ctx).render({ isPreview: false, now: true });
 
     expect(state.output).toBeUndefined();
-    expect(host.revokeObjectURL).toHaveBeenCalledWith('blob:fake-url');
+    // The stale result is dropped before any object URL is created, so there is
+    // nothing to leak or revoke.
+    expect(host.createObjectURL).not.toHaveBeenCalled();
+    expect(host.revokeObjectURL).not.toHaveBeenCalled();
     expect(host.playCompletionChime).not.toHaveBeenCalled();
     expect(state.rendering).toBe(false);
   });
 
-  it('revokes the blob URL when readFileAsDataURL throws', async () => {
+  it('revokes the previous output blob URL when committing a new result', async () => {
     const { ctx, state, host } = makeContext(1);
+    // Seed a prior committed output with a blob URL.
+    (state as unknown as { output: State['output'] }).output = {
+      isPreview: false,
+      outFile: new File(['old'], 'old.off'),
+      outFileURL: 'blob:old-url',
+      elapsedMillis: 0,
+      formattedElapsedMillis: '0ms',
+      formattedOutFileSize: '1 B',
+    };
     renderImpl.mockResolvedValue(renderOutput(1));
-    readFileAsDataURL.mockRejectedValue(new Error('read failed'));
 
     await new CompileCoordinator(ctx).render({ isPreview: false, now: true });
 
-    expect(state.output).toBeUndefined();
-    expect(host.revokeObjectURL).toHaveBeenCalledWith('blob:fake-url');
+    expect(host.revokeObjectURL).toHaveBeenCalledWith('blob:old-url');
+    expect(state.output?.outFileURL).toBe('blob:fake-url');
   });
 });

--- a/src/state/services/__tests__/export-service.test.ts
+++ b/src/state/services/__tests__/export-service.test.ts
@@ -35,8 +35,6 @@ function fileOutput(name: string, url = 'blob:out'): State['output'] {
     isPreview: false,
     outFile: f,
     outFileURL: url,
-    displayFile: f,
-    displayFileURL: url,
     elapsedMillis: 0,
     formattedElapsedMillis: '0ms',
     formattedOutFileSize: '1 B',

--- a/src/state/services/compile-coordinator.ts
+++ b/src/state/services/compile-coordinator.ts
@@ -1,7 +1,7 @@
 import { checkSyntax, render, type RenderArgs } from '../../runner/actions.ts';
 import { isExpectedJobCancellation, type ProcessStreams } from '../../runner/openscad-runner.ts';
 import { isUserFacingOperationError } from '../../user-facing-errors.ts';
-import { fetchSource, formatBytes, formatMillis, readFileAsDataURL } from '../../utils.ts';
+import { fetchSource, formatBytes, formatMillis } from '../../utils.ts';
 import { applyUserFacingError } from '../apply-user-facing-error.ts';
 import type { State } from '../app-state.ts';
 import { is2DFormatExtension } from '../formats.ts';
@@ -213,9 +213,6 @@ export class CompileCoordinator {
       backend: this.ctx.getState().params.backend,
       revision: this.ctx.getSourceRevision(),
     };
-    // Hoisted so the catch can revoke it if readFileAsDataURL throws after the
-    // blob URL was created (otherwise the object URL would leak).
-    let outFileURL: string | undefined;
     try {
       const output = await render(renderArgs)({ now });
       if (!isCurrent()) return; // a newer render/preview superseded this one
@@ -227,26 +224,11 @@ export class CompileCoordinator {
         this.ctx.mutate((s) => setRendering(s, false));
         return;
       }
-      const displayFile = output.outFile;
-      if (output.outFile.name.endsWith('.svg') || output.outFile.name.endsWith('.dxf')) {
-        is2D = true;
-      } else {
-        is2D = false;
-      }
-      outFileURL = this.ctx.host.createObjectURL(output.outFile);
-      const displayFileURL = displayFile && (await readFileAsDataURL(displayFile));
-      // readFileAsDataURL is asynchronous; the sources may have changed while it
-      // ran. Re-check before committing so a stale artifact never lands in state,
-      // and revoke the blob URL we created if we bail.
-      if (!isCurrent()) {
-        this.ctx.host.revokeObjectURL(outFileURL);
-        return; // a newer render/preview superseded this one — it owns the spinner
-      }
-      if (output.revision !== undefined && output.revision !== this.ctx.getSourceRevision()) {
-        this.ctx.host.revokeObjectURL(outFileURL);
-        this.ctx.mutate((s) => setRendering(s, false));
-        return;
-      }
+      is2D = output.outFile.name.endsWith('.svg') || output.outFile.name.endsWith('.dxf');
+      // Everything from the staleness checks above to the commit below is
+      // synchronous (the viewer reads the OFF File directly and uses outFileURL
+      // for SVG), so no newer render can land in between — no recheck needed.
+      const outFileURL = this.ctx.host.createObjectURL(output.outFile);
       this.ctx.mutate((s) => {
         setRendering(s, false);
         s.error = undefined;
@@ -259,16 +241,11 @@ export class CompileCoordinator {
         if (s.output?.outFileURL?.startsWith('blob:') ?? false) {
           this.ctx.host.revokeObjectURL(s.output!.outFileURL);
         }
-        if (s.output?.displayFileURL?.startsWith('blob:') ?? false) {
-          this.ctx.host.revokeObjectURL(s.output!.displayFileURL!);
-        }
 
         s.output = {
           isPreview: isPreview,
           outFile: output.outFile,
-          outFileURL: outFileURL!, // assigned above before any path reaching here
-          displayFile,
-          displayFileURL,
+          outFileURL,
           elapsedMillis: output.elapsedMillis,
           formattedElapsedMillis: formatMillis(output.elapsedMillis),
           formattedOutFileSize: formatBytes(output.outFile.size),
@@ -279,9 +256,6 @@ export class CompileCoordinator {
         }
       });
     } catch (err) {
-      // If the blob URL was created before the failure (readFileAsDataURL threw),
-      // revoke it so it doesn't leak.
-      if (outFileURL) this.ctx.host.revokeObjectURL(outFileURL);
       if (!isCurrent()) return; // superseded — the newer call owns the spinner state
       this.ctx.mutate((s) => {
         setRendering(s, false);

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -220,16 +220,3 @@ export async function fetchSource(
     throw new Error('Invalid source: ' + JSON.stringify({ path, content, url }));
   }
 }
-
-export function readFileAsDataURL(file: File) {
-  // TO data URI:
-  return new Promise<string>((res, rej) => {
-    const reader = new FileReader();
-    reader.onloadend = () => {
-      res(reader.result as string);
-    };
-    reader.onerror = rej;
-    reader.readAsDataURL(file);
-  });
-  // return URL.createObjectURL(file);
-}


### PR DESCRIPTION
## Gate A (#126) — remove dead display-artifact work

The re-review found `displayFile`/`displayFileURL` (on `FileOutput`) have **no consumers**: the viewer reads the OFF `File` directly and uses `outFileURL` for SVG. Yet every render base64-encoded the full OFF into `displayFileURL` via `readFileAsDataURL` — wasted memory/latency, and the only `await` between the post-render staleness checks and the commit (so it also required the extra recheck added in #112).

### Change
- Remove `displayFile`/`displayFileURL` from `FileOutput`.
- In `CompileCoordinator.render`: drop the data-URL read and the `displayFile*` commit fields. The path from the first `isCurrent()`/revision check to the `mutate` commit is now **fully synchronous**, so the #112 second recheck is removed as redundant; `outFileURL` becomes a `const` at its use site and the catch's dead blob-revoke is dropped.
- Delete the now-unused `readFileAsDataURL` helper.
- Tests: rewrite the coordinator tests to cover the remaining post-render **revision-staleness drop** (asserting `createObjectURL` is never called — proving the no-leak property structurally) and the **prior-output blob revoke**; drop `displayFile*` from the export test helper.

Repo-wide grep confirms zero remaining `displayFile`/`displayFileURL`/`readFileAsDataURL` consumers. Full `npm run verify` green (395 unit + 20 assembly). Adversarial review: no MUST-FIX (no consumer; staleness still correct; no leak; prior-output revoke intact).

Refs #126