### PR TITLE
docs(architecture): refresh stale boundary/lifecycle claims

### DIFF
--- a/docs/architecture/README.md
+++ b/docs/architecture/README.md
@@ -20,8 +20,8 @@ flowchart TD
   end
 
   subgraph state[Application state - src/state]
-    model[Model - EventTarget controller]
-    appstate[State / Source / app-state]
+    model[Model facade + services: Compile/Export/Layout/Project]
+    appstate[State / ProjectSource / app-state]
     fragment[fragment-state - URL persistence]
     urlmode[url-mode]
   end
@@ -40,7 +40,8 @@ flowchart TD
     fs[fs/filesystem - BrowserFS]
   end
 
-  subgraph viewercore[Viewer core - src/components/viewer]
+  subgraph viewercore[Viewer core - model-independent]
+    geomviewer[osc-geometry-viewer - Lit, props/events]
     three[ThreeScene]
     off[off-loader]
   end
@@ -64,39 +65,43 @@ flowchart TD
 
 ## Module map
 
-| Area             | Path                       | Responsibility                                                                                                                    |
-| ---------------- | -------------------------- | --------------------------------------------------------------------------------------------------------------------------------- |
-| Bootstrap        | `src/index.ts`             | Parse boot mode, init BrowserFS, construct `Model`, mount the shell                                                               |
-| State            | `src/state/`               | `Model` (central `EventTarget` controller), `State`/`Source`, URL persistence, url-mode, deep-mutate                              |
-| Compile pipeline | `src/runner/`              | Worker lifecycle + scheduler + timeouts, arg building, the in-worker WASM driver, the worker protocol, stderr→diagnostics parsing |
-| Diagnostics      | `src/diagnostics.ts`       | Host-neutral `Diagnostic` type + severity helpers                                                                                 |
-| Filesystem       | `src/fs/`                  | BrowserFS canonical mounts, demand-loaded libraries, `project-path` validation                                                    |
-| Runtime          | `src/runtime/`             | Asset URL resolution, bounded asset fetching, service worker, boot config                                                         |
-| Viewer core      | `src/components/viewer/`   | `ThreeScene` (framework-free Three.js wrapper), OFF loader                                                                        |
-| Editor package   | `src/language/`            | Monaco language registration, `Diagnostic`→Monaco marker adapter                                                                  |
-| UI               | `src/components/elements/` | Lit components (shells, editor/viewer/customizer panels, footer)                                                                  |
-| IO               | `src/io/`                  | OFF import, 3MF export, image hashing                                                                                             |
+| Area             | Path                       | Responsibility                                                                                                                                                                                                                                                       |
+| ---------------- | -------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| Bootstrap        | `src/index.ts`             | Parse boot mode, init BrowserFS, construct `Model`, mount the shell                                                                                                                                                                                                  |
+| State            | `src/state/`               | `Model` (central `EventTarget` façade/state owner) delegating to extracted services — `CompileCoordinator`, `ExportService`, `LayoutController`, `ProjectStore` — through a shared `ServiceContext`; `State`/`ProjectSource`, URL persistence, url-mode, deep-mutate |
+| Compile pipeline | `src/runner/`              | Worker lifecycle + scheduler + timeouts, arg building, the in-worker WASM driver, the worker protocol, stderr→diagnostics parsing                                                                                                                                    |
+| Diagnostics      | `src/diagnostics.ts`       | Host-neutral `Diagnostic` type + severity helpers                                                                                                                                                                                                                    |
+| Filesystem       | `src/fs/`                  | BrowserFS canonical mounts, demand-loaded libraries, `project-path` validation                                                                                                                                                                                       |
+| Runtime          | `src/runtime/`             | Asset URL resolution, bounded asset fetching, service worker, boot config                                                                                                                                                                                            |
+| Viewer core      | `src/components/viewer/`   | `ThreeScene` (framework-free Three.js wrapper), OFF loader                                                                                                                                                                                                           |
+| Editor package   | `src/language/`            | Monaco language registration, `Diagnostic`→Monaco marker adapter                                                                                                                                                                                                     |
+| UI               | `src/components/elements/` | Lit components (shells, editor/viewer/customizer panels, footer)                                                                                                                                                                                                     |
+| IO               | `src/io/`                  | OFF import, 3MF export, image hashing                                                                                                                                                                                                                                |
 
 ## Dependency boundaries
 
 The cleanup epic is moving the codebase toward a clean separation between a
 host-neutral core and the UI host(s). The current state of each rule:
 
