### PR TITLE
feat(viewer): imperative setCamera + optional thumbnails on osc-geometry-viewer

### DIFF
--- a/src/components/elements/osc-geometry-viewer.ts
+++ b/src/components/elements/osc-geometry-viewer.ts
@@ -31,6 +31,13 @@ export class OscGeometryViewer extends LitElement {
   @property({ type: Boolean }) active = true;
   /** Initial camera; applied on mount only — the user drives it afterward. */
   @property({ attribute: false }) camera: CameraState | null = null;
+  /**
+   * When true (default), a thumbnail hash is computed after each load and
+   * included in the `geometry-loaded` event. A host that only displays geometry
+   * (no preview placeholder) can set this false to skip the hashing work; the
+   * `geometry-loaded` event still fires (without a thumbhash) as the load signal.
+   */
+  @property({ type: Boolean }) generateThumbnails = true;
 
   @state() private _toastMessage: string | null = null;
 
@@ -93,6 +100,15 @@ export class OscGeometryViewer extends LitElement {
     if (this._toastTimer) clearTimeout(this._toastTimer);
   }
 
+  /**
+   * Imperatively set the camera pose (e.g. a host command: top view, restore
+   * pose). Applied silently so it does not echo back as a `camera-change` event.
+   * Unlike the mount-only `camera` property, this works at any time.
+   */
+  setCamera(camera: CameraState): void {
+    this._scene?.applyCameraState(camera, { silent: true });
+  }
+
   private async _loadGeometry(offText: string) {
     const scene = this._scene;
     if (!scene) return;
@@ -102,6 +118,12 @@ export class OscGeometryViewer extends LitElement {
       const geometry = offToBufferGeometry(parseOff(offText));
       scene.loadGeometry(geometry, this.color);
       if (this._container) this._container.dataset.geometryLoaded = 'true';
+
+      if (!this.generateThumbnails) {
+        // Geometry is loaded; signal the host without the (skipped) thumbnail.
+        this.dispatchEvent(new CustomEvent('geometry-loaded', { detail: {} }));
+        return;
+      }
 
       // Render the new geometry before capturing so the thumbnail isn't stale.
       scene.renderOnce();

--- a/src/components/viewer/ThreeScene.ts
+++ b/src/components/viewer/ThreeScene.ts
@@ -50,6 +50,9 @@ export class ThreeScene {
 
   // Callback fired (debounced) when the user moves the camera.
   onCameraChange: ((state: CameraState) => void) | null = null;
+  // Set while a programmatic applyCameraState({ silent }) runs, so its
+  // synchronous 'change' event is not echoed back to onCameraChange.
+  private suppressCameraChange = false;
   // Fired when the WebGL context is lost (recoverable; a restore re-renders).
   onContextLost: (() => void) | null = null;
 
@@ -101,7 +104,10 @@ export class ThreeScene {
     this.controls.addEventListener('change', () => {
       // Any control-driven change needs a frame...
       this.requestRender();
-      // ...and is forwarded to the caller (debounced 200 ms).
+      // ...and is forwarded to the caller (debounced 200 ms) — unless this change
+      // came from a programmatic applyCameraState({ silent }), which must not echo
+      // back to a host that just commanded it (feedback loop).
+      if (this.suppressCameraChange) return;
       if (!this.onCameraChange) return;
       if (this.cameraDebounceTimer) clearTimeout(this.cameraDebounceTimer);
       this.cameraDebounceTimer = setTimeout(() => {
@@ -265,13 +271,20 @@ export class ThreeScene {
     };
   }
 
-  applyCameraState(saved: CameraState): void {
-    this.camera.position.set(...saved.position);
-    this.controls.target.set(...saved.target);
-    this.camera.zoom = saved.zoom;
-    this.camera.updateProjectionMatrix();
-    this.controls.update();
-    this.requestRender();
+  applyCameraState(saved: CameraState, opts: { silent?: boolean } = {}): void {
+    // controls.update() dispatches 'change' synchronously; the flag is read by
+    // that handler to skip echoing this programmatic update back to the host.
+    if (opts.silent) this.suppressCameraChange = true;
+    try {
+      this.camera.position.set(...saved.position);
+      this.controls.target.set(...saved.target);
+      this.camera.zoom = saved.zoom;
+      this.camera.updateProjectionMatrix();
+      this.controls.update();
+      this.requestRender();
+    } finally {
+      this.suppressCameraChange = false;
+    }
   }
 
   setCameraPosition(name: string): void {


### PR DESCRIPTION
## #126 / ADR 0005 — reusable-viewer boundary additions

Two host-embedding additions to the model-independent `osc-geometry-viewer`:

- **`setCamera(camera)`** — apply a pose at **any** time (the existing `camera` property is mount-only). Implemented via a new `silent` option on `ThreeScene.applyCameraState` that suppresses the synchronous `'change'` echo, so a host-commanded pose doesn't loop back as a `camera-change` event (the feedback loop the re-review flagged).
- **`generateThumbnails`** (default `true`) — a host that only displays geometry can set it `false` to skip the per-load PNG capture + thumbhash; `geometry-loaded` still fires (without a `thumbhash`) as the load-complete signal.

No app behavior change — defaults preserved (`osc-viewer-panel` keeps thumbnails on; the mount-only `camera` path is unchanged). These are consumed by the forthcoming viewer-only build entry.

Note: `ThreeScene`/WebGL isn't unit-testable in jsdom (project norm); the new API is exercised by the viewer-entry's Playwright smoke test (next PR). Full `npm run verify` green (413 unit + 20 assembly, budgets ok).

Refs #126