### PR TITLE
fix(sw): order the CacheFirst large-asset route before the broad SWR

### DIFF
--- a/scripts/__tests__/build-sw.test.mjs
+++ b/scripts/__tests__/build-sw.test.mjs
@@ -1,0 +1,54 @@
+// @vitest-environment node
+
+import { describe, expect, it } from 'vitest';
+
+import { buildWorkboxConfig } from '../build-sw.mjs';
+
+const config = buildWorkboxConfig({ distDir: '/tmp/dist', swDest: '/tmp/dist/sw.js' });
+
+describe('buildWorkboxConfig precache policy', () => {
+  it('precaches everything (does NOT exclude the wasm / library zips)', () => {
+    // Precaching the large assets is intentional (see the comment + #114). Guard
+    // against re-introducing the reverted exclusion.
+    expect(config.globPatterns).toContain('**/*');
+    expect(config.globIgnores).not.toContain('**/*.wasm');
+    expect(config.globIgnores).not.toContain('libraries/**');
+  });
+});
+
+describe('buildWorkboxConfig runtime route order', () => {
+  // Workbox uses the FIRST matching route. The specific WASM/library CacheFirst
+  // rule must precede the broad same-origin StaleWhileRevalidate, or the latter
+  // swallows everything and CacheFirst is unreachable.
+  const firstMatch = (url) =>
+    config.runtimeCaching.find((route) => route.urlPattern({ url })) ?? null;
+
+  it('lists the CacheFirst large-asset rule before the broad SWR rule', () => {
+    const cacheFirstIdx = config.runtimeCaching.findIndex((r) => r.handler === 'CacheFirst');
+    const swrIdx = config.runtimeCaching.findIndex((r) => r.handler === 'StaleWhileRevalidate');
+    expect(cacheFirstIdx).toBeGreaterThanOrEqual(0);
+    expect(swrIdx).toBeGreaterThanOrEqual(0);
+    expect(cacheFirstIdx).toBeLessThan(swrIdx);
+  });
+
+  it('routes a .wasm request through CacheFirst, not the broad SWR', () => {
+    const route = firstMatch(new URL('https://example.com/assets/openscad-abc.wasm'));
+    expect(route?.handler).toBe('CacheFirst');
+    expect(route?.options.cacheName).toBe('large-assets');
+  });
+
+  it('routes a library zip through CacheFirst', () => {
+    const route = firstMatch(new URL('https://example.com/libraries/BOSL2.zip'));
+    expect(route?.handler).toBe('CacheFirst');
+  });
+
+  it('still routes other same-origin assets through StaleWhileRevalidate', () => {
+    globalThis.self = { location: { origin: 'https://app.example' } };
+    try {
+      const route = firstMatch(new URL('https://app.example/assets/index-abc.js'));
+      expect(route?.handler).toBe('StaleWhileRevalidate');
+    } finally {
+      delete globalThis.self;
+    }
+  });
+});

--- a/scripts/build-sw.mjs
+++ b/scripts/build-sw.mjs
@@ -2,34 +2,19 @@
 
 import fs from 'node:fs/promises';
 import path from 'node:path';
+import { fileURLToPath } from 'node:url';
 import workboxBuild from 'workbox-build';
 
 const { generateSW } = workboxBuild;
 
-const distDir = path.resolve('dist');
-const swDest = path.join(distDir, 'sw.js');
 const obsoleteArtifacts = ['openscad.js', 'openscad.wasm', 'fonts/InterVariable.woff2'];
 
