### PR TITLE
refactor(protocol): extract a shared envelope/validation core (ADR 0005)

### DIFF
--- a/src/embed/protocol.ts
+++ b/src/embed/protocol.ts
@@ -1,10 +1,22 @@
 // Versioned, validated embed message protocol (issue #63).
 //
 // The embed iframe and its host page communicate over `postMessage`. This
-// module is the single source of truth for the wire format: a protocol
+// module is the single source of truth for the embed wire format: a protocol
 // version, strict inbound validation with size limits, and structured error /
 // acknowledgement envelopes. It is intentionally free of DOM/Lit dependencies
-// so the validation can be unit-tested in isolation.
+// so the validation can be unit-tested in isolation. The version-agnostic
+// envelope/validation primitives live in `src/protocol/envelope.ts` (ADR 0005);
+// this module is one binding over that shared core.
+
+import {
+  isPlainJsonValue,
+  isRecord,
+  stampOutbound,
+  type ProtocolErrorCode,
+} from '../protocol/envelope.ts';
+
+// Origin checking is generic; re-export it so embed consumers keep one import.
+export { isTrustedOrigin } from '../protocol/envelope.ts';
 
 /**
  * Wire protocol version. Inbound messages MUST carry this exact value;
@@ -26,41 +38,12 @@ export type InboundMessage =
   | { type: 'getVars'; requestId?: string }
   | { type: 'getArtifact'; requestId?: string };
 
-export type EmbedErrorCode =
-  | 'malformed' // not an object / missing fields
-  | 'unsupported-version' // protocolVersion absent or != current
-  | 'unknown-type' // type not a recognised inbound command
-  | 'invalid-payload' // recognised type, wrong field types
-  | 'too-large'; // a bounded field exceeded its size limit
+/** Embed rejection codes are the shared protocol vocabulary. */
+export type EmbedErrorCode = ProtocolErrorCode;
 
 export type ValidationResult =
   | { ok: true; message: InboundMessage }
   | { ok: false; code: EmbedErrorCode; reason: string; requestId?: string };
-
-function isRecord(value: unknown): value is Record<string, unknown> {
-  return typeof value === 'object' && value !== null;
-}
-
-/**
- * Whether `value` is a plain JSON value (primitive, or array/plain-object
- * thereof). Exotic structured-cloneable types — `ArrayBuffer`, typed arrays,
- * `Map`, `Set`, `Blob`, `Date`, class instances, functions, symbols — are
- * rejected. `JSON.stringify` collapses those to `"{}"`/`undefined`, which would
- * let a multi-megabyte payload slip the encoded-size limit, so a setVar value
- * must be genuinely JSON-shaped. Assumes an acyclic input (callers stringify
- * first, which rejects cycles).
- */
-function isPlainJsonValue(value: unknown): boolean {
-  if (value === null) return true;
-  const t = typeof value;
-  if (t === 'string' || t === 'boolean') return true;
-  if (t === 'number') return Number.isFinite(value);
-  if (t !== 'object') return false; // function, symbol, bigint, undefined
-  if (Array.isArray(value)) return value.every(isPlainJsonValue);
-  const proto = Object.getPrototypeOf(value);
-  if (proto !== Object.prototype && proto !== null) return false; // exotic object
-  return Object.values(value as Record<string, unknown>).every(isPlainJsonValue);
-}
 
 /** Extract a string requestId if present, so errors/acks can echo it. */
 function readRequestId(data: Record<string, unknown>): string | undefined {
@@ -149,22 +132,7 @@ export function validateInbound(data: unknown): ValidationResult {
   }
 }
 
