### PR TITLE
feat(viewer): standalone viewer-only build entry over the L0 host transport

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
     "start:development": "cross-env NODE_ENV=development vite",
     "start:production": "cross-env PUBLIC_URL=/dist/ npm run build && serve -l 3000 .",
     "start": "npm run start:development",
-    "build": "cross-env NODE_ENV=production vite build && node ./scripts/build-sw.mjs && node ./scripts/verify-production-build.mjs",
+    "build": "cross-env NODE_ENV=production vite build && node ./scripts/build-sw.mjs && node ./scripts/verify-production-build.mjs && node ./scripts/verify-viewer-bundle.mjs",
     "build:publish": "node ./scripts/build-publish.mjs",
     "build:libs": "cross-env LIBS_BUILD_MODE=all node ./scripts/build-assets/cli.mjs",
     "build:libs:clean": "cross-env LIBS_BUILD_MODE=clean node ./scripts/build-assets/cli.mjs",

--- a/scripts/verify-publish-archive.mjs
+++ b/scripts/verify-publish-archive.mjs
@@ -39,6 +39,7 @@ async function main() {
   const entrySet = new Set(entryNames);
 
   assertArchiveHas(entrySet, 'index.html');
+  assertArchiveHas(entrySet, 'viewer.html');
   assertArchiveHasPrefix(entryNames, 'assets/');
   assertArchiveHasPrefix(entryNames, 'libraries/');
 

--- a/scripts/verify-viewer-bundle.mjs
+++ b/scripts/verify-viewer-bundle.mjs
@@ -1,0 +1,84 @@
+// Acceptance gate for the viewer-only entry (ADR 0005 / #126): the standalone
+// geometry viewer must not pull in the editor/compiler stack. Starting from
+// viewer.html's module entry, crawl the transitive chunk graph and assert none
+// of the reachable chunks reaches Monaco, BrowserFS, the OpenSCAD WASM, or a
+// service-worker registration.
+
+import { readFile } from 'node:fs/promises';
+import path from 'node:path';
+
+function distRoot() {
+  const i = process.argv.indexOf('--dir');
+  return path.resolve(i === -1 ? 'dist' : (process.argv[i + 1] ?? 'dist'));
+}
+
+function basename(p) {
+  return p.split('/').pop();
+}
+
+function fail(message) {
+  console.error(`[verify-viewer-bundle] ${message}`);
+  process.exit(1);
+}
+
+const dist = distRoot();
+const assetsDir = path.join(dist, 'assets');
+
+const viewerHtml = await readFile(path.join(dist, 'viewer.html'), 'utf8').catch(() => {
+  fail(`viewer.html not found under ${dist}`);
+});
+const entryMatch = viewerHtml.match(/<script[^>]*\btype="module"[^>]*\bsrc="([^"]+)"/);
+if (!entryMatch) fail('viewer.html has no module entry script');
+const entryFile = basename(entryMatch[1]);
+
+// BFS the reachable chunk graph. The reference regex captures any quoted `*.js`
+// basename — static `import`/`from`, dynamic `import(...)`, and vite preload dep
+// lists — which over-approximates reachability (safe for a must-not-reach gate).
+// Assumes vite's default hashed chunk names (`name-hash.js`, no `?query` suffix
+// and no internal dots); if that naming changes this regex must be revisited.
+const referenceRe = /["'`](?:[^"'`]*\/)?([\w-]+\.js)["'`]/g;
+const reachable = new Set();
+const queue = [entryFile];
+while (queue.length) {
+  const file = queue.shift();
+  if (reachable.has(file)) continue;
+  reachable.add(file);
+  let content;
+  try {
+    content = await readFile(path.join(assetsDir, file), 'utf8');
+  } catch {
+    continue; // not an emitted assets chunk
+  }
+  for (const m of content.matchAll(referenceRe)) {
+    if (!reachable.has(m[1])) queue.push(m[1]);
+  }
+}
+
+// Monaco is its own named chunk; reaching it is the cleanest signal.
+const monaco = [...reachable].filter((f) => f.startsWith('monaco-'));
+if (monaco.length) fail(`viewer bundle reaches Monaco chunk(s): ${monaco.join(', ')}`);
+
+// Content markers that survive minification (Web API property names / asset
+// extensions) for the other forbidden subsystems.
+const forbidden = [
+  { marker: 'BFSRequire', what: 'BrowserFS' },
+  { marker: 'serviceWorker', what: 'a service worker' },
+  { marker: '.wasm', what: 'the OpenSCAD WASM' },
+];
+for (const file of reachable) {
+  let content;
+  try {
+    content = await readFile(path.join(assetsDir, file), 'utf8');
+  } catch {
+    continue;
+  }
+  for (const { marker, what } of forbidden) {
+    if (content.includes(marker)) {
+      fail(`viewer chunk ${file} references ${what} ("${marker}")`);
+    }
+  }
+}
+
+console.log(
+  `[verify-viewer-bundle] OK — ${reachable.size} reachable chunks; no Monaco/BrowserFS/WASM/service-worker.`,
+);

--- a/src/viewer-entry/index.ts
+++ b/src/viewer-entry/index.ts
@@ -1,0 +1,92 @@
+// Viewer-only entry: a standalone, read-only <osc-geometry-viewer> driven
+// entirely by the Layer-0 host transport (ADR 0005). It deliberately pulls in
+// NOTHING from the app shell — no Model, BrowserFS, OpenSCAD WASM, Monaco, or
+// service worker — so it can run inside a VS Code webview or any iframe host.
+// scripts/verify-viewer-bundle.mjs enforces that exclusion at build time.
+
+import '../components/elements/osc-geometry-viewer.ts';
+import { isTrustedOrigin } from '../protocol/envelope.ts';
+import {
+  validateViewerInbound,
+  viewerCameraChange,
+  viewerError,
+  viewerGeometryLoaded,
+  viewerReady,
+} from '../protocol/viewer-transport.ts';
+import type { CameraState } from '../components/viewer/ThreeScene.ts';
+
+type GeometryViewer = HTMLElement & {
+  offText: string | null;
+  color: string;
+  showAxes: boolean;
+  active: boolean;
+  generateThumbnails: boolean;
+  setCamera(camera: CameraState): void;
+};
+
+const selfOrigin = window.location.origin;
+// A trusted parent origin may be injected via ?parentOrigin=… (default: same
+// origin). The wildcard is never trusted.
+const parentOrigin = new URLSearchParams(window.location.search).get('parentOrigin');
+const targetOrigin = parentOrigin ?? selfOrigin;
+// The viewer is meant to be embedded (iframe / webview): the host is the parent
+// frame. When opened top-level there is no host — don't post to ourselves (that
+// would re-enter our own inbound handler).
+const host: Window | null = window.parent !== window ? window.parent : null;
+
+const root = document.getElementById('viewer-root')!;
+const viewer = document.createElement('osc-geometry-viewer') as GeometryViewer;
+// Host-display only — no preview placeholder, so skip thumbnail hashing.
+viewer.generateThumbnails = false;
+root.appendChild(viewer);
+
+function post(message: object): void {
+  host?.postMessage(message, targetOrigin);
+}
+
+// Forward viewer events to the host.
+viewer.addEventListener('camera-change', (e) => {
+  post(viewerCameraChange((e as CustomEvent<CameraState>).detail));
+});
+viewer.addEventListener('geometry-loaded', (e) => {
+  post(viewerGeometryLoaded((e as CustomEvent<{ thumbhash?: string }>).detail.thumbhash));
+});
+viewer.addEventListener('viewer-error', (e) => {
+  // A render/parse failure of host-supplied geometry — distinct from a protocol
+  // validation rejection. Not opId-correlated: geometry loading is async and
+  // decoupled from the setGeometry message that triggered it.
+  post(viewerError('render-error', String((e as CustomEvent).detail)));
+});
+
+const onMessage = (event: MessageEvent): void => {
+  if (!isTrustedOrigin(event.origin, parentOrigin, selfOrigin)) return;
+  const result = validateViewerInbound(event.data);
+  if (!result.ok) {
+    post(viewerError(result.code, result.reason, result.opId));
+    return;
+  }
+  const msg = result.message;
+  switch (msg.type) {
+    case 'setGeometry':
+      viewer.offText = msg.offText;
+      break;
+    case 'setViewerSettings':
+      if (msg.color !== undefined) viewer.color = msg.color;
+      if (msg.showAxes !== undefined) viewer.showAxes = msg.showAxes;
+      if (msg.active !== undefined) viewer.active = msg.active;
+      break;
+    case 'setCamera':
+      viewer.setCamera(msg.camera);
+      break;
+    case 'dispose':
+      // Tear down fully: remove the element (disposes the GL scene) and stop
+      // listening, so no further messages are silently swallowed.
+      viewer.remove();
+      window.removeEventListener('message', onMessage);
+      break;
+  }
+};
+window.addEventListener('message', onMessage);
+
+// Announce readiness and the supported inbound commands.
+post(viewerReady(['setGeometry', 'setViewerSettings', 'setCamera', 'dispose']));

--- a/tests/viewer.spec.ts
+++ b/tests/viewer.spec.ts
@@ -1,0 +1,118 @@
+import { expect, test, type Page } from '@playwright/test';
+
+// The viewer-only entry (viewer.html) is driven entirely by the Layer-0 host
+// transport (ADR 0005). These tests play the host: a same-origin harness page
+// embeds viewer.html in an iframe (real embedding — the viewer posts to its
+// parent, not itself), sends messages, and asserts the viewer reports back.
+
+const isProductionServer = process.env.E2E_SERVER_MODE !== 'dev';
+const appOrigin = isProductionServer ? 'http://localhost:3000' : 'http://localhost:4000';
+const appBasePath =
+  process.env.E2E_SERVER_MODE === 'publish-root'
+    ? '/'
+    : process.env.E2E_SERVER_MODE === 'publish-subpath'
+      ? '/openscad-web/'
+      : isProductionServer
+        ? '/dist/'
+        : '/';
+const baseUrl = new URL(appBasePath, appOrigin);
+const viewerSrc = new URL('viewer.html', baseUrl).toString();
+const harnessUrl = new URL('__viewer_harness.html', baseUrl).toString();
+
+// Single-line OFF header (what parseOff's first branch consumes): a tetrahedron.
+const TETRAHEDRON_OFF = [
+  'OFF 4 4 0',
+  '0 0 0',
+  '1 0 0',
+  '0 1 0',
+  '0 0 1',
+  '3 0 1 2',
+  '3 0 1 3',
+  '3 0 2 3',
+  '3 1 2 3',
+  '',
+].join('\n');
+
+declare global {
+  interface Window {
+    __viewerMessages?: { type?: string; opId?: string }[];
+  }
+}
+
+/** Load a same-origin harness that embeds viewer.html in an iframe and collects
+ *  the messages it posts to the parent. */
+async function embedViewer(page: Page): Promise<void> {
+  await page.route('**/__viewer_harness.html', (route) =>
+    route.fulfill({
+      contentType: 'text/html',
+      body: '<!doctype html><meta charset="utf-8"><title>harness</title><body></body>',
+    }),
+  );
+  await page.goto(harnessUrl);
+  await page.evaluate((src) => {
+    window.__viewerMessages = [];
+    window.addEventListener('message', (e) => window.__viewerMessages!.push(e.data));
+    const frame = document.createElement('iframe');
+    frame.id = 'viewer-frame';
+    frame.src = src;
+    frame.style.cssText = 'width:400px;height:300px;border:0';
+    document.body.appendChild(frame);
+  }, viewerSrc);
+  // The viewer announces readiness to the parent.
+  await page.waitForFunction(
+    () => window.__viewerMessages?.some((m) => m?.type === 'ready'),
+    null,
+    {
+      timeout: 30_000,
+    },
+  );
+}
+
+async function postToViewer(page: Page, message: object): Promise<void> {
+  await page.evaluate((msg) => {
+    const frame = document.getElementById('viewer-frame') as HTMLIFrameElement;
+    frame.contentWindow!.postMessage(msg, window.location.origin);
+  }, message);
+}
+
+test('viewer-only entry loads geometry over the host transport', async ({ page }) => {
+  await embedViewer(page);
+
+  await postToViewer(page, {
+    protocolVersion: 1,
+    type: 'setGeometry',
+    offText: TETRAHEDRON_OFF,
+    opId: 'op-1',
+  });
+
+  // The viewer reports geometry-loaded back to the host.
+  await page.waitForFunction(
+    () => window.__viewerMessages?.some((m) => m?.type === 'geometry-loaded'),
+    null,
+    { timeout: 30_000 },
+  );
+
+  // The viewer never echoed an error for the valid input.
+  const hadError = await page.evaluate(() =>
+    window.__viewerMessages?.some((m) => m?.type === 'error'),
+  );
+  expect(hadError).toBeFalsy();
+});
+
+test('viewer-only entry rejects a malformed message with a correlated error', async ({ page }) => {
+  await embedViewer(page);
+
+  // Wrong protocol version → the viewer replies with an error envelope echoing opId.
+  await postToViewer(page, {
+    protocolVersion: 999,
+    type: 'setGeometry',
+    offText: 'OFF',
+    opId: 'bad',
+  });
+
+  await page.waitForFunction(
+    () => window.__viewerMessages?.some((m) => m?.type === 'error' && m?.opId === 'bad'),
+    null,
+    { timeout: 10_000 },
+  );
+});

--- a/viewer.html
+++ b/viewer.html
@@ -1,0 +1,30 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>OpenSCAD geometry viewer</title>
+    <meta
+      name="description"
+      content="Standalone read-only OpenSCAD geometry viewer, driven over a postMessage host transport. No editor, filesystem, or compiler."
+    />
+    <style>
+      html,
+      body {
+        margin: 0;
+        height: 100%;
+        background: var(--osc-viewer-bg, #1e1e1e);
+      }
+      #viewer-root,
+      osc-geometry-viewer {
+        display: block;
+        width: 100%;
+        height: 100vh;
+      }
+    </style>
+  </head>
+  <body>
+    <div id="viewer-root"></div>
+    <script type="module" src="/src/viewer-entry/index.ts"></script>
+  </body>
+</html>

--- a/vite.shared.ts
+++ b/vite.shared.ts
@@ -1,6 +1,9 @@
 import { readFileSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
 
 import type { UserConfig } from 'vite';
+
+const htmlInput = (name: string) => fileURLToPath(new URL(`./${name}`, import.meta.url));
 
 type PackageJsonShape = {
   homepage?: string;
@@ -29,13 +32,24 @@ export function createAppViteConfig({
     base,
     publicDir: 'public',
     optimizeDeps: {
-      entries: ['index.html'],
+      entries: ['index.html', 'viewer.html'],
     },
     build: {
       outDir,
       target: 'es2022',
       emptyOutDir: true,
       rollupOptions: {
+        // Two HTML entries: the full app (index.html) and a standalone, read-only
+        // geometry viewer (viewer.html) for host/webview embedding. The viewer
+        // entry pulls in only Lit + Three + the OFF viewer — no Monaco, BrowserFS,
+        // OpenSCAD WASM, Model, or service worker (asserted by
+        // scripts/verify-viewer-bundle.mjs).
+        // The `index` key keeps the app entry chunk named `index-*` (the bundle
+        // budgets and the existing tooling key off that).
+        input: {
+          index: htmlInput('index.html'),
+          viewer: htmlInput('viewer.html'),
+        },
         output: {
           // Split the two heavy vendor libraries into their own named chunks so
           // they can be budgeted separately and are only fetched by the surfaces


### PR DESCRIPTION
## #126 (Gate A) — the viewer-only build target

The final Gate-A piece: a dedicated, embeddable geometry viewer that a host (VS Code webview / iframe) drives over the Layer-0 transport (ADR 0005). Builds on the merged contract foundation (#132 ADR, #133 shared core, #134 L0 transport, #135 viewer API).

### What's here
- **`viewer.html` + `src/viewer-entry/`** — mounts only `<osc-geometry-viewer>` (`generateThumbnails=false`) and wires the L0 host: inbound `setGeometry`/`setViewerSettings`/`setCamera`/`dispose`, outbound `ready`/`geometry-loaded`/`camera-change`/`error`. Posts to the **parent frame** (never itself → no self-loop), at a specific `targetOrigin`, trusting only same-origin or an explicit `?parentOrigin=` (never `*`). `dispose` removes the element (disposing the GL scene) and unbinds the listener.
- **Vite multi-page input** (`{ index, viewer }`) — the `index` key preserves the `index-*` app chunk name, so `bundle-budgets.json` and tooling are unchanged.
- **Acceptance gate** `scripts/verify-viewer-bundle.mjs` (run in `build`): crawls the viewer entry's chunk graph and fails if it reaches **Monaco / BrowserFS / OpenSCAD WASM / service worker**. Current build: *6 reachable chunks; none forbidden.* The publish archive now also asserts `viewer.html` is present.
- **Playwright smoke test** (`tests/viewer.spec.ts`): a same-origin harness embeds `viewer.html` in an **iframe** (real embedding), round-trips a tetrahedron OFF → `geometry-loaded`, and checks a version-mismatch → correlated `error`. Passes in both prod (`dist`) and relocatable-publish (`dist-publish`) modes.

### Verification
Full `npm run verify` green (build + budgets + bundle gate + publish + archive); viewer e2e green in prod and publish-subpath. Adversarial review: **no MUST-FIX** — origin model sound (read-only display, no `*`, no exfiltration path), self-loop guarded, bundle gate robust for the named subsystems, deploy pipeline unaffected (SW not registered by the viewer; budgets/archive intact).

With this, **Gate A is fully passed** — a read-only VS Code viewer spike can now consume `viewer.html`. Gate B (#123 — instance-scoped sessions, multi-file/operation/artifact contracts, backend choice) remains parked pending direction.

Closes #126