-- **No editor library in domain/runner.** ✅ Enforced by convention today —
-  `src/state` and `src/runner` contain no `monaco-editor` import. Diagnostics
-  flow as the host-neutral `Diagnostic` type; the editor converts to Monaco
-  markers via `src/language/diagnostic-markers.ts` at its boundary.
+- **No editor library in domain/runner.** ✅ Enforced by lint — a
+  `no-restricted-imports` rule keeps `monaco-editor` (and other UI/editor
+  packages) out of `src/state`/`src/runner` (#106). Diagnostics flow as the
+  host-neutral `Diagnostic` type; the editor converts to Monaco markers via
+  `src/language/diagnostic-markers.ts` at its boundary.
 - **Untrusted input is validated centrally.** ✅ `fs/project-path` validates and
   bounds imported archive paths; `runtime/fetch-asset` bounds and status-checks
   asset fetches; `external-source` enforces the URL policy; `actions.formatValue`
   validates customizer values before building `-D` args.
 - **Viewer core is framework-free.** ✅ `ThreeScene` has no Lit/`Model`
-  dependency. ⚠️ `osc-viewer-panel` still reaches into the global `Model`; making
-  it a thin adapter over a model-independent `osc-geometry-viewer` is tracked in
-  #60.
-- **Domain is free of direct DOM access.** ⚠️ Not yet — `Model` plays the
-  completion chime via `document`, and `utils` owns browser download/IO helpers.
-  Extracting a web-host adapter is tracked in #59.
+  dependency, and `osc-geometry-viewer` is a model-independent Lit component that
+  takes OFF geometry and viewer settings as properties and emits DOM events
+  (`camera-change`, `geometry-loaded`). `osc-viewer-panel` is the thin adapter
+  that wires it to `Model`/`State` (#60, #61).
+- **Domain is free of direct DOM access.** ✅ `Model` and the compile/state
+  engine touch no `window`/`document`/`navigator`; browser side effects (object
+  URLs, downloads, the completion chime, base URL) go through a `HostAdapter`
+  (#59, #90). A lint rule forbids those globals in `src/state` (minus the adapter
+  files) and `src/runner` (#108).
 
 See the [ADRs](./adr/) for the decisions behind these boundaries, and
 [compile-lifecycle.md](./compile-lifecycle.md) for how a compile flows end to end.

--- a/docs/architecture/adr/0004-defer-source-union.md
+++ b/docs/architecture/adr/0004-defer-source-union.md
@@ -1,6 +1,11 @@
 # ADR 0004 — Defer the `Source` discriminated union
 
-**Status:** Deferred (#56)
+**Status:** Implemented — the decomposed effort the decision called for has
+landed. The `ProjectSource` union is the canonical state type with byte-compatible
+flat-shape conversions at the fragment/`state.json`/worker boundaries, and source
+revisions are stamped onto compile requests/results and checked before applying
+(#56 closed; revision stamping in #99). Binary _project_ assets remain out of
+scope (the byte path is hardened, but the import feature is deferred — see #121).
 
 ## Context
 

--- a/docs/architecture/compile-lifecycle.md
+++ b/docs/architecture/compile-lifecycle.md
@@ -8,25 +8,25 @@ pipeline and share one persistent Web Worker.
 
 ```mermaid
 sequenceDiagram
-  participant M as Model
-  participant A as actions (checkSyntax/render)
+  participant M as CompileCoordinator / ExportService
+  participant A as actions (checkSyntax/render/renderExport)
   participant S as scheduler (turnIntoDelayableExecution)
   participant R as openscad-runner
   participant W as Web Worker (WASM)
 
-  M->>A: render(args)({ now })
+  M->>A: render(args)({ now })  (revision stamped on the request)
   A->>S: debounce + supersede
   Note over S: prior delayed/running call is cancelled<br/>and its promise settled (rejected)
   S->>A: job() runs after the delay (or immediately if now)
   A->>R: spawnOpenSCAD(invocation, priority)
   R->>R: cancel lower-priority pending jobs
   R->>W: postMessage(CompileRequest, generation g)
-  W->>W: fresh WASM runtime, mount libs, callMain (synchronous)
-  W-->>R: stdout/stderr/result/error (tagged by id)
+  W->>W: FIFO queue — one compile at a time:<br/>fresh WASM runtime, mount libs, callMain (synchronous)
+  W-->>R: stdout/stderr/result/error (tagged by id, revision echoed)
   R->>R: drop messages from a stale worker generation
   R-->>A: OpenSCADInvocationResults
-  A->>M: RenderOutput { outFile, diagnostics, ... }
-  M->>M: apply only if still the current call (per-kind sequence guard)
+  A->>M: RenderOutput { outFile, diagnostics, revision, ... }
+  M->>M: apply only if still current (per-kind sequence + source revision)
 ```
 
 ## Scheduling and supersession
@@ -40,6 +40,15 @@ can't clobber a newer one. See [ADR 0003](./adr/0003-deterministic-scheduler.md)
 Priorities (`syntax < preview < render < export`) let a higher-priority request
 discard lower-priority **pending** jobs. Because `callMain` is synchronous, a
 job already executing in the worker cannot be interrupted mid-flight.
+
+Preview/render share one delayable instance; **export has its own** (so an
+automatic preview can't supersede an in-progress format conversion, and export
+is submitted at `export` priority). Inside the worker, a **serial FIFO queue**
+runs exactly one compile at a time: the async setup of a job (FS init, library
+mount, WASM creation, source fetch) cannot interleave with another's, and each
+job's stdout/stderr callbacks close over its own request id and output buffer —
+so concurrent requests can't cross-attribute output. A `cancel` message drops a
+still-queued job; an actively-running synchronous `callMain` is uninterruptible.
 
 ## Timeout and worker recovery
 
@@ -59,28 +68,33 @@ generation, and lazily creates a clean worker on the next request. The generatio
 counter makes late messages from a terminated worker no-ops. See
 [ADR 0002](./adr/0002-worker-timeout-recovery.md).
 
-## Staleness defense (three layers)
+## Staleness defense (four layers)
 
 A result can arrive after it is no longer wanted (user kept typing, switched
-files, or triggered a higher-priority job). Stale results are dropped at three
+files, or triggered a higher-priority job). Stale results are dropped at four
 independent layers:
 
 1. **Worker generation** — messages from a terminated worker are ignored
    (`openscad-runner`).
 2. **Scheduler settlement** — a superseded call's promise rejects rather than
    resolving with stale output (`turnIntoDelayableExecution`).
-3. **Per-kind sequence guard** — `Model.render`/`checkSyntax` apply a result only
-   if it is still the latest call of that kind, so a stale call can't clobber the
-   `previewing`/`rendering`/`checkingSyntax` flags a newer call owns.
-
-A project-level revision stamped onto requests/results (a cleaner single
-mechanism) is deferred with the typed-contracts work; see
-[ADR 0004](./adr/0004-defer-source-union.md).
+3. **Per-kind sequence guard** — `CompileCoordinator` (preview/render/syntax) and
+   `ExportService` (export, via a `_exportSeq` token) apply a result only if it is
+   still the latest call of that kind, so a stale call can't clobber the
+   `previewing`/`rendering`/`checkingSyntax`/`exporting` flags a newer call owns.
+4. **Source revision** — `Model.setState` bumps a monotonic source revision when
+   `params.sources` changes; each preview/render request is stamped with the
+   revision at request time and echoed back, and `CompileCoordinator` drops a
+   result whose revision no longer matches. This catches the case where the
+   sources changed but no newer compile of the same kind owns the spinner (e.g.
+   after `newFile()`). See [ADR 0004](./adr/0004-defer-source-union.md).
 
 ## Arguments and diagnostics
 
 `buildOpenScadArgs` (`src/runner/actions.ts`) is the single source of truth for
 the OpenSCAD command line; every compile path builds through it.
-`output-parser` turns OpenSCAD's stderr into host-neutral `Diagnostic`s; the
-editor renders them via the Monaco adapter. See
+`output-parser` turns OpenSCAD's stderr into host-neutral `Diagnostic`s, each
+carrying the compiler-reported file `path`; the editor groups them by path and
+applies each group to the matching Monaco model, so a multi-file project shows a
+file's diagnostics on its own model. See
 [ADR 0001](./adr/0001-host-neutral-diagnostics.md).


### PR DESCRIPTION
## #124 — architecture docs refresh

The re-review (and the prior audit) flagged the architecture docs as materially stale. Corrected against current `main`:

**`README.md` (dependency boundaries)**
- **Viewer core** ✅ — `osc-geometry-viewer` is the model-independent viewer (OFF + settings via props, `camera-change`/`geometry-loaded` events); `osc-viewer-panel` is the thin adapter (#60/#61). (Was ⚠️ "still reaches into global Model".)
- **DOM-free domain** ✅ — the engine touches no `window`/`document`/`navigator`; side effects go through `HostAdapter`, with a lint guard (#59/#90/#108). (Was ⚠️ "Model plays the chime via document".)
- **No editor library in domain/runner** — now **lint-enforced** (#106), not "by convention".
- Module map + diagram: `Model` shown as a façade over `CompileCoordinator`/`ExportService`/`LayoutController`/`ProjectStore`; `Source` → `ProjectSource`.

**`compile-lifecycle.md`**
- Staleness is now **four layers**: source revision is stamped on requests/results and checked (no longer "deferred"; #99). Documents the worker's **serial FIFO queue** (#111), the **separate export channel** + `export` priority, and **per-file diagnostic routing** (#116). References `CompileCoordinator`/`ExportService` instead of `Model` directly.

**ADR 0004** status: `Deferred` → `Implemented` (the decomposed union effort landed; #56 closed, revision in #99).

Docs-only; no code change. Prettier-clean.

Refs #124