### PR TITLE
fix(runner): split worker timeout into queue-wait and execution budgets

### DIFF
--- a/src/runner/__tests__/worker-timeout.test.ts
+++ b/src/runner/__tests__/worker-timeout.test.ts
@@ -1,51 +1,65 @@
-// Regression coverage for issue #47: a hung OpenSCAD worker must be recovered.
+// Regression coverage for issue #47 (recover a wedged worker) and #137 (the
+// timeout must distinguish queue-wait from execution, and a job waiting behind
+// legitimate compiles must not be recycled).
 //
 // callMain() is a synchronous WASM call. If it wedges, the worker can process no
-// further messages, so the runner must terminate and recreate it on timeout
-// rather than leaving every subsequent compile blocked on a dead worker.
-//
-// A real stuck worker never responds to ANY message, so the FakeWorker here
-// hangs per-instance: a worker created in "hang" mode answers nothing until it
-// is terminated and a fresh worker is created.
+// further messages, so the runner must terminate and recreate it on timeout. The
+// worker runs jobs in a serial FIFO queue and reports `started` on dequeue; the
+// host charges queue-wait and execution against separate budgets and treats any
+// `started` as forward progress that re-arms still-queued jobs' queue timers.
 
-// The runner's per-job timeout (kept in sync with SOFT/COMPILE timeout in the runner).
-const TIMEOUT_MS = 30_000;
+// Kept in sync with the runner: QUEUE_TIMEOUT_MS and the per-op EXEC budgets.
+const QUEUE_TIMEOUT_MS = 60_000;
+const SYNTAX_EXEC_MS = 20_000;
 
-type WorkerResponseMessage = {
-  type: 'result';
-  id: string;
-  exitCode: number;
-  outputs: [string, Uint8Array][];
-  mergedOutputs: unknown[];
-  elapsedMillis: number;
-};
+type Mode = 'normal' | 'hang-silent' | 'hang-after-started';
 
 const createdWorkers: FakeWorker[] = [];
-let nextWorkerHangs = false;
+let nextWorkerMode: Mode = 'normal';
+let nextJobDurationMs = 0;
 
