### PR TITLE
fix(viewer): guard thumbnail hashing against superseded geometry/SVG loads

### DIFF
--- a/src/components/elements/osc-geometry-viewer.ts
+++ b/src/components/elements/osc-geometry-viewer.ts
@@ -38,6 +38,10 @@ export class OscGeometryViewer extends LitElement {
   private _ro: ResizeObserver | null = null;
   private _container: HTMLDivElement | null = null;
   private _loadedOffText: string | null = null;
+  // Monotonic load id: a newer _loadGeometry supersedes an older one whose
+  // thumbnail hashing is still in flight, so a slow older hash cannot overwrite
+  // the newer geometry's preview.
+  private _loadSeq = 0;
   private _toastTimer: ReturnType<typeof setTimeout> | null = null;
 
   override firstUpdated() {
@@ -93,6 +97,7 @@ export class OscGeometryViewer extends LitElement {
     const scene = this._scene;
     if (!scene) return;
     this._loadedOffText = offText;
+    const loadSeq = ++this._loadSeq;
     try {
       const geometry = offToBufferGeometry(parseOff(offText));
       scene.loadGeometry(geometry, this.color);
@@ -102,7 +107,8 @@ export class OscGeometryViewer extends LitElement {
       scene.renderOnce();
       const dataUrl = scene.renderer.domElement.toDataURL('image/png');
       const thumbhash = await imageToThumbhash(dataUrl);
-      if (this._scene !== scene) return; // torn down during hashing
+      // Bail if torn down OR superseded by a newer geometry while hashing.
+      if (this._scene !== scene || this._loadSeq !== loadSeq) return;
       this.dispatchEvent(new CustomEvent('geometry-loaded', { detail: { thumbhash } }));
     } catch (err) {
       console.error('Error loading OFF geometry:', err);

--- a/src/components/elements/osc-viewer-panel.test.ts
+++ b/src/components/elements/osc-viewer-panel.test.ts
@@ -1,0 +1,63 @@
+// @vitest-environment jsdom
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+// Control the async hashing step so we can interleave two SVG loads.
+const imageToThumbhash = vi.fn();
+vi.mock('../../io/image_hashes.ts', async (importActual) => ({
+  ...(await importActual<typeof import('../../io/image_hashes.ts')>()),
+  imageToThumbhash: (p: string) => imageToThumbhash(p),
+}));
+
+import { OscViewerPanel } from './osc-viewer-panel.ts';
+
+function makePanel() {
+  const el = new OscViewerPanel();
+  const mutations: unknown[] = [];
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  (el as any)._model = {
+    mutate: (f: (s: { preview?: { thumbhash: string } }) => void) => {
+      const s: { preview?: { thumbhash: string } } = {};
+      f(s);
+      mutations.push(s.preview);
+      return true;
+    },
+  };
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const load = (url: string) => (el as any)._loadSvgPreview(url) as Promise<void>;
+  return { load, mutations };
+}
+
+describe('osc-viewer-panel SVG preview staleness', () => {
+  beforeEach(() => imageToThumbhash.mockReset());
+
+  it('does not let a stale SVG hash overwrite a newer one', async () => {
+    const { load, mutations } = makePanel();
+
+    // First load hangs on hashing; second resolves immediately.
+    let resolveFirst!: (h: string) => void;
+    imageToThumbhash
+      .mockReturnValueOnce(new Promise<string>((r) => (resolveFirst = r)))
+      .mockResolvedValueOnce('hash-2');
+
+    const p1 = load('blob:svg-1'); // begins hashing, hangs
+    const p2 = load('blob:svg-2'); // supersedes, resolves 'hash-2'
+    await p2;
+
+    // The stale first hash now arrives — it must be dropped.
+    resolveFirst('hash-1');
+    await p1;
+
+    expect(mutations).toEqual([{ thumbhash: 'hash-2' }]);
+  });
+
+  it('ignores a repeat load of the same SVG URL', async () => {
+    const { load, mutations } = makePanel();
+    imageToThumbhash.mockResolvedValue('hash');
+
+    await load('blob:svg-1');
+    await load('blob:svg-1'); // same URL → no-op
+
+    expect(imageToThumbhash).toHaveBeenCalledTimes(1);
+    expect(mutations).toEqual([{ thumbhash: 'hash' }]);
+  });
+});

--- a/src/components/elements/osc-viewer-panel.ts
+++ b/src/components/elements/osc-viewer-panel.ts
@@ -79,6 +79,9 @@ export class OscViewerPanel extends LitElement {
     this._lastSvgPreviewUrl = svgUrl;
     try {
       const hash = await imageToThumbhash(svgUrl);
+      // A newer SVG output superseded this one while hashing — don't overwrite
+      // its preview with this stale hash.
+      if (this._lastSvgPreviewUrl !== svgUrl) return;
       this._model.mutate((s) => {
         s.preview = { thumbhash: hash };
       });


### PR DESCRIPTION
## Gate A (#126) — stale-load tokens for thumbnail hashing

Both preview-hashing paths could publish a **stale** thumbhash: after the async hash, they only verified their target still existed, not that a *newer* payload had loaded.

- `osc-geometry-viewer._loadGeometry` checked only `this._scene !== scene` (torn down), so geometry A's hash could land after geometry B's and overwrite B's preview.
- `osc-viewer-panel._loadSvgPreview` recorded the URL before `imageToThumbhash` but committed without rechecking it.

### Fix
- **OFF path:** a monotonic `_loadSeq`; after hashing, bail if `this._loadSeq !== loadSeq` (superseded) as well as if torn down.
- **SVG path:** after `imageToThumbhash`, return if `this._lastSvgPreviewUrl !== svgUrl`.

### Tests
`osc-viewer-panel.test.ts` (new): a stale SVG hash doesn't overwrite a newer one; a repeat load of the same URL is a no-op. (The first fails against the unfixed code.) The Three.js geometry viewer isn't unit-testable in jsdom — the OFF guard mirrors the tested SVG pattern and the established seq-token pattern; CI e2e exercises the viewer.

Full `npm run verify` green (397 unit + 20 assembly).

Refs #126; addresses the stale-thumbhash item tracked in #122.