### PR TITLE
feat(viewer): correlated L0 acks; check event.source; canonicalize parentOrigin

### DIFF
--- a/src/protocol/__tests__/viewer-transport.test.ts
+++ b/src/protocol/__tests__/viewer-transport.test.ts
@@ -5,9 +5,13 @@ import {
   VIEWER_PROTOCOL_VERSION,
   validateViewerInbound,
   viewerCameraChange,
+  viewerCameraSet,
+  viewerDisposed,
   viewerError,
   viewerGeometryLoaded,
+  viewerGeometrySet,
   viewerReady,
+  viewerSettingsSet,
   type CameraPose,
 } from '../viewer-transport.ts';
 
@@ -132,5 +136,17 @@ describe('outbound builders', () => {
       reason: 'bad',
       opId: 'op9',
     });
+  });
+
+  it('correlated acks echo opId and omit it when absent', () => {
+    expect(viewerGeometrySet('a')).toEqual({ protocolVersion: v, type: 'geometry-set', opId: 'a' });
+    expect(viewerSettingsSet('b')).toEqual({
+      protocolVersion: v,
+      type: 'viewer-settings-set',
+      opId: 'b',
+    });
+    expect(viewerCameraSet('c')).toEqual({ protocolVersion: v, type: 'camera-set', opId: 'c' });
+    expect(viewerDisposed('d')).toEqual({ protocolVersion: v, type: 'disposed', opId: 'd' });
+    expect(viewerGeometrySet()).toEqual({ protocolVersion: v, type: 'geometry-set' });
   });
 });

--- a/src/protocol/viewer-transport.ts
+++ b/src/protocol/viewer-transport.ts
@@ -157,3 +157,15 @@ export function viewerError(code: ProtocolErrorCode | string, reason: string, op
     ...(opId !== undefined ? { opId } : {}),
   });
 }
+
+// Correlated terminal acknowledgements — one per inbound command, echoing its
+// opId so a host can await deterministic completion. (The spontaneous
+// `camera-change` and the render-complete `geometry-loaded` stay uncorrelated.)
+function ack(type: string, opId?: string) {
+  return stampOutbound(VIEWER_PROTOCOL_VERSION, type, opId !== undefined ? { opId } : {});
+}
+
+export const viewerGeometrySet = (opId?: string) => ack('geometry-set', opId);
+export const viewerSettingsSet = (opId?: string) => ack('viewer-settings-set', opId);
+export const viewerCameraSet = (opId?: string) => ack('camera-set', opId);
+export const viewerDisposed = (opId?: string) => ack('disposed', opId);

--- a/src/viewer-entry/index.ts
+++ b/src/viewer-entry/index.ts
@@ -9,9 +9,13 @@ import { isTrustedOrigin } from '../protocol/envelope.ts';
 import {
   validateViewerInbound,
   viewerCameraChange,
+  viewerCameraSet,
+  viewerDisposed,
   viewerError,
   viewerGeometryLoaded,
+  viewerGeometrySet,
   viewerReady,
+  viewerSettingsSet,
 } from '../protocol/viewer-transport.ts';
 import type { CameraState } from '../components/viewer/ThreeScene.ts';
 
@@ -25,9 +29,21 @@ type GeometryViewer = HTMLElement & {
 };
 
 const selfOrigin = window.location.origin;
-// A trusted parent origin may be injected via ?parentOrigin=… (default: same
-// origin). The wildcard is never trusted.
-const parentOrigin = new URLSearchParams(window.location.search).get('parentOrigin');
+// A trusted parent origin may be injected via ?parentOrigin=…; parse it as a URL
+// and keep only the origin, rejecting malformed values and unsupported schemes
+// (and never the wildcard). A bad value falls back to same-origin-only trust.
+function canonicalOrigin(raw: string | null): string | null {
+  if (raw == null) return null;
+  try {
+    const url = new URL(raw);
+    return url.protocol === 'https:' || url.protocol === 'http:' ? url.origin : null;
+  } catch {
+    return null;
+  }
+}
+const parentOrigin = canonicalOrigin(
+  new URLSearchParams(window.location.search).get('parentOrigin'),
+);
 const targetOrigin = parentOrigin ?? selfOrigin;
 // The viewer is meant to be embedded (iframe / webview): the host is the parent
 // frame. When opened top-level there is no host — don't post to ourselves (that
