### PR TITLE
fix(editor): dispose project-scoped Monaco models on replace/teardown (#122)

### DIFF
--- a/src/components/elements/__tests__/editor-model-ownership.test.ts
+++ b/src/components/elements/__tests__/editor-model-ownership.test.ts
@@ -1,0 +1,37 @@
+import { describe, expect, it } from 'vitest';
+
+import { isProjectScopedPath, staleModelPaths } from '../editor-model-ownership.ts';
+
+describe('isProjectScopedPath', () => {
+  it('owns editable project files (under /home or top-level)', () => {
+    expect(isProjectScopedPath('/home/demo.scad')).toBe(true);
+    expect(isProjectScopedPath('/home/lib/part.scad')).toBe(true);
+    expect(isProjectScopedPath('/top.scad')).toBe(true);
+  });
+
+  it('does not own library files or directory mounts', () => {
+    expect(isProjectScopedPath('/libraries/BOSL2/std.scad')).toBe(false);
+    expect(isProjectScopedPath('/home/')).toBe(false);
+    expect(isProjectScopedPath('/libraries/')).toBe(false);
+  });
+});
+
+describe('staleModelPaths', () => {
+  it('flags owned paths no longer in the project for disposal', () => {
+    const owned = ['/home/a.scad', '/home/b.scad', '/home/c.scad'];
+    const live = new Set(['/home/a.scad']); // b and c removed (project replaced)
+    expect(staleModelPaths(owned, live, '/home/a.scad')).toEqual(['/home/b.scad', '/home/c.scad']);
+  });
+
+  it('never disposes the active model, even if absent from sources', () => {
+    const owned = ['/home/a.scad'];
+    const live = new Set<string>(); // active not yet reflected in sources
+    expect(staleModelPaths(owned, live, '/home/a.scad')).toEqual([]);
+  });
+
+  it('keeps every model when all are still live', () => {
+    const owned = ['/home/a.scad', '/home/b.scad'];
+    const live = new Set(owned);
+    expect(staleModelPaths(owned, live, '/home/a.scad')).toEqual([]);
+  });
+});

--- a/src/components/elements/editor-model-ownership.ts
+++ b/src/components/elements/editor-model-ownership.ts
@@ -1,0 +1,39 @@
+// Editor model ownership helpers (#122). The editor panel creates one Monaco
+// text model per file URI, but Monaco never disposes those models on its own —
+// `editor.dispose()` frees the editor, not the externally-created models. Left
+// alone they accumulate for every path ever opened and across panel remounts.
+// The panel "owns" the models it creates for project files and disposes them
+// when their file leaves the project or the panel tears down. These pure helpers
+// hold that policy so it can be unit-tested without a real Monaco/DOM.
+
+import { getParentDir } from '../../fs/filesystem.ts';
+
+/**
+ * A model is *project-scoped* (and therefore panel-owned) when it backs an
+ * editable project file: a file under `/home/` or a top-level file. Directory
+ * mounts and library files (e.g. `/libraries/...`) are excluded — those are not
+ * part of the user's project and are managed elsewhere.
+ */
+export function isProjectScopedPath(path: string): boolean {
+  if (path.endsWith('/')) return false;
+  return path.startsWith('/home/') || getParentDir(path) === '/';
+}
+
+/**
+ * Of the owned model paths, the ones to dispose given the project's current
+ * source set: any owned path no longer present in the live sources. The active
+ * path is always kept — its model is on screen, and disposing it would break the
+ * editor.
+ */
+export function staleModelPaths(
+  ownedPaths: Iterable<string>,
+  livePaths: ReadonlySet<string>,
+  activePath: string,
+): string[] {
+  const stale: string[] = [];
+  for (const path of ownedPaths) {
+    if (path === activePath) continue;
+    if (!livePaths.has(path)) stale.push(path);
+  }
+  return stale;
+}

--- a/src/components/elements/osc-editor-panel.ts
+++ b/src/components/elements/osc-editor-panel.ts
@@ -7,6 +7,7 @@ import * as monacoTypes from 'monaco-editor/esm/vs/editor/editor.api';
 // panel does — embed/customizer surfaces never fetch it.
 import 'monaco-editor/min/vs/editor/editor.main.css';
 import { getModel } from '../../state/model-context.ts';
+import { isProjectScopedPath, staleModelPaths } from './editor-model-ownership.ts';
 import { getFS } from '../../state/fs-context.ts';
 import { zipArchives } from '../../fs/zip-archives.generated.ts';
 import { getParentDir, join } from '../../fs/filesystem.ts';
@@ -40,6 +41,9 @@ export class OscEditorPanel extends LitElement {
   private _monaco: typeof monacoTypes | null = null;
   private _ro: ResizeObserver | null = null;
   private _updatingFromState = false;
+  // Project-file models this panel created, keyed by path, so they can be
+  // disposed when their file leaves the project or the panel tears down (#122).
+  private _ownedModels = new Map<string, monacoTypes.editor.ITextModel>();
 
   private _onState = (e: Event) => {
     const st = (e as CustomEvent<State>).detail;
@@ -61,11 +65,16 @@ export class OscEditorPanel extends LitElement {
           } else {
             editorModel.setValue(this._model.source);
           }
+          this._trackModel(st.params.activePath, editorModel);
           this._editor.setModel(editorModel);
         } finally {
           this._updatingFromState = false;
         }
       }
+
+      // A project replace (e.g. ZIP import) swaps the source set; drop the models
+      // for files that are no longer part of the project so they don't leak.
+      this._pruneOwnedModels(st);
 
       const checkerRun = st.lastCheckerRun;
       if (checkerRun) {
@@ -112,6 +121,29 @@ export class OscEditorPanel extends LitElement {
     }
   }
 
+  /** Record a model the panel created for a project file so it can be disposed
+   *  later. Library/non-project models are managed elsewhere and left alone. */
+  private _trackModel(path: string, model: monacoTypes.editor.ITextModel) {
+    if (isProjectScopedPath(path)) this._ownedModels.set(path, model);
+  }
+
+  /** Dispose owned models whose file is no longer in the project (keeping the
+   *  active one, which is on screen). */
+  private _pruneOwnedModels(st: State) {
+    const livePaths = new Set(st.params.sources.map((s) => s.path));
+    for (const path of staleModelPaths(this._ownedModels.keys(), livePaths, st.params.activePath)) {
+      this._ownedModels.get(path)?.dispose();
+      this._ownedModels.delete(path);
+    }
+  }
+
+  /** Dispose every owned model — used on teardown so models don't outlive the
+   *  panel in Monaco's global registry. */
+  private _disposeOwnedModels() {
+    for (const model of this._ownedModels.values()) model.dispose();
+    this._ownedModels.clear();
+  }
+
   private _closeMenu = (e: MouseEvent) => {
     if (!e.composedPath().includes(this)) this._menuOpen = false;
   };
@@ -131,6 +163,9 @@ export class OscEditorPanel extends LitElement {
     this._ro?.disconnect();
     this._editor?.dispose();
     this._editor = null;
+    // Dispose the editor's models after the editor itself; Monaco leaves
+    // externally-created models in its global registry otherwise (#122).
+    this._disposeOwnedModels();
   }
 
   override async firstUpdated() {
@@ -164,6 +199,7 @@ export class OscEditorPanel extends LitElement {
     if (!editorModel) {
       editorModel = monaco.editor.createModel(this._model.source, 'openscad', uri);
     }
+    this._trackModel(st.params.activePath, editorModel);
 
     const editor = monaco.editor.create(container, {
       model: editorModel,


### PR DESCRIPTION
## What

The editor panel created one Monaco text model per file URI but never disposed them. Monaco keeps **externally-created** models in its global registry even after `editor.dispose()` (verified: passing `model:` to `monaco.editor.create` sets `_ownsModel = false`), so a model leaked for **every file path ever opened** and across editor-panel remounts.

## Change

- Track the models the panel creates for **project files** (under `/home/` or top-level; libraries and directory mounts excluded — the same predicate `_buildFileOptions` uses for the "My Files" group).
- Dispose them when their file leaves the project (the source set changes, e.g. a ZIP import replaces the project) and when the panel tears down.
- Ownership/prune policy lives in a pure, unit-tested helper (`editor-model-ownership.ts`): `isProjectScopedPath` + `staleModelPaths` (always keeps the active/on-screen model).

## Safety (adversarially reviewed)

- **Never disposes the on-screen model:** `setModel(file://activePath)` runs before prune in the same handler, and `staleModelPaths` unconditionally skips `activePath`.
- **No double-dispose:** pruned models are removed from the map, so teardown can't re-dispose them; `editor.dispose()` doesn't touch externally-owned models. (Monaco's `TextModel.dispose()` is not idempotent, so single-disposal matters — the map guarantees it.)
- **Library files** opened in the editor are intentionally not owned (managed elsewhere); they were never disposed before this change, so no regression.

## Tests

- New unit tests for `isProjectScopedPath` and `staleModelPaths` (5 cases).
- Full gate green locally: `npm run verify` (tsc + lint + 429 tests + build), exit 0.

Part of the #122 P2 hardening backlog. Refs #122