-/**
- * Whether an inbound message's origin is trusted. With no configured
- * `parentOrigin` only this document's own origin is trusted (same-origin mode);
- * a configured `parentOrigin` is then the sole trusted origin (explicit-origin
- * mode). The wildcard is never trusted — there is no default acceptance of
- * arbitrary parent origins.
- */
-export function isTrustedOrigin(
-  eventOrigin: string,
-  parentOrigin: string | null,
-  selfOrigin: string,
-): boolean {
-  return eventOrigin === (parentOrigin ?? selfOrigin);
-}
-
-/** Stamp an outbound payload with the protocol version. */
+/** Stamp an outbound payload with the embed protocol version. */
 export function outbound(type: string, payload: Record<string, unknown> = {}) {
-  return { protocolVersion: EMBED_PROTOCOL_VERSION, type, ...payload };
+  return stampOutbound(EMBED_PROTOCOL_VERSION, type, payload);
 }

--- a/src/protocol/__tests__/envelope.test.ts
+++ b/src/protocol/__tests__/envelope.test.ts
@@ -1,0 +1,61 @@
+import { describe, expect, it } from 'vitest';
+
+import { isPlainJsonValue, isRecord, isTrustedOrigin, stampOutbound } from '../envelope.ts';
+
+describe('isRecord', () => {
+  it('accepts plain objects and arrays, rejects null/primitives', () => {
+    expect(isRecord({})).toBe(true);
+    expect(isRecord([])).toBe(true);
+    expect(isRecord(null)).toBe(false);
+    expect(isRecord('x')).toBe(false);
+    expect(isRecord(3)).toBe(false);
+  });
+});
+
+describe('isPlainJsonValue', () => {
+  it('accepts JSON primitives, arrays, and plain objects', () => {
+    expect(isPlainJsonValue('s')).toBe(true);
+    expect(isPlainJsonValue(true)).toBe(true);
+    expect(isPlainJsonValue(1.5)).toBe(true);
+    expect(isPlainJsonValue(null)).toBe(true);
+    expect(isPlainJsonValue([1, 'a', { b: 2 }])).toBe(true);
+    expect(isPlainJsonValue({ a: { b: [3] } })).toBe(true);
+  });
+
+  it('rejects non-finite numbers and non-JSON / exotic types', () => {
+    expect(isPlainJsonValue(NaN)).toBe(false);
+    expect(isPlainJsonValue(Infinity)).toBe(false);
+    expect(isPlainJsonValue(undefined)).toBe(false);
+    expect(isPlainJsonValue(() => 0)).toBe(false);
+    expect(isPlainJsonValue(new Map())).toBe(false);
+    expect(isPlainJsonValue(new Uint8Array([1]))).toBe(false);
+    expect(isPlainJsonValue(new Date())).toBe(false);
+    expect(isPlainJsonValue([1, () => 0])).toBe(false); // exotic nested
+  });
+});
+
+describe('isTrustedOrigin', () => {
+  it('trusts only self-origin when no parentOrigin is configured', () => {
+    expect(isTrustedOrigin('https://a.test', null, 'https://a.test')).toBe(true);
+    expect(isTrustedOrigin('https://b.test', null, 'https://a.test')).toBe(false);
+  });
+
+  it('trusts only the configured parentOrigin when set', () => {
+    expect(isTrustedOrigin('https://p.test', 'https://p.test', 'https://a.test')).toBe(true);
+    expect(isTrustedOrigin('https://a.test', 'https://p.test', 'https://a.test')).toBe(false);
+  });
+});
+
+describe('stampOutbound', () => {
+  it('stamps the version and merges the payload under the type', () => {
+    expect(stampOutbound(7, 'ready', { capabilities: ['view'] })).toEqual({
+      protocolVersion: 7,
+      type: 'ready',
+      capabilities: ['view'],
+    });
+  });
+
+  it('defaults to an empty payload', () => {
+    expect(stampOutbound(1, 'ping')).toEqual({ protocolVersion: 1, type: 'ping' });
+  });
+});