@@ -59,6 +75,9 @@ viewer.addEventListener('viewer-error', (e) => {
 });
 
 const onMessage = (event: MessageEvent): void => {
+  // Trust both the origin AND the sender window: a same-origin sibling frame
+  // must not be able to drive the viewer. When embedded, only the host frame.
+  if (host !== null && event.source !== host) return;
   if (!isTrustedOrigin(event.origin, parentOrigin, selfOrigin)) return;
   const result = validateViewerInbound(event.data);
   if (!result.ok) {
@@ -69,20 +88,24 @@ const onMessage = (event: MessageEvent): void => {
   switch (msg.type) {
     case 'setGeometry':
       viewer.offText = msg.offText;
+      post(viewerGeometrySet(msg.opId));
       break;
     case 'setViewerSettings':
       if (msg.color !== undefined) viewer.color = msg.color;
       if (msg.showAxes !== undefined) viewer.showAxes = msg.showAxes;
       if (msg.active !== undefined) viewer.active = msg.active;
+      post(viewerSettingsSet(msg.opId));
       break;
     case 'setCamera':
       viewer.setCamera(msg.camera);
+      post(viewerCameraSet(msg.opId));
       break;
     case 'dispose':
       // Tear down fully: remove the element (disposes the GL scene) and stop
       // listening, so no further messages are silently swallowed.
       viewer.remove();
       window.removeEventListener('message', onMessage);
+      post(viewerDisposed(msg.opId));
       break;
   }
 };

--- a/tests/viewer.spec.ts
+++ b/tests/viewer.spec.ts
@@ -85,7 +85,12 @@ test('viewer-only entry loads geometry over the host transport', async ({ page }
     opId: 'op-1',
   });
 
-  // The viewer reports geometry-loaded back to the host.
+  // The command is acknowledged (correlated by opId) and the render completes.
+  await page.waitForFunction(
+    () => window.__viewerMessages?.some((m) => m?.type === 'geometry-set' && m?.opId === 'op-1'),
+    null,
+    { timeout: 10_000 },
+  );
   await page.waitForFunction(
     () => window.__viewerMessages?.some((m) => m?.type === 'geometry-loaded'),
     null,
@@ -93,6 +98,41 @@ test('viewer-only entry loads geometry over the host transport', async ({ page }
   );
 
   // The viewer never echoed an error for the valid input.
+  const hadError = await page.evaluate(() =>
+    window.__viewerMessages?.some((m) => m?.type === 'error'),
+  );
+  expect(hadError).toBeFalsy();
+});
+
+test('a setCamera sent immediately on ready is not dropped (race with mount)', async ({ page }) => {
+  await embedViewer(page);
+
+  // Sent right after `ready`, before the geometry/scene is necessarily built.
+  await postToViewer(page, {
+    protocolVersion: 1,
+    type: 'setCamera',
+    camera: { position: [10, 10, 10], target: [0, 0, 0], zoom: 1 },
+    opId: 'cam-1',
+  });
+  await postToViewer(page, {
+    protocolVersion: 1,
+    type: 'setGeometry',
+    offText: TETRAHEDRON_OFF,
+    opId: 'geo-1',
+  });
+
+  // The camera command is acknowledged (buffered then applied, not dropped) and
+  // geometry still loads — no error.
+  await page.waitForFunction(
+    () => window.__viewerMessages?.some((m) => m?.type === 'camera-set' && m?.opId === 'cam-1'),
+    null,
+    { timeout: 10_000 },
+  );
+  await page.waitForFunction(
+    () => window.__viewerMessages?.some((m) => m?.type === 'geometry-loaded'),
+    null,
+    { timeout: 30_000 },
+  );
   const hadError = await page.evaluate(() =>
     window.__viewerMessages?.some((m) => m?.type === 'error'),
   );


### PR DESCRIPTION
## #138 (Layer-0 viewer hardening) — transport half

Completes #138 (component half landed in #140). From the re-review:

- **Correlated success responses** — each inbound command gets a terminal ack echoing its `opId`: `setGeometry`→`geometry-set`, `setViewerSettings`→`viewer-settings-set`, `setCamera`→`camera-set`, `dispose`→`disposed`. The spontaneous `camera-change` and the render-complete `geometry-loaded` stay uncorrelated events. A host can now await deterministic completion (the prior `ack`≠`completion` / "next geometry-loaded is ambiguous" gap).
- **`event.source` check** — the handler verifies the sender is the host frame, not just the origin, so a same-origin sibling frame can't drive the read-only viewer.
- **Canonicalize `parentOrigin`** — parsed as a URL and reduced to `.origin`, rejecting malformed values, non-`http(s)` schemes, and the wildcard; a bad value falls back to same-origin-only trust (fail closed).

### Tests
Transport ack builders unit-tested; e2e (iframe embedding) asserts the `geometry-set` ack **and** that a `setCamera` sent immediately on `ready` is acknowledged (not dropped — validates the #140 buffering fix end-to-end) with geometry still loading. Full `npm run verify` green (418 unit + 20 assembly); bundle gate + publish archive intact; e2e green in prod + publish modes.

Closes #138