### PR TITLE
fix(editor): create the active model before applying diagnostics

### DIFF
--- a/src/components/elements/osc-editor-panel.ts
+++ b/src/components/elements/osc-editor-panel.ts
@@ -48,12 +48,9 @@ export class OscEditorPanel extends LitElement {
 
     // Sync editor content when active path changes or source is externally modified
     if (this._editor && this._monaco) {
-      const checkerRun = st.lastCheckerRun;
-      if (checkerRun) {
-        this._applyDiagnosticMarkers(checkerRun.markers);
-      }
-
-      // If path changed, update the editor model
+      // Update/create the active file's model FIRST, then apply diagnostics —
+      // so a diagnostic for a freshly-opened file routes to its now-existing
+      // model instead of falling back to the active one (and never reapplying).
       if (prev?.params.activePath !== st.params.activePath) {
         this._updatingFromState = true;
         try {
@@ -68,6 +65,11 @@ export class OscEditorPanel extends LitElement {
         } finally {
           this._updatingFromState = false;
         }
+      }
+
+      const checkerRun = st.lastCheckerRun;
+      if (checkerRun) {
+        this._applyDiagnosticMarkers(checkerRun.markers);
       }
 
       // lineNumbers option


### PR DESCRIPTION
## Gate A (#126) — diagnostic routing ordering

In `osc-editor-panel._onState`, diagnostics were applied **before** the active-path change created/switched the destination Monaco model. So a diagnostic for a file whose model didn't exist yet fell back to the active model; opening that file then created its model **after** marker routing and didn't reapply — leaving the marker on the wrong file (e.g. `main.scad`) until a later state event.

### Fix
Reorder `_onState`: create/switch the active file's model first, then call `_applyDiagnosticMarkers`. A freshly-opened file's diagnostics now route to its now-existing model on the same event. Behavior is unchanged for events without an active-path change (the model block is skipped, markers apply as before), and the reorder doesn't interact with `_updatingFromState` (that flag guards content push-back, not marker application).

Full `npm run verify` green; CI e2e exercises the editor. (The Monaco model registry isn't unit-mocked, consistent with the project's existing stance — the pure `groupMarkersByPath` routing is unit-tested in `diagnostics.test.ts`.)

Refs #126