### PR TITLE
fix(state): revoke object URLs on manual downloads (#122)

### DIFF
--- a/src/state/__tests__/fsapi-handle-scope.test.ts
+++ b/src/state/__tests__/fsapi-handle-scope.test.ts
@@ -73,6 +73,7 @@ function mockHost(): HostAdapter {
     createObjectURL: vi.fn(() => 'blob:fake'),
     revokeObjectURL: vi.fn(),
     download: vi.fn(),
+    downloadBlob: vi.fn(),
     playCompletionChime: vi.fn(),
     baseUrl: vi.fn(() => 'http://localhost/'),
   };
@@ -115,7 +116,7 @@ describe('FSAPI handle scoping (#62)', () => {
     await model.saveProject();
 
     expect(writable.write).toHaveBeenCalledWith('cube(10);');
-    expect(host.download).not.toHaveBeenCalled();
+    expect(host.downloadBlob).not.toHaveBeenCalled();
   });
 
   it('does not reuse a stale handle after a ZIP import replaces the project', async () => {
@@ -141,7 +142,7 @@ describe('FSAPI handle scoping (#62)', () => {
     // with no handle for the active path it falls back to a download.
     await model.saveProject();
     expect(writable.write).not.toHaveBeenCalled();
-    expect(host.download).toHaveBeenCalled();
+    expect(host.downloadBlob).toHaveBeenCalled();
   });
 
   it('drops the handle even when the imported archive reuses the opened path', async () => {
@@ -165,6 +166,6 @@ describe('FSAPI handle scoping (#62)', () => {
 
     await model.saveProject();
     expect(writable.write).not.toHaveBeenCalled();
-    expect(host.download).toHaveBeenCalled();
+    expect(host.downloadBlob).toHaveBeenCalled();
   });
 });

--- a/src/state/__tests__/web-host-adapter.test.ts
+++ b/src/state/__tests__/web-host-adapter.test.ts
@@ -58,6 +58,7 @@ function mockHost() {
     createObjectURL: vi.fn(() => 'blob:fake'),
     revokeObjectURL: vi.fn(),
     download: vi.fn(),
+    downloadBlob: vi.fn(),
     playCompletionChime: vi.fn(),
     baseUrl: vi.fn(() => 'http://localhost/'),
   };
@@ -71,6 +72,26 @@ describe('WebHostAdapter', () => {
     expect(() => host.revokeObjectURL(url)).not.toThrow();
     expect(() => host.playCompletionChime()).not.toThrow(); // no #complete-sound element -> no-op
     expect(typeof host.baseUrl()).toBe('string');
+  });
+
+  it('downloadBlob revokes the object URL it creates (no leak)', () => {
+    vi.useFakeTimers();
+    const createSpy = vi.spyOn(URL, 'createObjectURL').mockReturnValue('blob:fake');
+    const revokeSpy = vi.spyOn(URL, 'revokeObjectURL').mockImplementation(() => {});
+    try {
+      const host = new WebHostAdapter();
+      host.downloadBlob(new Blob(['x']), 'model.scad');
+      expect(createSpy).toHaveBeenCalledTimes(1);
+      // The revoke is deferred a turn so the browser can read the URL first.
+      expect(revokeSpy).not.toHaveBeenCalled();
+      vi.runAllTimers();
+      expect(revokeSpy).toHaveBeenCalledWith('blob:fake');
+    } finally {
+      vi.runAllTimers();
+      vi.useRealTimers();
+      createSpy.mockRestore();
+      revokeSpy.mockRestore();
+    }
   });
 });
 

--- a/src/state/model.ts
+++ b/src/state/model.ts
@@ -350,12 +350,12 @@ export class Model extends EventTarget {
       const contentBytes = new TextEncoder().encode(content) as Uint8Array<ArrayBuffer>;
       const blob = new Blob([contentBytes], { type: 'text/plain' });
       const file = new File([blob], this.state.params.activePath.split('/').pop()!);
-      this.host.download(this.host.createObjectURL(file), file.name);
+      this.host.downloadBlob(file, file.name);
     } else {
       try {
         const blob = await this.projectStore.buildZip(this.state.params.sources);
         const file = new File([blob], 'project.zip');
-        this.host.download(this.host.createObjectURL(file), file.name);
+        this.host.downloadBlob(file, file.name);
       } catch (err) {
         this.mutate((s) => {
           applyUserFacingError(s, err, 'model');

--- a/src/state/services/__tests__/export-service.test.ts
+++ b/src/state/services/__tests__/export-service.test.ts
@@ -62,6 +62,7 @@ function makeCtx(partial: Partial<State['params']> & { is2D?: boolean; output?: 
     createObjectURL: vi.fn(() => 'blob:new'),
     revokeObjectURL: vi.fn(),
     download: vi.fn(),
+    downloadBlob: vi.fn(),
     playCompletionChime: vi.fn(),
     baseUrl: vi.fn(() => 'http://localhost/'),
   } satisfies HostAdapter;

--- a/src/state/services/__tests__/layout-controller.test.ts
+++ b/src/state/services/__tests__/layout-controller.test.ts
@@ -30,6 +30,7 @@ function makeCtx(layout: State['view']['layout'], logs = false) {
       createObjectURL: () => '',
       revokeObjectURL: () => {},
       download: () => {},
+      downloadBlob: () => {},
       playCompletionChime: () => {},
       baseUrl: () => '',
     },

--- a/src/state/web-host-adapter.ts
+++ b/src/state/web-host-adapter.ts
@@ -10,6 +10,12 @@ export interface HostAdapter {
   createObjectURL(blob: Blob | File): string;
   revokeObjectURL(url: string): void;
   download(url: string, filename: string): void;
+  /**
+   * Download a blob, then revoke the temporary object URL it creates so it does
+   * not leak. Prefer this over `download(createObjectURL(blob), name)`, which
+   * never frees the URL.
+   */
+  downloadBlob(blob: Blob | File, filename: string): void;
   playCompletionChime(): void;
   baseUrl(): string;
 }
@@ -26,6 +32,14 @@ export class WebHostAdapter implements HostAdapter {
 
   download(url: string, filename: string): void {
     downloadUrl(url, filename);
+  }
+
+  downloadBlob(blob: Blob | File, filename: string): void {
+    const url = URL.createObjectURL(blob);
+    downloadUrl(url, filename);
+    // The anchor click is synchronous but the browser reads the URL after the
+    // current task; defer the revoke one turn so the download still resolves.
+    setTimeout(() => URL.revokeObjectURL(url), 0);
   }
 
   playCompletionChime(): void {


### PR DESCRIPTION
## What

`Model.saveProject()` created a blob object URL via `host.createObjectURL()` and **never revoked it**, leaking one object URL (and its blob) per manual save — both the single-file and ZIP code paths.

## Change

- Add `HostAdapter.downloadBlob(blob, filename)`: creates the object URL, downloads, then revokes it one turn later (`setTimeout(…, 0)`) so the browser still reads the URL during the synchronous anchor click.
- Route both `saveProject()` sites (single-file save, ZIP save) through it.
- The export-output URL (`outFileURL`) is intentionally **unchanged** — it persists in state with its own revoke-on-replace lifecycle so the export panel can re-link/re-download it.

## Tests

- New unit test: `downloadBlob` revokes the URL it creates (deferred a turn).
- Updated HostAdapter stubs in the affected tests; `fsapi-handle-scope` assertions switched from `download` → `downloadBlob`.
- Full gate green: `npm run verify` (tsc + lint + 424+25 tests + build + publish-archive), exit 0.

Part of the #122 P2 hardening backlog.

Refs #122