### PR TITLE
fix(state): flush persistence on tab hide/close (#122)

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -123,6 +123,16 @@ window.addEventListener('load', async () => {
   const model = new Model(fs, initialState, undefined, statePersister);
   setModel(model);
 
+  // Persistence is debounced, so an edit made right before the tab is hidden or
+  // closed could otherwise be lost. Force a flush on `pagehide` and when the
+  // page becomes hidden (the latter is the reliable signal on mobile, where
+  // `pagehide`/`beforeunload` often don't fire). Both are idempotent — a flush
+  // with no durable change is a no-op.
+  window.addEventListener('pagehide', () => void model.flushPersist());
+  document.addEventListener('visibilitychange', () => {
+    if (document.visibilityState === 'hidden') void model.flushPersist();
+  });
+
   // The shell module download was started at the top of bootstrap; awaiting it
   // here guarantees the custom element is defined before it is created/upgraded.
   await shellModule;

--- a/src/state/__tests__/scoped-persistence.test.ts
+++ b/src/state/__tests__/scoped-persistence.test.ts
@@ -102,6 +102,33 @@ describe('scoped persistence (#58)', () => {
     expect(persister.set).toHaveBeenCalledTimes(1); // no extra write
   });
 
+  it('flushPersist writes a pending durable change immediately, bypassing the debounce', async () => {
+    const { model, persister } = makeModel();
+    model.mutate((s) => (s.view.showAxes = false));
+    expect(persister.set).not.toHaveBeenCalled(); // still inside the debounce window
+
+    await model.flushPersist();
+    expect(persister.set).toHaveBeenCalledTimes(1);
+
+    // The debounce timer was cancelled by the flush — it must not fire a 2nd write.
+    await vi.advanceTimersByTimeAsync(1000);
+    expect(persister.set).toHaveBeenCalledTimes(1);
+  });
+
+  it('flushPersist on no pending change is a no-op', async () => {
+    const { model, persister } = makeModel();
+    await model.flushPersist();
+    expect(persister.set).not.toHaveBeenCalled();
+  });
+
+  it('dispose cancels a pending persist timer so it never writes', async () => {
+    const { model, persister } = makeModel();
+    model.mutate((s) => (s.view.showAxes = false));
+    model.dispose();
+    await vi.advanceTimersByTimeAsync(1000);
+    expect(persister.set).not.toHaveBeenCalled();
+  });
+
   it('swallows persister errors without throwing', async () => {
     const { model, persister } = makeModel();
     persister.set.mockRejectedValueOnce(new Error('disk full'));

--- a/src/state/model.ts
+++ b/src/state/model.ts
@@ -134,8 +134,32 @@ export class Model extends EventTarget {
     this._persistTimer = setTimeout(() => {
       this._persistTimer = null;
       this._persistDeadline = null;
-      void this.flushPersist();
+      void this._persistDurable();
     }, delay);
+  }
+
+  /**
+   * Persist the durable slice immediately, bypassing the debounce. Call this on
+   * tab hide/close (`pagehide` / `visibilitychange`) so an edit made inside the
+   * debounce window isn't lost. Resolves once the write settles.
+   */
+  flushPersist(): Promise<void> {
+    if (this._persistTimer) {
+      clearTimeout(this._persistTimer);
+      this._persistTimer = null;
+    }
+    this._persistDeadline = null;
+    return this._persistDurable();
+  }
+
+  /** Cancel any pending persistence timer. For teardown (tests / re-init); the
+   *  caller should `flushPersist()` first if it wants the latest written. */
+  dispose() {
+    if (this._persistTimer) {
+      clearTimeout(this._persistTimer);
+      this._persistTimer = null;
+    }
+    this._persistDeadline = null;
   }
 
   /**
@@ -143,7 +167,7 @@ export class Model extends EventTarget {
    * mutations write nothing). Serialized so writes can't overlap or reorder; the
    * latest state is coalesced into a single follow-up write, and errors are logged.
    */
-  private async flushPersist() {
+  private async _persistDurable() {
     if (!this.statePersister) return;
     if (this._persistInFlight) {
       this._persistPending = true; // re-check & persist the latest once the current write finishes
@@ -161,7 +185,7 @@ export class Model extends EventTarget {
       this._persistInFlight = false;
       if (this._persistPending) {
         this._persistPending = false;
-        void this.flushPersist();
+        void this._persistDurable();
       }
     }
   }


### PR DESCRIPTION
## What

Durable-state writes are **debounced** (500ms), so an edit made just before the tab is hidden or closed can be lost inside the debounce window.

## Change

- `Model.flushPersist()` — cancels the debounce timer and persists the durable slice immediately; resolves once the write settles.
- `Model.dispose()` — cancels a pending persist timer (teardown / re-init).
- Wire `pagehide` + `visibilitychange:hidden` in the entry (`index.ts`, which owns window/document) to force a flush. `visibilitychange` is included because `pagehide`/`beforeunload` are unreliable on mobile.

Both triggers are idempotent — a flush with no durable change recomputes the JSON signature, sees it's unchanged, and writes nothing. In-flight writes still coalesce via the existing serialization.

The `Model` stays DOM-free: the listeners live in the entry and call the new public method.

## Tests

- `flushPersist` writes a pending change immediately and cancels the debounce (no second write).
- `flushPersist` with nothing pending is a no-op.
- `dispose` cancels the pending timer so it never writes.
- Full gate green: `npm run verify`, exit 0 (427 tests).

Part of the #122 P2 hardening backlog. Refs #122