### PR TITLE
fix(viewer): correlate the geometry render result to its setGeometry opId

### DIFF
--- a/src/protocol/__tests__/viewer-transport.test.ts
+++ b/src/protocol/__tests__/viewer-transport.test.ts
@@ -118,10 +118,11 @@ describe('outbound builders', () => {
       type: 'ready',
       capabilities: ['view'],
     });
-    expect(viewerGeometryLoaded('hash')).toEqual({
+    expect(viewerGeometryLoaded('hash', 'op7')).toEqual({
       protocolVersion: v,
       type: 'geometry-loaded',
       thumbhash: 'hash',
+      opId: 'op7',
     });
     expect(viewerGeometryLoaded()).toEqual({ protocolVersion: v, type: 'geometry-loaded' });
     expect(viewerCameraChange(pose)).toEqual({

--- a/src/protocol/viewer-transport.ts
+++ b/src/protocol/viewer-transport.ts
@@ -140,9 +140,10 @@ export function viewerReady(capabilities: string[]) {
   return stampOutbound(VIEWER_PROTOCOL_VERSION, 'ready', { capabilities });
 }
 
-export function viewerGeometryLoaded(thumbhash?: string) {
+export function viewerGeometryLoaded(thumbhash?: string, opId?: string) {
   return stampOutbound(VIEWER_PROTOCOL_VERSION, 'geometry-loaded', {
     ...(thumbhash !== undefined ? { thumbhash } : {}),
+    ...(opId !== undefined ? { opId } : {}),
   });
 }
 
@@ -158,9 +159,11 @@ export function viewerError(code: ProtocolErrorCode | string, reason: string, op
   });
 }
 
-// Correlated terminal acknowledgements — one per inbound command, echoing its
-// opId so a host can await deterministic completion. (The spontaneous
-// `camera-change` and the render-complete `geometry-loaded` stay uncorrelated.)
+// Correlated acknowledgements that a command was applied, echoing its opId.
+// `viewer-settings-set`, `camera-set`, and `disposed` are terminal (those
+// commands apply synchronously). `geometry-set` only confirms the geometry was
+// *accepted* — its render outcome arrives later as a `geometry-loaded` or an
+// `error`, correlated by the same opId.
 function ack(type: string, opId?: string) {
   return stampOutbound(VIEWER_PROTOCOL_VERSION, type, opId !== undefined ? { opId } : {});
 }

--- a/src/viewer-entry/index.ts
+++ b/src/viewer-entry/index.ts
@@ -60,18 +60,24 @@ function post(message: object): void {
   host?.postMessage(message, targetOrigin);
 }
 
+// The opId of the in-flight setGeometry, so the (async) render outcome it
+// produces — geometry-loaded or a render error — can be correlated back to it.
+// Only setGeometry sets viewer.offText, so every load maps to one setGeometry.
+let geometryOpId: string | undefined;
+
 // Forward viewer events to the host.
 viewer.addEventListener('camera-change', (e) => {
   post(viewerCameraChange((e as CustomEvent<CameraState>).detail));
 });
 viewer.addEventListener('geometry-loaded', (e) => {
-  post(viewerGeometryLoaded((e as CustomEvent<{ thumbhash?: string }>).detail.thumbhash));
+  post(
+    viewerGeometryLoaded((e as CustomEvent<{ thumbhash?: string }>).detail.thumbhash, geometryOpId),
+  );
 });
 viewer.addEventListener('viewer-error', (e) => {
   // A render/parse failure of host-supplied geometry — distinct from a protocol
-  // validation rejection. Not opId-correlated: geometry loading is async and
-  // decoupled from the setGeometry message that triggered it.
-  post(viewerError('render-error', String((e as CustomEvent).detail)));
+  // validation rejection — correlated to the setGeometry that triggered it.
+  post(viewerError('render-error', String((e as CustomEvent).detail), geometryOpId));
 });
 
 const onMessage = (event: MessageEvent): void => {
@@ -87,8 +93,9 @@ const onMessage = (event: MessageEvent): void => {
   const msg = result.message;
   switch (msg.type) {
     case 'setGeometry':
+      geometryOpId = msg.opId; // correlate the eventual geometry-loaded / error
       viewer.offText = msg.offText;
-      post(viewerGeometrySet(msg.opId));
+      post(viewerGeometrySet(msg.opId)); // accepted; render outcome follows
       break;
     case 'setViewerSettings':
       if (msg.color !== undefined) viewer.color = msg.color;

--- a/tests/viewer.spec.ts
+++ b/tests/viewer.spec.ts
@@ -85,14 +85,15 @@ test('viewer-only entry loads geometry over the host transport', async ({ page }
     opId: 'op-1',
   });
 
-  // The command is acknowledged (correlated by opId) and the render completes.
+  // The command is accepted (geometry-set) and the render result is correlated
+  // back to the same opId (geometry-loaded carries opId).
   await page.waitForFunction(
     () => window.__viewerMessages?.some((m) => m?.type === 'geometry-set' && m?.opId === 'op-1'),
     null,
     { timeout: 10_000 },
   );
   await page.waitForFunction(
-    () => window.__viewerMessages?.some((m) => m?.type === 'geometry-loaded'),
+    () => window.__viewerMessages?.some((m) => m?.type === 'geometry-loaded' && m?.opId === 'op-1'),
     null,
     { timeout: 30_000 },
   );
@@ -102,6 +103,30 @@ test('viewer-only entry loads geometry over the host transport', async ({ page }
     window.__viewerMessages?.some((m) => m?.type === 'error'),
   );
   expect(hadError).toBeFalsy();
+});
+
+test('a malformed model is accepted then reports a correlated render error', async ({ page }) => {
+  await embedViewer(page);
+
+  await postToViewer(page, {
+    protocolVersion: 1,
+    type: 'setGeometry',
+    offText: 'OFF not-a-valid-mesh',
+    opId: 'bad-geo',
+  });
+
+  // Accepted immediately...
+  await page.waitForFunction(
+    () => window.__viewerMessages?.some((m) => m?.type === 'geometry-set' && m?.opId === 'bad-geo'),
+    null,
+    { timeout: 10_000 },
+  );
+  // ...then a render error correlated to the same opId (not an uncorrelated event).
+  await page.waitForFunction(
+    () => window.__viewerMessages?.some((m) => m?.type === 'error' && m?.opId === 'bad-geo'),
+    null,
+    { timeout: 10_000 },
+  );
 });
 
 test('a setCamera sent immediately on ready is not dropped (race with mount)', async ({ page }) => {


### PR DESCRIPTION
## P2 (follow-up review) — `geometry-set` acknowledged acceptance, not loading

`geometry-set` was posted immediately on accepting `offText`, before the async OFF parse/render. So a malformed model produced a **successful correlated `geometry-set`** followed by an **uncorrelated `viewer-error`**, and the ack comment overstated them as "terminal".

### Fix (the "correlate" option from the review)
The entry remembers the in-flight `setGeometry` opId and attaches it to the eventual render outcome: `geometry-loaded` now carries the `opId`, and a render error is correlated to it too. The comment now states `geometry-set` confirms **acceptance**; `viewer-settings-set`/`camera-set`/`disposed` stay terminal (synchronous), while the geometry **render result** follows as a correlated `geometry-loaded` or `error`. A host can now await a deterministic terminal result for `setGeometry`.

### Tests
- e2e: a valid model → `geometry-loaded` carrying the opId; a **malformed** model → `geometry-set` (accepted) then an `error` correlated to the same opId.
- transport unit test updated for `geometry-loaded`'s opId.

Full `npm run verify` green (418 unit + 20 assembly); bundle gate + e2e (prod + publish) pass.

Refs #138