### PR TITLE
fix(export): cancel the in-flight render when an export supersedes it (#122)

### DIFF
--- a/src/state/services/__tests__/export-service.test.ts
+++ b/src/state/services/__tests__/export-service.test.ts
@@ -29,6 +29,33 @@ import type { ServiceContext } from '../service-context.ts';
 
 const mockRenderExport = _mockRenderExport as ReturnType<typeof vi.fn>;
 
+/**
+ * A renderExport mock whose inner thunk returns an AbortablePromise-shaped value
+ * (a Promise with a `kill` spy), mirroring the real delayable so the service can
+ * own and kill the in-flight render. The promise stays pending until `resolve`
+ * (or `reject`) is called by the test.
+ */
+function hangingRender() {
+  let resolve!: (v: RenderOutput) => void;
+  let reject!: (e: unknown) => void;
+  const kill = vi.fn();
+  const inner = vi.fn(() =>
+    Object.assign(
+      new Promise<RenderOutput>((res, rej) => {
+        resolve = res;
+        reject = rej;
+      }),
+      { kill },
+    ),
+  );
+  return {
+    inner,
+    kill,
+    resolve: (v: RenderOutput) => resolve(v),
+    reject: (e: unknown) => reject(e),
+  };
+}
+
 function fileOutput(name: string, url = 'blob:out'): State['output'] {
   const f = new File(['x'], name);
   return {
@@ -158,21 +185,22 @@ describe('ExportService', () => {
     const svc = new ExportService(ctx);
 
     // First export's conversion hangs; the second resolves immediately.
-    let resolveFirst!: (v: RenderOutput) => void;
-    const firstInner = vi.fn(() => new Promise<RenderOutput>((r) => (resolveFirst = r)));
+    const first = hangingRender();
     const secondInner = vi.fn().mockResolvedValue({
       outFile: new File(['second'], 'second.stl'),
       logText: '',
       markers: [],
       elapsedMillis: 1,
     });
-    mockRenderExport.mockReturnValueOnce(firstInner).mockReturnValueOnce(secondInner);
+    mockRenderExport.mockReturnValueOnce(first.inner).mockReturnValueOnce(secondInner);
 
     const p1 = svc.export(); // token 1 — awaits the hanging conversion
     const p2 = svc.export(); // token 2 — resolves and commits
     await p2;
+    // The superseding export killed the first render job.
+    expect(first.kill).toHaveBeenCalled();
     // Now let the first (superseded) export finish; its token is stale.
-    resolveFirst({
+    first.resolve({
       outFile: new File(['first'], 'first.stl'),
       logText: '',
       markers: [],
@@ -210,10 +238,8 @@ describe('ExportService', () => {
     });
     const svc = new ExportService(ctx);
 
-    let resolveFirst!: (v: RenderOutput) => void;
-    mockRenderExport.mockReturnValueOnce(
-      vi.fn(() => new Promise<RenderOutput>((r) => (resolveFirst = r))),
-    );
+    const first = hangingRender();
+    mockRenderExport.mockReturnValueOnce(first.inner);
 
     const p1 = svc.export(); // token 1 — STL conversion hangs, exporting=true
     // User switches to a pass-through format (OFF) and exports again.
@@ -222,7 +248,11 @@ describe('ExportService', () => {
     });
     await svc.export(); // token 2 — pass-through downloads the OFF, supersedes token 1
 
-    resolveFirst({
+    // The pass-through branch never calls renderExport, but still killed the
+    // in-flight STL render rather than letting the worker finish a dropped result.
+    expect(first.kill).toHaveBeenCalled();
+
+    first.resolve({
       outFile: new File(['x'], 'first.stl'),
       logText: '',
       markers: [],
@@ -243,10 +273,8 @@ describe('ExportService', () => {
     });
     const svc = new ExportService(ctx);
 
-    let resolveFirst!: (v: RenderOutput) => void;
-    mockRenderExport.mockReturnValueOnce(
-      vi.fn(() => new Promise<RenderOutput>((r) => (resolveFirst = r))),
-    );
+    const first = hangingRender();
+    mockRenderExport.mockReturnValueOnce(first.inner);
 
     const p1 = svc.export(); // token 1 — exporting=true
     // User switches to 3MF (no extruder colors) and exports → the picker shows.
@@ -255,7 +283,11 @@ describe('ExportService', () => {
     });
     await svc.export(); // token 2 — picker branch
 
-    resolveFirst({
+    // The picker branch returns early without renderExport, but still killed the
+    // in-flight render.
+    expect(first.kill).toHaveBeenCalled();
+
+    first.resolve({
       outFile: new File(['x'], 'first.stl'),
       logText: '',
       markers: [],
@@ -276,22 +308,20 @@ describe('ExportService', () => {
     });
     const svc = new ExportService(ctx);
 
-    let rejectFirst!: (e: unknown) => void;
+    const first = hangingRender();
     const secondInner = vi.fn().mockResolvedValue({
       outFile: new File(['ok'], 'second.stl'),
       logText: '',
       markers: [],
       elapsedMillis: 1,
     });
-    mockRenderExport
-      .mockReturnValueOnce(vi.fn(() => new Promise<RenderOutput>((_r, rej) => (rejectFirst = rej))))
-      .mockReturnValueOnce(secondInner);
+    mockRenderExport.mockReturnValueOnce(first.inner).mockReturnValueOnce(secondInner);
 
     const p1 = svc.export(); // token 1 — hangs
     const p2 = svc.export(); // token 2 — resolves and commits
     await p2;
     // The stale first export now fails with a non-cancellation error.
-    rejectFirst(new Error('boom'));
+    first.reject(new Error('boom'));
     await p1;
 
     // The current export's success is untouched: no error surfaced, only its download.

--- a/src/state/services/export-service.ts
+++ b/src/state/services/export-service.ts
@@ -5,7 +5,7 @@ import { parseOff } from '../../io/import_off.ts';
 import { renderExport, type RenderOutput } from '../../runner/actions.ts';
 import { isExpectedJobCancellation, type ProcessStreams } from '../../runner/openscad-runner.ts';
 import { isUserFacingOperationError } from '../../user-facing-errors.ts';
-import { formatBytes, formatMillis } from '../../utils.ts';
+import { formatBytes, formatMillis, type AbortablePromise } from '../../utils.ts';
 import { applyUserFacingError } from '../apply-user-facing-error.ts';
 import type { ServiceContext } from './service-context.ts';
 
@@ -23,6 +23,18 @@ export class ExportService {
   // the 3MF path which does not run through the delayable) must not clobber the
   // newer one's result/download when its async work finally settles.
   private _exportSeq = 0;
+
+  // The in-flight format-conversion render job, if any. The export-token logic
+  // stops a superseded export from committing a stale result, but the branches
+  // that supersede WITHOUT calling renderExport (pass-through, 3MF picker, GLB,
+  // 3MF) never trigger the delayable's own cancellation. Owning the handle lets
+  // every export cancel the previous render at entry: this drops it if still
+  // queued and settles the superseded export's promise immediately rather than
+  // leaving it to be dropped by token later. A render already executing in the
+  // worker can't be interrupted (its synchronous callMain runs to completion and
+  // the host discards the result by id), but it no longer holds up the new
+  // export's state. See #122.
+  private _activeRender: AbortablePromise<RenderOutput> | null = null;
 
   private rawStreamsCallback(ps: ProcessStreams) {
     this.ctx.mutate((s) => {
@@ -43,6 +55,13 @@ export class ExportService {
     // result nor leave the spinner stuck.
     const token = ++this._exportSeq;
     const isCurrent = () => this._exportSeq === token;
+    // Cancel any in-flight conversion render so a superseding export — including
+    // a pass-through or picker branch that never calls renderExport — drops a
+    // still-queued render and promptly settles the previous export's await with a
+    // cancellation it treats as supersession (#122). A render already executing
+    // in the worker still finishes there; its result is discarded by id.
+    this._activeRender?.kill();
+    this._activeRender = null;
     // Snapshot is safe: export never mutates output/params/is2D, only the
     // export/exporting/error/log/view fields it writes via the mutate callback.
     const state = this.ctx.getState();
@@ -118,7 +137,7 @@ export class ExportService {
           markers: [],
         };
       } else {
-        output = await renderExport({
+        const job = renderExport({
           mountArchives: false,
           scadPath: '/export.scad',
           sources: [
@@ -138,6 +157,14 @@ export class ExportService {
           priority: 'export',
           streamsCallback: this.rawStreamsCallback.bind(this),
         })({ now: true });
+        // Own the handle so a later export can kill this render if it supersedes
+        // before the worker finishes.
+        this._activeRender = job;
+        try {
+          output = await job;
+        } finally {
+          if (this._activeRender === job) this._activeRender = null;
+        }
       }
 
       // A newer export superseded this one while its conversion ran; it owns the


### PR DESCRIPTION
## What

The export token (`_exportSeq`) stops a superseded export from committing a stale result, but the branches that supersede **without** calling `renderExport` (pass-through, 3MF picker, GLB, 3MF-with-colors) never triggered the delayable's own cancellation — so a previous export's render promise lingered until dropped by token.

## Change

`ExportService` now owns the active render's `AbortablePromise` and cancels it at the start of every `export()`. Any superseding export — whatever branch it takes — drops a still-queued render and promptly settles the previous export's `await` with a cancellation that's already treated as supersession.

### Honest scope (adversarially reviewed)

A render **already executing** in the worker can't be interrupted — its synchronous `callMain` runs to completion and the host discards the result by id (unchanged behavior; truly stopping it would require terminating + re-initializing the worker, which isn't worth it for a few seconds of wasted CPU and could disrupt other queued work). What this fix adds: a still-**queued** render is genuinely cancelled, and the superseded export's promise/spinner settle immediately instead of lingering. A reviewer subagent confirmed the handle logic is race-free (no lost-kill, no wrong-handle clear, safe double-kill, no spinner/error leak).

## Tests

The pass-through and 3MF-picker supersession tests now assert the in-flight render was cancelled; the render mock returns an `AbortablePromise`-shaped value (Promise + `kill` spy) mirroring the real delayable. Full gate green locally (432 unit + 25 assembly).

Part of the #122 P2 hardening backlog. Refs #122