+// A FakeWorker that faithfully serializes: it processes one queued job at a time,
+// posting `started` on dequeue and `result` after `jobDurationMs`, then pumps the
+// next. `hang-silent` never answers; `hang-after-started` posts `started` then
+// wedges (stays busy forever, like an infinite callMain).
 class FakeWorker {
   onmessage: ((e: MessageEvent) => void) | null = null;
   onerror: ((e: ErrorEvent) => void) | null = null;
-  readonly hangs: boolean;
+  readonly mode: Mode;
+  readonly jobDurationMs: number;
   terminated = false;
+  private queue: string[] = [];
+  private busy = false;
 
   constructor() {
-    this.hangs = nextWorkerHangs;
+    this.mode = nextWorkerMode;
+    this.jobDurationMs = nextJobDurationMs;
     createdWorkers.push(this);
   }
 
   postMessage(msg: { type: string; id: string }) {
     if (msg.type !== 'compile') return;
-    if (this.hangs) return; // a wedged worker never answers any message
-    const response: WorkerResponseMessage = {
-      type: 'result',
-      id: msg.id,
-      exitCode: 0,
-      outputs: [],
-      mergedOutputs: [],
-      elapsedMillis: 0,
-    };
-    setTimeout(() => this.onmessage?.({ data: response } as MessageEvent), 0);
+    if (this.mode === 'hang-silent') return; // never answers any message
+    this.queue.push(msg.id);
+    this.pump();
+  }
+
+  private pump() {
+    if (this.busy || this.terminated) return;
+    const id = this.queue.shift();
+    if (id === undefined) return;
+    this.busy = true;
+    if (this.terminated) return;
+    this.onmessage?.({ data: { type: 'started', id } } as MessageEvent);
+    if (this.mode === 'hang-after-started') return; // wedge: never frees the worker
+    setTimeout(() => {
+      if (this.terminated) return;
+      this.onmessage?.({
+        data: { type: 'result', id, exitCode: 0, outputs: [], mergedOutputs: [], elapsedMillis: 0 },
+      } as MessageEvent);
+      this.busy = false;
+      this.pump();
+    }, this.jobDurationMs);
   }
 
   terminate() {
@@ -63,7 +77,8 @@ beforeEach(async () => {
   vi.resetModules();
   vi.useFakeTimers();
   createdWorkers.length = 0;
-  nextWorkerHangs = false;
+  nextWorkerMode = 'normal';
+  nextJobDurationMs = 0;
   ({ spawnOpenSCAD } = await import('../openscad-runner.ts'));
 });
 
@@ -71,49 +86,83 @@ afterEach(() => {
   vi.useRealTimers();
 });
 
-describe('worker timeout recovery (#47)', () => {
-  it('terminates a wedged worker on timeout and recovers on the next compile', async () => {
-    nextWorkerHangs = true;
+describe('worker timeout recovery (#47, #137)', () => {
+  it('recycles a worker that never reports a job started (queue-wait timeout)', async () => {
+    nextWorkerMode = 'hang-silent';
     const hung = spawnOpenSCAD({ mountArchives: false, args: ['a.scad'] }, () => {});
     const hungOutcome = hung.then(
       () => 'resolved',
       (e) => e as Error,
     );
 
-    await vi.advanceTimersByTimeAsync(TIMEOUT_MS + 100);
+    await vi.advanceTimersByTimeAsync(QUEUE_TIMEOUT_MS + 100);
 
     const err = await hungOutcome;
     expect(err).toBeInstanceOf(Error);
-    expect(String(err)).toMatch(/timed out/i);
-
-    // The wedged worker must have been terminated (not left running).
+    expect(String(err)).toMatch(/timed out.*waiting to run/i);
     expect(createdWorkers[0].terminated).toBe(true);
 
-    // The next compile must run on a fresh worker and succeed.
-    nextWorkerHangs = false;
+    // The next compile runs on a fresh worker and succeeds.
+    nextWorkerMode = 'normal';
     const next = spawnOpenSCAD({ mountArchives: false, args: ['b.scad'] }, () => {});
     await vi.advanceTimersByTimeAsync(10);
     const result = await next;
-
     expect(result.exitCode).toBe(0);
-    expect(createdWorkers).toHaveLength(2); // a clean worker was created lazily
+    expect(createdWorkers).toHaveLength(2);
     expect(createdWorkers[1].terminated).toBe(false);
   });
 
+  it('recycles a worker that reports started then wedges, at the execution budget', async () => {
+    nextWorkerMode = 'hang-after-started';
+    // A syntax check has the shortest execution budget.
+    const hung = spawnOpenSCAD({ mountArchives: false, args: ['a.scad'] }, () => {}, 'syntax');
+    const outcome = hung.then(
+      () => 'resolved',
+      (e) => e as Error,
+    );
+
+    // It must NOT survive past its (short) execution budget, even though the
+    // larger queue-wait budget has not elapsed — proving `started` switched timers.
+    await vi.advanceTimersByTimeAsync(SYNTAX_EXEC_MS + 100);
+
+    const err = await outcome;
+    expect(err).toBeInstanceOf(Error);
+    expect(String(err)).toMatch(/execution budget/i);
+    expect(createdWorkers[0].terminated).toBe(true);
+  });
+
+  it('does not recycle jobs that legitimately wait behind earlier compiles', async () => {
+    // Three same-priority (non-superseding) exports, each running 35s, serialize:
+    // they finish at ~35s, ~70s, ~105s. The third waits ~70s in the queue — well
+    // past the 60s queue budget measured from its own submission. It must NOT be
+    // recycled (and must not take the healthy running compile down with it),
+    // because each `started` re-arms the still-queued jobs' queue timers.
+    nextJobDurationMs = 35_000;
+    const jobs = [0, 1, 2].map((i) =>
+      spawnOpenSCAD({ mountArchives: false, args: [`m${i}.scad`] }, () => {}, 'export'),
+    );
+
+    await vi.advanceTimersByTimeAsync(3 * 35_000 + 1_000);
+
+    const results = await Promise.all(jobs);
+    expect(results.map((r) => r.exitCode)).toEqual([0, 0, 0]);
+    expect(createdWorkers).toHaveLength(1);
+    expect(createdWorkers[0].terminated).toBe(false);
+  });
+
   it('ignores a late response from a terminated worker generation', async () => {
-    nextWorkerHangs = true;
+    nextWorkerMode = 'hang-silent';
     const hung = spawnOpenSCAD({ mountArchives: false, args: ['a.scad'] }, () => {});
     const hungOutcome = hung.then(
       () => 'resolved',
       (e) => e as Error,
     );
-    await vi.advanceTimersByTimeAsync(TIMEOUT_MS + 100);
+    await vi.advanceTimersByTimeAsync(QUEUE_TIMEOUT_MS + 100);
     await hungOutcome;
 
     const oldWorker = createdWorkers[0];
     expect(oldWorker.terminated).toBe(true);
 
-    // A message arriving late from the terminated worker must be ignored, not throw.
     expect(() =>
       oldWorker.onmessage?.({
         data: {

--- a/src/runner/openscad-runner.ts
+++ b/src/runner/openscad-runner.ts
@@ -71,6 +71,10 @@ type PendingJob = {
   reject: (e: Error) => void;
   streamsCallback: (ps: ProcessStreams) => void;
   priority: number;
+  /** Execution budget (ms) applied once the worker reports the job `started`. */
+  execTimeoutMs: number;
+  /** True once the worker reports this job `started` (now on the execution clock). */
+  started: boolean;
   startTime: number;
   timeoutHandle: ReturnType<typeof setTimeout> | null;
 };
@@ -84,10 +88,45 @@ let _workerGeneration = 0;
 let _firstCompileRequested = false;
 let _firstCompileCompleted = false;
 
-// A compile that has not produced a result within this window means the worker
-// is wedged (callMain is synchronous and cannot be interrupted), so the worker
-// is terminated and recreated rather than left blocking all future work.
-const COMPILE_TIMEOUT_MS = 30_000;
+// Two independent budgets (the worker runs jobs in a serial FIFO queue, so a
+// single submission-to-result timer would charge a job for time it spent merely
+// waiting behind another compile):
+//   - QUEUE: submission → the worker reports `started`. Generous, because a job
+//     can legitimately wait behind earlier compiles; exceeding it means the
+//     worker is wedged before it could even begin this job, so recycle it.
+//   - EXECUTION (per operation): `started` → result. Charged only to the running
+//     compile. A wedged synchronous callMain trips this and recycles the worker.
+const QUEUE_TIMEOUT_MS = 60_000;
+const EXEC_TIMEOUT_MS: Record<JobPriority, number> = {
+  syntax: 20_000,
+  preview: 30_000,
+  render: 60_000,
+  export: 60_000,
+};
+
+// Arm (or re-arm) a job's queue-wait timer. The queue timer is a worker-liveness
+// check: it is reset whenever any job reports `started` (forward progress), so it
+// fires only if the worker makes no progress at all for the window — a wedge —
+// not merely because a job waited a long time behind legitimate compiles.
+function armQueueTimer(id: string, job: PendingJob): void {
+  if (job.timeoutHandle != null) clearTimeout(job.timeoutHandle);
+  job.timeoutHandle = setTimeout(
+    () => failTimedOutJob(id, `Compile timed out after ${QUEUE_TIMEOUT_MS / 1000}s waiting to run`),
+    QUEUE_TIMEOUT_MS,
+  );
+}
+
+// Fail a timed-out job and recycle the (presumed wedged) worker. Shared by the
+// queue-wait and execution timers.
+function failTimedOutJob(id: string, reason: string): void {
+  const stuck = _pending.get(id);
+  if (!stuck) return; // already resolved, cancelled, or superseded
+  clearJobTimers(stuck);
+  _pending.delete(id);
+  stuck.reject(new Error(reason));
+  console.warn(`[runner] ${reason} (compile ${id})`);
+  recycleWorker('Worker recycled after timeout');
+}
 
 function getWorker(): Worker {
   if (!_worker) {
@@ -122,7 +161,28 @@ function handleWorkerMessage(e: MessageEvent<WorkerResponse>, generation: number
   const job = _pending.get(msg.id);
   if (!job) return; // stale response — job was cancelled or timed out
 
-  if (msg.type === 'result') {
+  if (msg.type === 'started') {
+    // The job left the queue and is executing: replace the queue-wait timer with
+    // the execution budget so the compile gets its full allowance regardless of
+    // how long it waited in the queue.
+    job.started = true;
+    if (job.timeoutHandle != null) clearTimeout(job.timeoutHandle);
+    job.timeoutHandle = setTimeout(
+      () =>
+        failTimedOutJob(
+          msg.id,
+          `Compile exceeded its ${job.execTimeoutMs / 1000}s execution budget`,
+        ),
+      job.execTimeoutMs,
+    );
+    // Forward progress: re-arm the queue-wait window for every still-queued job,
+    // so a job merely waiting behind legitimate compiles is never recycled (and
+    // never takes the healthy running compile down with it).
+    for (const [otherId, other] of _pending) {
+      if (other === job || other.started) continue;
+      armQueueTimer(otherId, other);
+    }
+  } else if (msg.type === 'result') {
     const r = msg as CompileResult;
     recordCompilePerf(job, r.perf);
     clearJobTimers(job);
@@ -232,24 +292,19 @@ export function spawnOpenSCAD(
       reject,
       streamsCallback,
       priority: incomingPriority,
+      execTimeoutMs: EXEC_TIMEOUT_MS[priority],
+      started: false,
       startTime: performance.now(),
       timeoutHandle: null,
     };
 
-    // Timeout: the worker has produced no result in time. Because callMain is a
-    // synchronous WASM call, a wedged worker can process neither this job nor any
-    // queued or future request — so reject this job and recycle the worker so the
-    // next request runs on a clean one. recycleWorker() rejects the remaining
-    // pending jobs (which are stuck behind this one on the same worker).
-    job.timeoutHandle = setTimeout(() => {
-      const stuck = _pending.get(id);
-      if (!stuck) return; // already resolved, cancelled, or superseded
-      clearJobTimers(stuck);
-      _pending.delete(id);
-      reject(new Error(`Compile timed out after ${COMPILE_TIMEOUT_MS / 1000}s`));
-      console.warn(`[runner] Compile ${id} timed out after ${COMPILE_TIMEOUT_MS / 1000}s`);
-      recycleWorker('Worker recycled after timeout');
-    }, COMPILE_TIMEOUT_MS);
+    // Queue-wait timeout: the worker has not even reported this job `started`
+    // within the window. Because callMain is a synchronous WASM call, a wedged
+    // worker can process neither this job nor any queued or future request — so
+    // reject this job and recycle the worker. The timer is re-armed to the
+    // execution budget once the worker reports `started` (see handleWorkerMessage),
+    // so queue time is never charged against the compile's own allowance.
+    armQueueTimer(id, job);
 
     _pending.set(id, job);
 

--- a/src/runner/openscad-worker.ts
+++ b/src/runner/openscad-worker.ts
@@ -17,6 +17,7 @@ import {
   CompileResult,
   CompileError,
   CompilePerfStats,
+  CompileStarted,
   CompileStdout,
   CompileStderr,
   MergedOutput,
@@ -112,6 +113,11 @@ async function runCompile(msg: CompileRequest): Promise<void> {
   const mergedOutputs: MergedOutput[] = [];
   const start = performance.now();
   const perf: CompilePerfStats = {};
+
+  // The job has left the queue and is now executing: tell the host so it can
+  // switch this job from the queue-wait budget to the execution budget (queue
+  // time must not consume the compile's allowance).
+  self.postMessage({ type: 'started', id } satisfies CompileStarted);
 
   try {
     await ensureWorkerBrowserFSLoaded();


### PR DESCRIPTION
## P1 (#137) — worker timeout counted queue-wait, not just execution

The single 30s timer was armed at **submission**, but since #111 the worker runs jobs in a **serial FIFO queue** (one uninterruptible `callMain` at a time). So a job's budget included time spent merely waiting behind another compile — a high-priority export queued behind a long preview could time out before/just-after it began, wrongly recycling a healthy worker.

### Fix
- The worker posts `{type:'started', id}` on dequeue (the `CompileStarted` type already existed, unused).
- The host arms a **queue-wait** timer at submission (`QUEUE_TIMEOUT_MS = 60s`); on `started` it replaces it with a per-operation **execution** budget (`syntax 20s, preview 30s, render/export 60s`) — measured from `started`, so queue time is never charged to the compile.
- **Forward-progress reset:** any `started` re-arms every still-queued job's queue timer, so the queue timer fires only when the worker makes *no progress at all* (a wedge) — not because a job legitimately waited behind earlier compiles. This eliminates a false positive where N stacked same-priority jobs could recycle a *healthy running* compile as collateral (caught in adversarial review).

Strictly more lenient than before (a 40s render that died at 30s-from-submission now gets 60s-from-`started`). Worker recovery preserved across all wedge modes.

### Tests (`worker-timeout.test.ts`, faithful serializing fake worker)
queue-wait timeout (never-started) · execution budget (started-then-wedge, at the short syntax budget — proves the timer switched) · **stacked legitimate jobs not recycled** (3×35s exports, ~70s queue wait, all succeed) · late-message-ignored.

Full `npm run verify` green (415 unit + 20 assembly). Adversarial review: no MUST-FIX (timer lifecycle leak-free, recovery preserved); the one design NIT it raised is fixed here by the forward-progress reset.

Closes #137