--- a/src/protocol/envelope.ts
+++ b/src/protocol/envelope.ts
@@ -1,0 +1,64 @@
+// Shared host↔app message-protocol core (ADR 0005).
+//
+// Transport-agnostic, DOM-free primitives that every protocol binding reuses:
+// the embed iframe protocol (src/embed/protocol.ts), the read-only viewer
+// transport, and the future host-neutral session protocol. Each binding owns its
+// own protocol version, message set, and correlation field; this module owns only
+// the version-stamped envelope, origin checking, and the shared validators.
+
+/** Generic protocol-level rejection reasons (shared error vocabulary). */
+export type ProtocolErrorCode =
+  | 'malformed' // not an object / missing required fields
+  | 'unsupported-version' // protocolVersion absent or mismatched
+  | 'unknown-type' // type not a recognised inbound command
+  | 'invalid-payload' // recognised type, wrong field types
+  | 'too-large'; // a bounded field exceeded its size limit
+
+export function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null;
+}
+
+/**
+ * Whether `value` is a plain JSON value (primitive, or array/plain-object
+ * thereof). Exotic structured-cloneable types — `ArrayBuffer`, typed arrays,
+ * `Map`, `Set`, `Blob`, `Date`, class instances, functions, symbols — are
+ * rejected. `JSON.stringify` collapses those to `"{}"`/`undefined`, which would
+ * let a multi-megabyte payload slip an encoded-size limit, so a value crossing
+ * the boundary must be genuinely JSON-shaped. Assumes an acyclic input (callers
+ * stringify first, which rejects cycles).
+ */
+export function isPlainJsonValue(value: unknown): boolean {
+  if (value === null) return true;
+  const t = typeof value;
+  if (t === 'string' || t === 'boolean') return true;
+  if (t === 'number') return Number.isFinite(value);
+  if (t !== 'object') return false; // function, symbol, bigint, undefined
+  if (Array.isArray(value)) return value.every(isPlainJsonValue);
+  const proto = Object.getPrototypeOf(value);
+  if (proto !== Object.prototype && proto !== null) return false; // exotic object
+  return Object.values(value as Record<string, unknown>).every(isPlainJsonValue);
+}
+
+/**
+ * Whether an inbound message's origin is trusted. With no configured
+ * `parentOrigin` only this document's own origin is trusted (same-origin mode);
+ * a configured `parentOrigin` is then the sole trusted origin (explicit-origin
+ * mode). The wildcard is never trusted — there is no default acceptance of
+ * arbitrary parent origins.
+ */
+export function isTrustedOrigin(
+  eventOrigin: string,
+  parentOrigin: string | null,
+  selfOrigin: string,
+): boolean {
+  return eventOrigin === (parentOrigin ?? selfOrigin);
+}
+
+/** Stamp an outbound payload with a protocol version. */
+export function stampOutbound(
+  protocolVersion: number,
+  type: string,
+  payload: Record<string, unknown> = {},
+) {
+  return { protocolVersion, type, ...payload };
+}


### PR DESCRIPTION
## #126 / ADR 0005 — shared protocol core

Per ADR 0005 (approved), generalize the embed protocol's version-agnostic envelope/validation machinery into a DOM-free **`src/protocol/envelope.ts`** so the viewer transport and the future host-neutral session protocol build on one core — without expanding the iframe-specific embed protocol.

### Extracted (shared)
`isRecord`, `isPlainJsonValue`, `isTrustedOrigin`, `stampOutbound(version, type, payload)`, and the `ProtocolErrorCode` vocabulary.

### Embed rebinds (no behavior change)
`src/embed/protocol.ts` imports the shared primitives; `EmbedErrorCode` aliases `ProtocolErrorCode`; `outbound` wraps `stampOutbound(EMBED_PROTOCOL_VERSION, …)`; `isTrustedOrigin` is re-exported so consumers keep one import. Message set, version, size limits, and `requestId` handling are unchanged.

### Verification
The **21 embed protocol tests are unchanged and pass** (the behavior oracle); new `src/protocol/__tests__/envelope.test.ts` covers the shared primitives. Full `npm run verify` green (404 unit + 20 assembly).

Refs #126