### PR TITLE
feat(viewer): buffer pre-mount setCamera; optional controls + theme vars

### DIFF
--- a/src/components/elements/osc-geometry-viewer.test.ts
+++ b/src/components/elements/osc-geometry-viewer.test.ts
@@ -1,0 +1,23 @@
+// @vitest-environment jsdom
+import { describe, expect, it } from 'vitest';
+
+import { OscGeometryViewer } from './osc-geometry-viewer.ts';
+import type { CameraState } from '../viewer/ThreeScene.ts';
+
+const pose: CameraState = { position: [1, 2, 3], target: [0, 0, 0], zoom: 1.5 };
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+const priv = (el: OscGeometryViewer) => el as unknown as { _pendingCamera: CameraState | null };
+
+describe('osc-geometry-viewer setCamera (race with mount)', () => {
+  it('buffers a camera commanded before the scene exists', () => {
+    const el = new OscGeometryViewer();
+    // Not mounted → no scene yet; the command must not be dropped.
+    el.setCamera(pose);
+    expect(priv(el)._pendingCamera).toEqual(pose);
+  });
+
+  it('shows the camera controls by default', () => {
+    expect(new OscGeometryViewer().showControls).toBe(true);
+  });
+});

--- a/src/components/elements/osc-geometry-viewer.ts
+++ b/src/components/elements/osc-geometry-viewer.ts
@@ -38,6 +38,10 @@ export class OscGeometryViewer extends LitElement {
    * `geometry-loaded` event still fires (without a thumbhash) as the load signal.
    */
   @property({ type: Boolean }) generateThumbnails = true;
+  /** Show the built-in camera-preset buttons. A host with its own UI can hide them. */
+  @property({ type: Boolean }) showControls = true;
+  /** Scene background (any CSS/Three colour). Defaults to the viewer's dark grey. */
+  @property() background?: string;
 
   @state() private _toastMessage: string | null = null;
 
@@ -45,6 +49,9 @@ export class OscGeometryViewer extends LitElement {
   private _ro: ResizeObserver | null = null;
   private _container: HTMLDivElement | null = null;
   private _loadedOffText: string | null = null;
+  // A camera pose commanded via setCamera() before the scene exists, applied
+  // once firstUpdated() builds it (avoids dropping a command that races mount).
+  private _pendingCamera: CameraState | null = null;
   // Monotonic load id: a newer _loadGeometry supersedes an older one whose
   // thumbnail hashing is still in flight, so a slow older hash cannot overwrite
   // the newer geometry's preview.
@@ -58,7 +65,14 @@ export class OscGeometryViewer extends LitElement {
 
     const scene = new ThreeScene(container);
     this._scene = scene;
+    if (this.background) scene.setBackground(this.background);
     if (this.camera) scene.applyCameraState(this.camera);
+    // A setCamera() that arrived before the scene existed wins over the initial
+    // camera property (it was an explicit host command).
+    if (this._pendingCamera) {
+      scene.applyCameraState(this._pendingCamera, { silent: true });
+      this._pendingCamera = null;
+    }
     scene.setAxesVisible(this.showAxes);
     scene.onCameraChange = (cam) =>
       this.dispatchEvent(new CustomEvent<CameraState>('camera-change', { detail: cam }));
@@ -82,6 +96,7 @@ export class OscGeometryViewer extends LitElement {
     if (changed.has('active')) scene.setActive(this.active);
     if (changed.has('showAxes')) scene.setAxesVisible(this.showAxes);
     if (changed.has('color') && this.color) scene.setModelColor(this.color);
+    if (changed.has('background') && this.background) scene.setBackground(this.background);
     if (changed.has('offText') && this.offText && this.offText !== this._loadedOffText) {
       this._loadGeometry(this.offText);
     }
@@ -106,7 +121,8 @@ export class OscGeometryViewer extends LitElement {
    * Unlike the mount-only `camera` property, this works at any time.
    */
   setCamera(camera: CameraState): void {
-    this._scene?.applyCameraState(camera, { silent: true });
+    if (this._scene) this._scene.applyCameraState(camera, { silent: true });
+    else this._pendingCamera = camera; // applied when firstUpdated() builds the scene
   }
 
   private async _loadGeometry(offText: string) {
@@ -160,8 +176,8 @@ export class OscGeometryViewer extends LitElement {
           position: absolute;
           top: 8px;
           right: 8px;
-          background: var(--osc-overlay);
-          color: var(--osc-on-accent);
+          background: var(--osc-viewer-control-background, var(--osc-overlay, rgba(0, 0, 0, 0.6)));
+          color: var(--osc-viewer-control-foreground, var(--osc-on-accent, #fff));
           padding: 4px 12px;
           border-radius: 4px;
           font-size: 0.8rem;
@@ -177,26 +193,30 @@ export class OscGeometryViewer extends LitElement {
         style="flex:1;position:relative;width:100%;height:100%;"
       ></div>
       ${this._toastMessage ? html`<div class="osc-toast">${this._toastMessage}</div>` : ''}
-      <div
-        aria-label="Viewer camera presets"
-        style="position:absolute;bottom:8px;right:8px;display:flex;flex-direction:column;gap:2px;z-index:2;"
-      >
-        ${NAMED_POSITIONS.map(
-          ({ name }) => html`
-            <button
-              title="${name} view"
-              aria-label=${`Set ${name} view`}
-              @click=${() => {
-                this._scene?.setCameraPosition(name);
-                this._showToast(`${name} view`);
-              }}
-              style="font-size:0.65rem;padding:2px 6px;cursor:pointer;opacity:0.75;background:var(--osc-overlay);color:var(--osc-on-accent);border:none;border-radius:3px;"
+      ${this.showControls
+        ? html`
+            <div
+              aria-label="Viewer camera presets"
+              style="position:absolute;bottom:8px;right:8px;display:flex;flex-direction:column;gap:2px;z-index:2;"
             >
-              ${name}
-            </button>
-          `,
-        )}
-      </div>
+              ${NAMED_POSITIONS.map(
+                ({ name }) => html`
+                  <button
+                    title="${name} view"
+                    aria-label=${`Set ${name} view`}
+                    @click=${() => {
+                      this._scene?.setCameraPosition(name);
+                      this._showToast(`${name} view`);
+                    }}
+                    style="font-size:0.65rem;padding:2px 6px;cursor:pointer;opacity:0.75;background:var(--osc-viewer-control-background, var(--osc-overlay, rgba(0, 0, 0, 0.6)));color:var(--osc-viewer-control-foreground, var(--osc-on-accent, #fff));border:none;border-radius:3px;"
+                  >
+                    ${name}
+                  </button>
+                `,
+              )}
+            </div>
+          `
+        : ''}
     `;
   }
 }

--- a/src/components/viewer/ThreeScene.ts
+++ b/src/components/viewer/ThreeScene.ts
@@ -271,6 +271,12 @@ export class ThreeScene {
     };
   }
 
+  /** Set the scene background (any Three.js color representation). */
+  setBackground(color: THREE.ColorRepresentation): void {
+    this.scene.background = new THREE.Color(color);
+    this.requestRender();
+  }
+
   applyCameraState(saved: CameraState, opts: { silent?: boolean } = {}): void {
     // controls.update() dispatches 'change' synchronously; the flag is read by
     // that handler to skip echoing this programmatic update back to the host.


### PR DESCRIPTION
## #138 (Layer-0 viewer hardening) — component half

From the re-review of `main@d7008fd`:

- **`setCamera` race fix** — a camera commanded before `firstUpdated()` built the scene was a `_scene?.` no-op and **silently dropped** (a host sending it right after the entry's `ready` would lose it). Now buffered in `_pendingCamera` and applied when the scene is created (an explicit host command wins over the initial `camera` property). Unit-tested.
- **`showControls`** (default `true`) — a host with its own UI can hide the built-in camera-preset buttons.
- **`background`** property + **`ThreeScene.setBackground()`** — the previously hard-coded scene background is now configurable.
- **Theme contract** — the controls/toast use self-contained CSS-variable defaults (`--osc-viewer-control-background`/`-foreground`, falling back through the app palette to literal colours), so the standalone viewer is themed without the app stylesheet.

No app behavior change — all defaults preserved. Full `npm run verify` green (417 unit + 20 assembly); viewer bundle gate + e2e pass.

The transport-side items of #138 (correlated `*-set` responses, `event.source` check, `parentOrigin` canonicalization) follow in a second PR.

Refs #138, #126