-async function removeObsoleteArtifacts() {
-  for (const artifact of obsoleteArtifacts) {
-    try {
-      await fs.rm(path.join(distDir, artifact), { force: true });
-    } catch {
-      /* ignore */
-    }
-  }
-
-  try {
-    await fs.rmdir(path.join(distDir, 'fonts'));
-  } catch {
-    /* ignore */
-  }
-}
-
-try {
-  await removeObsoleteArtifacts();
-
-  const result = await generateSW({
+/**
+ * Build the Workbox `generateSW` config. Pure (no I/O) so the precache policy and
+ * the runtime-route order are unit-testable — both are correctness-critical.
+ */
+export function buildWorkboxConfig({ distDir, swDest }) {
+  return {
     mode: 'production',
     globDirectory: distDir,
     // Precache EVERYTHING in dist, including the ~9.6 MB WASM binary and the
@@ -58,17 +43,12 @@ try {
     clientsClaim: false,
     skipWaiting: false,
     // Runtime caching only applies to requests NOT served by the precache above
-    // (which already covers the WASM binary and library zips). These rules are a
-    // fallback for any same-origin request that misses the precache.
+    // (which already covers the WASM binary and library zips); these are a
+    // fallback for a same-origin request that misses the precache. Workbox uses
+    // the FIRST matching route, so the specific WASM/library CacheFirst rule must
+    // precede the broad same-origin StaleWhileRevalidate — otherwise the latter
+    // swallows every same-origin request and the CacheFirst rule is unreachable.
     runtimeCaching: [
-      {
-        urlPattern: ({ url }) => url.origin === self.location.origin,
-        handler: 'StaleWhileRevalidate',
-        options: {
-          cacheName: 'same-origin-assets',
-          expiration: { maxEntries: 200, purgeOnQuotaError: true },
-        },
-      },
       {
         urlPattern: ({ url }) =>
           url.pathname.endsWith('.wasm') || url.pathname.includes('/libraries/'),
@@ -78,8 +58,39 @@ try {
           expiration: { maxEntries: 50, purgeOnQuotaError: true },
         },
       },
+      {
+        urlPattern: ({ url }) => url.origin === self.location.origin,
+        handler: 'StaleWhileRevalidate',
+        options: {
+          cacheName: 'same-origin-assets',
+          expiration: { maxEntries: 200, purgeOnQuotaError: true },
+        },
+      },
     ],
-  });
+  };
+}
+
+async function removeObsoleteArtifacts(distDir) {
+  for (const artifact of obsoleteArtifacts) {
+    try {
+      await fs.rm(path.join(distDir, artifact), { force: true });
+    } catch {
+      /* ignore */
+    }
+  }
+
+  try {
+    await fs.rmdir(path.join(distDir, 'fonts'));
+  } catch {
+    /* ignore */
+  }
+}
+
+export async function runBuildSW({ distDir = path.resolve('dist') } = {}) {
+  const swDest = path.join(distDir, 'sw.js');
+  await removeObsoleteArtifacts(distDir);
+
+  const result = await generateSW(buildWorkboxConfig({ distDir, swDest }));
 
   // generateSW already emits a `SKIP_WAITING` message listener in the worker,
   // so the app can let the user apply a waiting update on demand (see
@@ -101,7 +112,17 @@ try {
   console.log(
     `[build-sw] Generated ${swDest} with ${result.count} precached entries (${result.size} bytes).`,
   );
-} catch (error) {
-  console.error(error);
-  process.exitCode = 1;
+  return result;
+}
+
+const isEntrypoint =
+  process.argv[1] != null && path.resolve(process.argv[1]) === fileURLToPath(import.meta.url);
+
+if (isEntrypoint) {
+  try {
+    await runBuildSW();
+  } catch (error) {
+    console.error(error);
+    process.exitCode = 1;
+  }
 }


### PR DESCRIPTION
## #122 — SW runtime route order

Workbox uses the **first** matching runtime route, but the broad same-origin `StaleWhileRevalidate` was registered before the specific WASM/library `CacheFirst` rule — making `CacheFirst` unreachable. Reorder so the specific rule precedes the broad one. (Under the intentional full precache these runtime routes only fire on a precache miss, so this is a correctness/clarity fix, not a behavior change in the common path.)

Extracted a pure `buildWorkboxConfig()` (guarded run behind an entrypoint check) so the policy is testable; new assembly test asserts the route order **and** that the precache still keeps the wasm/library zips (guards the reverted #113 exclusion from creeping back).

Full `npm run verify` green (423 unit + 25 assembly); SW builds with 51 precached entries as before.

Refs #122