### PR TITLE
fix(state): roll back deep mutations when the callback throws (#122)

### DIFF
--- a/src/state/__tests__/deep-mutate.test.ts
+++ b/src/state/__tests__/deep-mutate.test.ts
@@ -1,0 +1,117 @@
+import { describe, expect, it } from 'vitest';
+
+import { bubbleUpDeepMutations } from '../deep-mutate.ts';
+
+describe('bubbleUpDeepMutations — structural sharing (characterization)', () => {
+  it('returns the same root identity when nothing changes', () => {
+    const o = { a: 1, nested: { b: 2 } };
+    const result = bubbleUpDeepMutations(o, () => {});
+    expect(result).toBe(o);
+    expect(result.nested).toBe(o.nested);
+  });
+
+  it('bumps only the root identity on a change; descendants stay in place', () => {
+    // The recursion is for change *detection*: only the root is rebuilt, while
+    // nested objects keep their identity and are mutated in place (see the
+    // model.ts comment — sources identity is reassigned by callers, not here).
+    const o = { left: { x: 1 }, right: { y: 2 } };
+    const leftBefore = o.left;
+    const rightBefore = o.right;
+    const result = bubbleUpDeepMutations(o, (s) => {
+      s.left.x = 99;
+    });
+    expect(result).not.toBe(o); // root changed
+    expect(result.left).toBe(leftBefore); // same ref, mutated in place
+    expect(result.right).toBe(rightBefore); // untouched sibling unchanged
+    expect(result.left.x).toBe(99);
+  });
+
+  it('detects added and removed keys as changes', () => {
+    const added = bubbleUpDeepMutations({ a: 1 } as { a: number; b?: number }, (s) => {
+      s.b = 2;
+    });
+    expect(added.b).toBe(2);
+
+    const removed = bubbleUpDeepMutations({ a: 1, b: 2 } as { a: number; b?: number }, (s) => {
+      delete s.b;
+    });
+    expect('b' in removed).toBe(false);
+  });
+});
+
+describe('bubbleUpDeepMutations — rollback on a throwing callback (#122)', () => {
+  it('leaves the tree untouched and rethrows when the callback throws', () => {
+    const o = { view: { color: '#000', axes: true }, params: { activePath: '/a' } };
+    const err = new Error('boom');
+    expect(() =>
+      bubbleUpDeepMutations(o, (s) => {
+        s.view.color = '#fff'; // partial edit before the throw
+        throw err;
+      }),
+    ).toThrow(err);
+
+    // The live object is reverted to exactly its original values.
+    expect(o.view.color).toBe('#000');
+    expect(o.view.axes).toBe(true);
+    expect(o.params.activePath).toBe('/a');
+  });
+
+  it('restores keys the callback added before throwing', () => {
+    const o = { a: 1 } as { a: number; b?: number };
+    expect(() =>
+      bubbleUpDeepMutations(o, (s) => {
+        s.b = 2;
+        throw new Error('x');
+      }),
+    ).toThrow();
+    expect('b' in o).toBe(false);
+  });
+
+  it('restores keys the callback deleted before throwing', () => {
+    const o = { a: 1, b: 2 } as { a: number; b?: number };
+    expect(() =>
+      bubbleUpDeepMutations(o, (s) => {
+        delete s.b;
+        throw new Error('x');
+      }),
+    ).toThrow();
+    expect(o.b).toBe(2);
+  });
+
+  it('restores array contents and length mutated before throwing', () => {
+    const o = { items: [{ id: 1 }, { id: 2 }] };
+    const original = o.items;
+    expect(() =>
+      bubbleUpDeepMutations(o, (s) => {
+        s.items.push({ id: 3 });
+        s.items[0].id = 999;
+        throw new Error('x');
+      }),
+    ).toThrow();
+    expect(o.items).toBe(original); // same array reference, restored
+    expect(o.items.length).toBe(2);
+    expect(o.items.map((i) => i.id)).toEqual([1, 2]);
+  });
+
+  it('restores original key order after a deleted key is rolled back', () => {
+    // Order matters: a later successful persist compares JSON.stringify of the
+    // durable slice, so a reordered key would cause a spurious write.
+    const o = { a: 1, b: 2, c: 3 } as { a: number; b?: number; c: number };
+    expect(() =>
+      bubbleUpDeepMutations(o, (s) => {
+        delete s.b;
+        throw new Error('x');
+      }),
+    ).toThrow();
+    expect(Object.keys(o)).toEqual(['a', 'b', 'c']);
+    expect(JSON.stringify(o)).toBe('{"a":1,"b":2,"c":3}');
+  });
+
+  it('still applies the mutation normally when the callback does not throw', () => {
+    const o = { n: 1 };
+    const result = bubbleUpDeepMutations(o, (s) => {
+      s.n = 5;
+    });
+    expect(result.n).toBe(5);
+  });
+});

--- a/src/state/deep-mutate.ts
+++ b/src/state/deep-mutate.ts
@@ -13,8 +13,43 @@ type KVEntriesMap = Map<KVObject, [string, any][]>;
  */
 export function bubbleUpDeepMutations<T extends KVObject>(o: T, mutate: (o: T) => void): T {
   const allOriginalEntries = collectObjectEntriesDeeply(o);
-  mutate(o);
+  try {
+    mutate(o);
+  } catch (e) {
+    // `mutate` edits the tree in place, so a callback that throws partway would
+    // otherwise leave the live state partially mutated *and* with no change
+    // event dispatched (the caller bails before setState). Roll every touched
+    // object back to its captured entries so a failed mutation is a no-op, then
+    // rethrow. (The proper long-term fix is explicit immutable reducers — #122.)
+    restoreOriginalEntries(allOriginalEntries);
+    throw e;
+  }
   return bubbleChangesUp(o, allOriginalEntries) as T;
+}
+
+/**
+ * Reset every captured object to exactly its original own-enumerable entries:
+ * drop keys the mutation added, restore originals (pointing back at the original
+ * child references, which are themselves restored as they were also captured),
+ * and fix array length. Objects the mutation newly created aren't captured, but
+ * become unreferenced once their would-be parents are restored.
+ */
+function restoreOriginalEntries(allOriginalEntries: KVEntriesMap) {
+  for (const [obj, entries] of allOriginalEntries) {
+    // Clear all current keys, then re-add the captured ones in their original
+    // order, so a key the callback deleted is restored in place rather than at
+    // the end — keeping JSON key order (and thus the persistence signature)
+    // stable across a rolled-back mutation.
+    for (const key of Object.keys(obj)) {
+      delete obj[key];
+    }
+    for (const [k, v] of entries) {
+      obj[k] = v;
+    }
+    if (Array.isArray(obj)) {
+      obj.length = entries.length;
+    }
+  }
 }
 
 function collectObjectEntriesDeeply(o: KVObject, out: KVEntriesMap = new Map()): KVEntriesMap {
@@ -31,6 +66,11 @@ function collectObjectEntriesDeeply(o: KVObject, out: KVEntriesMap = new Map()):
     if (v instanceof RegExp || v instanceof Blob) {
       continue;
     }
+    // Captures plain objects/arrays only. Map/Set/File (extends Blob) internals
+    // are treated as opaque, so an in-place mutation *inside* one would not be
+    // rolled back. The State tree holds none in a mutated-in-place position
+    // (e.g. output.outFile is replaced wholesale, never mutated), so this is
+    // safe today; revisit if state grows such a field.
     collectObjectEntriesDeeply(v, out);
   }
   return out;


### PR DESCRIPTION
## What

`bubbleUpDeepMutations(o, mutate)` applies the mutation **in place** on the live state, then rebuilds the root identity if anything changed. If `mutate` threw partway, the live state was left **partially mutated** *and* no change event was dispatched (the caller bails before `setState`) — a silent inconsistency.

## Change

The full entry snapshot is already captured up front (`collectObjectEntriesDeeply`). On a throwing callback, restore every touched object to its captured entries — clearing keys and re-adding the originals **in their captured order** (so a deleted key is restored in place, keeping JSON key order and thus the persistence signature stable) — then rethrow. **The success path is unchanged** (only a `try/catch` wraps the in-place mutate).

## Adversarial review

A reviewer subagent confirmed: arrays-of-objects are captured and restored; reassign-new-parent + mutate-deep-original is fully restored (map iteration order irrelevant — only references are rewritten); restore can't throw on the plain-object State (no freeze/seal/accessors); no cycles (durable state is JSON-serialized). The two minor/latent items it raised — key-order on deleted-key restore, and the opaque-object (Map/Set/File) capture assumption — are both addressed here (order-faithful restore + a clarifying comment + a key-order test).

## Tests

Adds the first direct tests for `deep-mutate` (none existed): structural-sharing characterization + rollback for value / key-add / key-delete / array / key-order cases. Full gate green: `npm run verify`, exit 0 (438 tests).

Part of the #122 P2 hardening backlog. Refs #122