### PR TITLE
feat(protocol): add the Layer-0 viewer transport (ADR 0005)

### DIFF
--- a/src/protocol/__tests__/viewer-transport.test.ts
+++ b/src/protocol/__tests__/viewer-transport.test.ts
@@ -1,0 +1,136 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+  MAX_OFF_LENGTH,
+  VIEWER_PROTOCOL_VERSION,
+  validateViewerInbound,
+  viewerCameraChange,
+  viewerError,
+  viewerGeometryLoaded,
+  viewerReady,
+  type CameraPose,
+} from '../viewer-transport.ts';
+
+const v = VIEWER_PROTOCOL_VERSION;
+const pose: CameraPose = { position: [1, 2, 3], target: [0, 0, 0], zoom: 1.5 };
+
+describe('validateViewerInbound', () => {
+  it('rejects non-objects and version mismatches', () => {
+    expect(validateViewerInbound(null)).toMatchObject({ ok: false, code: 'malformed' });
+    expect(validateViewerInbound({ type: 'dispose' })).toMatchObject({
+      ok: false,
+      code: 'unsupported-version',
+    });
+    expect(validateViewerInbound({ protocolVersion: 999, type: 'dispose' })).toMatchObject({
+      ok: false,
+      code: 'unsupported-version',
+    });
+  });
+
+  it('rejects an unknown type and echoes opId on errors', () => {
+    const r = validateViewerInbound({ protocolVersion: v, type: 'nope', opId: 'x1' });
+    expect(r).toMatchObject({ ok: false, code: 'unknown-type', opId: 'x1' });
+  });
+
+  it('accepts setGeometry and carries opId/sessionId', () => {
+    const r = validateViewerInbound({
+      protocolVersion: v,
+      type: 'setGeometry',
+      offText: 'OFF\n0 0 0\n',
+      opId: 'op1',
+      sessionId: 's1',
+    });
+    expect(r).toEqual({
+      ok: true,
+      message: { type: 'setGeometry', offText: 'OFF\n0 0 0\n', opId: 'op1', sessionId: 's1' },
+    });
+  });
+
+  it('rejects a non-string or oversized offText', () => {
+    expect(
+      validateViewerInbound({ protocolVersion: v, type: 'setGeometry', offText: 42 }),
+    ).toMatchObject({ ok: false, code: 'invalid-payload' });
+    expect(
+      validateViewerInbound({
+        protocolVersion: v,
+        type: 'setGeometry',
+        offText: 'x'.repeat(MAX_OFF_LENGTH + 1),
+      }),
+    ).toMatchObject({ ok: false, code: 'too-large' });
+  });
+
+  it('accepts setViewerSettings with only the provided fields', () => {
+    const r = validateViewerInbound({
+      protocolVersion: v,
+      type: 'setViewerSettings',
+      color: '#fff',
+      showAxes: false,
+    });
+    expect(r).toEqual({
+      ok: true,
+      message: { type: 'setViewerSettings', color: '#fff', showAxes: false },
+    });
+  });
+
+  it('rejects wrong field types in setViewerSettings', () => {
+    expect(
+      validateViewerInbound({ protocolVersion: v, type: 'setViewerSettings', showAxes: 'yes' }),
+    ).toMatchObject({ ok: false, code: 'invalid-payload' });
+    expect(
+      validateViewerInbound({ protocolVersion: v, type: 'setViewerSettings', color: 3 }),
+    ).toMatchObject({ ok: false, code: 'invalid-payload' });
+  });
+
+  it('accepts a valid camera pose and rejects malformed ones', () => {
+    expect(validateViewerInbound({ protocolVersion: v, type: 'setCamera', camera: pose })).toEqual({
+      ok: true,
+      message: { type: 'setCamera', camera: pose },
+    });
+    for (const bad of [
+      { position: [1, 2], target: [0, 0, 0], zoom: 1 }, // short triple
+      { position: [1, 2, 3], target: [0, 0, 0], zoom: 'x' }, // bad zoom
+      { position: [1, 2, NaN], target: [0, 0, 0], zoom: 1 }, // non-finite
+      { target: [0, 0, 0], zoom: 1 }, // missing position
+      'nope',
+    ]) {
+      expect(
+        validateViewerInbound({ protocolVersion: v, type: 'setCamera', camera: bad }),
+      ).toMatchObject({ ok: false, code: 'invalid-payload' });
+    }
+  });
+
+  it('accepts dispose', () => {
+    expect(validateViewerInbound({ protocolVersion: v, type: 'dispose' })).toEqual({
+      ok: true,
+      message: { type: 'dispose' },
+    });
+  });
+});
+
+describe('outbound builders', () => {
+  it('stamp the version and shape', () => {
+    expect(viewerReady(['view'])).toEqual({
+      protocolVersion: v,
+      type: 'ready',
+      capabilities: ['view'],
+    });
+    expect(viewerGeometryLoaded('hash')).toEqual({
+      protocolVersion: v,
+      type: 'geometry-loaded',
+      thumbhash: 'hash',
+    });
+    expect(viewerGeometryLoaded()).toEqual({ protocolVersion: v, type: 'geometry-loaded' });
+    expect(viewerCameraChange(pose)).toEqual({
+      protocolVersion: v,
+      type: 'camera-change',
+      camera: pose,
+    });
+    expect(viewerError('invalid-payload', 'bad', 'op9')).toEqual({
+      protocolVersion: v,
+      type: 'error',
+      code: 'invalid-payload',
+      reason: 'bad',
+      opId: 'op9',
+    });
+  });
+});

--- a/src/protocol/viewer-transport.ts
+++ b/src/protocol/viewer-transport.ts
@@ -1,0 +1,159 @@
+// Layer-0 viewer transport (ADR 0005): the message set for a read-only,
+// host-embedded geometry viewer. A host (iframe / VS Code webview) sends OFF
+// geometry and viewer settings; the viewer reports ready/camera/errors. No
+// compile and no artifacts — pure display. Built on the shared envelope core,
+// DOM-free so the validation is unit-testable in isolation.
+
+import { isRecord, stampOutbound, type ProtocolErrorCode } from './envelope.ts';
+
+/** Bump on any breaking change to the L0 inbound/outbound shapes. */
+export const VIEWER_PROTOCOL_VERSION = 1;
+
+// OFF geometry text from a (trusted) host can be large; cap it as DoS hygiene.
+// Measured in UTF-16 code units.
+export const MAX_OFF_LENGTH = 64 * 1024 * 1024;
+
+/** A camera pose, host-neutral (matches the viewer's CameraState shape). */
+export type CameraPose = {
+  position: [number, number, number];
+  target: [number, number, number];
+  zoom: number;
+};
+
+/** Fields every inbound message may carry for correlation (ADR 0005 envelope). */
+type Correlated = { opId?: string; sessionId?: string };
+
+export type ViewerInbound =
+  | ({ type: 'setGeometry'; offText: string } & Correlated)
+  | ({
+      type: 'setViewerSettings';
+      color?: string;
+      showAxes?: boolean;
+      active?: boolean;
+    } & Correlated)
+  | ({ type: 'setCamera'; camera: CameraPose } & Correlated)
+  | ({ type: 'dispose' } & Correlated);
+
+export type ViewerValidation =
+  | { ok: true; message: ViewerInbound }
+  | { ok: false; code: ProtocolErrorCode; reason: string; opId?: string };
+
+function readString(v: unknown): string | undefined {
+  return typeof v === 'string' ? v : undefined;
+}
+
+function isFiniteNumber(v: unknown): v is number {
+  return typeof v === 'number' && Number.isFinite(v);
+}
+
+function readTriple(v: unknown): [number, number, number] | null {
+  return Array.isArray(v) && v.length === 3 && v.every(isFiniteNumber)
+    ? [v[0] as number, v[1] as number, v[2] as number]
+    : null;
+}
+
+function readCameraPose(v: unknown): CameraPose | null {
+  if (!isRecord(v)) return null;
+  const position = readTriple(v.position);
+  const target = readTriple(v.target);
+  if (!position || !target || !isFiniteNumber(v.zoom)) return null;
+  return { position, target, zoom: v.zoom };
+}
+
+function correlation(data: Record<string, unknown>): Correlated {
+  const opId = readString(data.opId);
+  const sessionId = readString(data.sessionId);
+  return { ...(opId ? { opId } : {}), ...(sessionId ? { sessionId } : {}) };
+}
+
+/**
+ * Validate an untrusted inbound viewer message against the L0 protocol. Returns
+ * the narrowed message or a structured rejection the host can be told about.
+ */
+export function validateViewerInbound(data: unknown): ViewerValidation {
+  if (!isRecord(data)) {
+    return { ok: false, code: 'malformed', reason: 'message is not an object' };
+  }
+  const opId = readString(data.opId);
+  if (data.protocolVersion !== VIEWER_PROTOCOL_VERSION) {
+    return {
+      ok: false,
+      code: 'unsupported-version',
+      reason: `expected protocolVersion ${VIEWER_PROTOCOL_VERSION}`,
+      opId,
+    };
+  }
+  if (typeof data.type !== 'string') {
+    return { ok: false, code: 'malformed', reason: 'missing message type', opId };
+  }
+  const corr = correlation(data);
+
+  switch (data.type) {
+    case 'setGeometry': {
+      if (typeof data.offText !== 'string') {
+        return { ok: false, code: 'invalid-payload', reason: 'offText must be a string', opId };
+      }
+      if (data.offText.length > MAX_OFF_LENGTH) {
+        return { ok: false, code: 'too-large', reason: 'offText exceeds the size limit', opId };
+      }
+      return { ok: true, message: { type: 'setGeometry', offText: data.offText, ...corr } };
+    }
+    case 'setViewerSettings': {
+      const color = data.color === undefined ? undefined : readString(data.color);
+      if (data.color !== undefined && color === undefined) {
+        return { ok: false, code: 'invalid-payload', reason: 'color must be a string', opId };
+      }
+      if (data.showAxes !== undefined && typeof data.showAxes !== 'boolean') {
+        return { ok: false, code: 'invalid-payload', reason: 'showAxes must be a boolean', opId };
+      }
+      if (data.active !== undefined && typeof data.active !== 'boolean') {
+        return { ok: false, code: 'invalid-payload', reason: 'active must be a boolean', opId };
+      }
+      return {
+        ok: true,
+        message: {
+          type: 'setViewerSettings',
+          ...(color !== undefined ? { color } : {}),
+          ...(data.showAxes !== undefined ? { showAxes: data.showAxes as boolean } : {}),
+          ...(data.active !== undefined ? { active: data.active as boolean } : {}),
+          ...corr,
+        },
+      };
+    }
+    case 'setCamera': {
+      const camera = readCameraPose(data.camera);
+      if (!camera) {
+        return { ok: false, code: 'invalid-payload', reason: 'invalid camera pose', opId };
+      }
+      return { ok: true, message: { type: 'setCamera', camera, ...corr } };
+    }
+    case 'dispose':
+      return { ok: true, message: { type: 'dispose', ...corr } };
+    default:
+      return { ok: false, code: 'unknown-type', reason: `unknown type "${data.type}"`, opId };
+  }
+}
+
+// Outbound builders (viewer → host), version-stamped.
+
+export function viewerReady(capabilities: string[]) {
+  return stampOutbound(VIEWER_PROTOCOL_VERSION, 'ready', { capabilities });
+}
+
+export function viewerGeometryLoaded(thumbhash?: string) {
+  return stampOutbound(VIEWER_PROTOCOL_VERSION, 'geometry-loaded', {
+    ...(thumbhash !== undefined ? { thumbhash } : {}),
+  });
+}
+
+export function viewerCameraChange(camera: CameraPose) {
+  return stampOutbound(VIEWER_PROTOCOL_VERSION, 'camera-change', { camera });
+}
+
+export function viewerError(code: ProtocolErrorCode | string, reason: string, opId?: string) {
+  return stampOutbound(VIEWER_PROTOCOL_VERSION, 'error', {
+    code,
+    reason,
+    ...(opId !== undefined ? { opId } : {}),
+  });
+}


### PR DESCRIPTION
## #126 / ADR 0005 — Layer-0 viewer transport

The message set for the read-only, host-embedded geometry viewer, on the shared envelope core (#133):

- **Inbound:** `setGeometry{offText}`, `setViewerSettings{color?,showAxes?,active?}`, `setCamera{camera}`, `dispose` — each with optional `opId`/`sessionId`.
- **Outbound builders:** `viewerReady`, `viewerGeometryLoaded`, `viewerCameraChange`, `viewerError`, all version-stamped.

`validateViewerInbound` is strict: version-gated, per-type field validation, an `offText` size cap (DoS hygiene), full camera-pose validation (finite-number triples + zoom), and `opId` echoed on rejections. DOM-free, so fully unit-testable.

No host wiring yet — this is the contract the viewer-only build entry implements against. **9 tests** cover every branch; full `npm run verify` green (413 unit + 20 assembly).

Refs #126