### PR TITLE
fix(import): enforce size limits while streaming, not after buffering (#122)

### DIFF
--- a/src/__tests__/external-source.test.ts
+++ b/src/__tests__/external-source.test.ts
@@ -1,0 +1,105 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+import { fetchResolvedExternalSourceBytes } from '../external-source.ts';
+
+const URL_OK = new URL('https://example.com/model.scad');
+
+/** A minimal streaming Response: hands out `chunks` from a reader, exposes the
+ *  `cancel` spy, and throws if `arrayBuffer()` is used (it shouldn't be). */
+function streamResponse(chunks: Uint8Array[], { contentLength }: { contentLength?: string } = {}) {
+  let i = 0;
+  const cancel = vi.fn(async () => {});
+  const getReader = vi.fn(() => ({
+    read: async () =>
+      i < chunks.length
+        ? { done: false as const, value: chunks[i++] }
+        : { done: true as const, value: undefined },
+    cancel,
+  }));
+  return {
+    ok: true,
+    status: 200,
+    headers: {
+      get: (k: string) => (k.toLowerCase() === 'content-length' ? (contentLength ?? null) : null),
+    },
+    body: { getReader },
+    arrayBuffer: async () => {
+      throw new Error('arrayBuffer() should not be called on a streaming body');
+    },
+    _cancel: cancel,
+    _getReader: getReader,
+  };
+}
+
+function bufferedResponse(bytes: Uint8Array, { contentLength }: { contentLength?: string } = {}) {
+  return {
+    ok: true,
+    status: 200,
+    headers: {
+      get: (k: string) => (k.toLowerCase() === 'content-length' ? (contentLength ?? null) : null),
+    },
+    body: null,
+    arrayBuffer: async () => bytes.buffer,
+  };
+}
+
+afterEach(() => vi.unstubAllGlobals());
+
+describe('fetchResolvedExternalSourceBytes streaming size limit', () => {
+  it('streams a body under the limit and returns the concatenated bytes', async () => {
+    const res = streamResponse([new Uint8Array([1, 2, 3]), new Uint8Array([4, 5])]);
+    vi.stubGlobal(
+      'fetch',
+      vi.fn(async () => res),
+    );
+
+    const out = await fetchResolvedExternalSourceBytes(URL_OK, { maxBytes: 1024 });
+    expect(Array.from(out)).toEqual([1, 2, 3, 4, 5]);
+  });
+
+  it('aborts the stream as soon as the cumulative size exceeds the budget', async () => {
+    // Two 4-byte chunks against a 6-byte budget: the second crosses it.
+    const res = streamResponse([new Uint8Array(4), new Uint8Array(4)]);
+    vi.stubGlobal(
+      'fetch',
+      vi.fn(async () => res),
+    );
+
+    await expect(fetchResolvedExternalSourceBytes(URL_OK, { maxBytes: 6 })).rejects.toThrow(
+      /too large/,
+    );
+    expect(res._cancel).toHaveBeenCalled(); // the download was cancelled, not drained
+  });
+
+  it('rejects on an oversized content-length before reading the body', async () => {
+    const res = streamResponse([new Uint8Array(1)], { contentLength: '999999' });
+    vi.stubGlobal(
+      'fetch',
+      vi.fn(async () => res),
+    );
+
+    await expect(fetchResolvedExternalSourceBytes(URL_OK, { maxBytes: 10 })).rejects.toThrow(
+      /too large/,
+    );
+    expect(res._getReader).not.toHaveBeenCalled(); // never started streaming
+  });
+
+  it('falls back to a buffered read with the same cap when there is no stream body', async () => {
+    vi.stubGlobal(
+      'fetch',
+      vi.fn(async () => bufferedResponse(new Uint8Array([9, 8, 7]))),
+    );
+    const out = await fetchResolvedExternalSourceBytes(URL_OK, { maxBytes: 1024 });
+    expect(Array.from(out)).toEqual([9, 8, 7]);
+  });
+
+  it('rejects an oversized buffered body in the no-stream fallback', async () => {
+    vi.stubGlobal(
+      'fetch',
+      vi.fn(async () => bufferedResponse(new Uint8Array(20))),
+    );
+    await expect(fetchResolvedExternalSourceBytes(URL_OK, { maxBytes: 10 })).rejects.toThrow(
+      /too large/,
+    );
+  });
+});

--- a/src/external-source.ts
+++ b/src/external-source.ts
@@ -111,17 +111,49 @@ export async function fetchResolvedExternalSourceBytes(
     throw new Error(`HTTP ${response.status} while fetching source.`);
   }
 
+  const tooLarge = () => new Error(`Source file is too large (> ${maxBytes / 1024 / 1024} MB).`);
+
   const contentLength = response.headers.get('content-length');
   if (contentLength && Number(contentLength) > maxBytes) {
-    throw new Error(`Source file is too large (> ${maxBytes / 1024 / 1024} MB).`);
+    throw tooLarge();
   }
 
-  const buffer = await response.arrayBuffer();
-  if (buffer.byteLength > maxBytes) {
-    throw new Error(`Source file is too large (> ${maxBytes / 1024 / 1024} MB).`);
+  // Stream the body and abort as soon as the cumulative size exceeds the budget,
+  // so a response with no (or a lying) content-length can't buffer unboundedly
+  // into memory before the check. Falls back to a buffered read with the same
+  // post-hoc cap when the body isn't a readable stream (e.g. some test mocks).
+  const body = response.body;
+  if (!body) {
+    const buffer = await response.arrayBuffer();
+    if (buffer.byteLength > maxBytes) {
+      throw tooLarge();
+    }
+    return new Uint8Array(buffer);
   }
 
-  return new Uint8Array(buffer);
+  const reader = body.getReader();
+  const chunks: Uint8Array[] = [];
+  let total = 0;
+  for (;;) {
+    const { done, value } = await reader.read();
+    if (done) break;
+    total += value.byteLength;
+    if (total > maxBytes) {
+      // Abort the download, but don't await/propagate cancel() — a slow or
+      // rejecting cancel must not mask (or delay) the clear "too large" error.
+      void reader.cancel().catch(() => {});
+      throw tooLarge();
+    }
+    chunks.push(value);
+  }
+
+  const out = new Uint8Array(total);
+  let offset = 0;
+  for (const chunk of chunks) {
+    out.set(chunk, offset);
+    offset += chunk.byteLength;
+  }
+  return out;
 }
 
 export async function fetchExternalSourceBytes(

--- a/src/fs/project-path.ts
+++ b/src/fs/project-path.ts
@@ -9,6 +9,12 @@ export const MAX_PROJECT_PATH_LENGTH = 1024;
 export const MAX_PROJECT_FILE_COUNT = 2000;
 /** Maximum total uncompressed bytes accepted from one imported archive (64 MiB). */
 export const MAX_PROJECT_TOTAL_BYTES = 64 * 1024 * 1024;
+/**
+ * Maximum *compressed* bytes accepted as an imported archive (64 MiB). Rejects an
+ * absurdly large archive up front, before JSZip parses it. The uncompressed total
+ * is separately bounded per-entry while decompressing (zip-bomb defense).
+ */
+export const MAX_COMPRESSED_ZIP_BYTES = 64 * 1024 * 1024;
 
 export class ProjectPathError extends Error {
   constructor(message: string) {

--- a/src/state/__tests__/fake-zip.ts
+++ b/src/state/__tests__/fake-zip.ts
@@ -1,0 +1,80 @@
+// Shared JSZip test double. Controls archive contents deterministically without
+// depending on JSZip's own (de)compression, and exposes BOTH `.async('string')`
+// and the streaming `internalStream('string')` surface the importer uses, so a
+// 'data' handler can pause/abort before the whole entry is read.
+
+/** A fake JSZip entry: `.async` plus an async-emitting `internalStream`. */
+export function fakeEntry(content: string) {
+  return {
+    dir: false,
+    async: () => Promise.resolve(content),
+    internalStream(_type: 'string') {
+      const handlers: Record<string, (arg?: unknown) => void> = {};
+      let paused = false;
+      let i = 0;
+      const stream = {
+        on(event: string, cb: (arg?: unknown) => void) {
+          handlers[event] = cb;
+          return stream;
+        },
+        pause() {
+          paused = true;
+          return stream;
+        },
+        resume() {
+          // Emit the content in 64 KiB chunks across microtasks, then end —
+          // letting a 'data' handler pause (stopping the pump) before the whole
+          // entry is read, exactly as the importer's budget abort does.
+          paused = false;
+          const pump = () => {
+            if (paused) return;
+            if (i >= content.length) {
+              handlers.end?.();
+              return;
+            }
+            const chunk = content.slice(i, i + 64 * 1024);
+            i += chunk.length;
+            handlers.data?.(chunk);
+            queueMicrotask(pump);
+          };
+          queueMicrotask(pump);
+          return stream;
+        },
+      };
+      return stream;
+    },
+  };
+}
+
+export function fakeZip(entries: Record<string, string>) {
+  const files: Record<string, ReturnType<typeof fakeEntry>> = {};
+  for (const [name, content] of Object.entries(entries)) {
+    files[name] = fakeEntry(content);
+  }
+  return { files };
+}
+
+/** A fake entry whose stream emits an 'error' (e.g. a corrupt/undecodable entry). */
+export function fakeErrorEntry(error: unknown) {
+  return {
+    dir: false,
+    async: () => Promise.reject(error),
+    internalStream(_type: 'string') {
+      const handlers: Record<string, (arg?: unknown) => void> = {};
+      const stream = {
+        on(event: string, cb: (arg?: unknown) => void) {
+          handlers[event] = cb;
+          return stream;
+        },
+        pause() {
+          return stream;
+        },
+        resume() {
+          queueMicrotask(() => handlers.error?.(error));
+          return stream;
+        },
+      };
+      return stream;
+    },
+  };
+}

--- a/src/state/__tests__/fsapi-handle-scope.test.ts
+++ b/src/state/__tests__/fsapi-handle-scope.test.ts
@@ -26,15 +26,8 @@ vi.mock('../../io/import_off.ts', () => ({ parseOff: vi.fn() }));
 // Control archive contents without depending on real JSZip in jsdom.
 vi.mock('jszip', () => ({ default: { loadAsync: vi.fn() } }));
 import JSZip from 'jszip';
+import { fakeZip } from './fake-zip.ts';
 const mockLoadAsync = (JSZip as unknown as { loadAsync: ReturnType<typeof vi.fn> }).loadAsync;
-
-function fakeZip(entries: Record<string, string>) {
-  const files: Record<string, { dir: boolean; async: () => Promise<string> }> = {};
-  for (const [name, content] of Object.entries(entries)) {
-    files[name] = { dir: false, async: () => Promise.resolve(content) };
-  }
-  return { files };
-}
 
 function makeFs() {
   return {

--- a/src/state/__tests__/zip-import.test.ts
+++ b/src/state/__tests__/zip-import.test.ts
@@ -4,7 +4,11 @@
 import { Model } from '../model.ts';
 import { State } from '../app-state.ts';
 import { defaultSourcePath, defaultModelColor } from '../initial-state.ts';
-import { MAX_PROJECT_FILE_COUNT, MAX_PROJECT_TOTAL_BYTES } from '../../fs/project-path.ts';
+import {
+  MAX_COMPRESSED_ZIP_BYTES,
+  MAX_PROJECT_FILE_COUNT,
+  MAX_PROJECT_TOTAL_BYTES,
+} from '../../fs/project-path.ts';
 
 vi.mock('../../runner/actions.ts', () => {
   const makeDelayable = (resolvedValue: unknown) =>
@@ -25,15 +29,8 @@ vi.mock('../../io/import_off.ts', () => ({ parseOff: vi.fn() }));
 // name handling.
 vi.mock('jszip', () => ({ default: { loadAsync: vi.fn() } }));
 import JSZip from 'jszip';
+import { fakeErrorEntry, fakeZip } from './fake-zip.ts';
 const mockLoadAsync = (JSZip as unknown as { loadAsync: ReturnType<typeof vi.fn> }).loadAsync;
-
-function fakeZip(entries: Record<string, string>) {
-  const files: Record<string, { dir: boolean; async: () => Promise<string> }> = {};
-  for (const [name, content] of Object.entries(entries)) {
-    files[name] = { dir: false, async: () => Promise.resolve(content) };
-  }
-  return { files };
-}
 
 function makeMockFs() {
   return {
@@ -160,10 +157,54 @@ describe('importProjectZip validation (#50)', () => {
     expect(model.state.error).toBeTruthy();
   });
 
+  it('rejects an archive whose compressed size exceeds the cap, before parsing', async () => {
+    await model.importProjectZip(new ArrayBuffer(MAX_COMPRESSED_ZIP_BYTES + 1));
+
+    // The cap is checked up front, so JSZip is never asked to parse the buffer.
+    expect(mockLoadAsync).not.toHaveBeenCalled();
+    expect(mockFs.writeFile).not.toHaveBeenCalled();
+    expect(model.state.error).toBeTruthy();
+  });
+
   it('rejects an archive that exceeds the uncompressed size limit', async () => {
     mockLoadAsync.mockResolvedValue(
       fakeZip({ 'big.scad': 'x'.repeat(MAX_PROJECT_TOTAL_BYTES + 1) }),
     );
+
+    await model.importProjectZip(new ArrayBuffer(0));
+
+    expect(mockFs.writeFile).not.toHaveBeenCalled();
+    expect(model.state.error).toBeTruthy();
+  });
+
+  it('aborts when entries cumulatively exceed the uncompressed limit', async () => {
+    // Each entry fits on its own, but together they blow the budget — the second
+    // entry's stream aborts as the running total crosses the limit.
+    const half = 'x'.repeat(Math.ceil(MAX_PROJECT_TOTAL_BYTES / 2) + 1);
+    mockLoadAsync.mockResolvedValue(fakeZip({ 'a.scad': half, 'b.scad': half }));
+
+    await model.importProjectZip(new ArrayBuffer(0));
+
+    // The whole import is rejected before the write phase, so nothing is written.
+    expect(mockFs.writeFile).not.toHaveBeenCalled();
+    expect(model.state.error).toBeTruthy();
+  });
+
+  it('rejects when an entry fails to decompress (stream error)', async () => {
+    mockLoadAsync.mockResolvedValue({
+      files: { 'bad.scad': fakeErrorEntry(new Error('corrupt entry')) },
+    });
+
+    await model.importProjectZip(new ArrayBuffer(0));
+
+    expect(mockFs.writeFile).not.toHaveBeenCalled();
+    expect(model.state.error).toBeTruthy();
+  });
+
+  it('wraps a non-Error stream failure into an Error', async () => {
+    mockLoadAsync.mockResolvedValue({
+      files: { 'bad.scad': fakeErrorEntry('plain string failure') },
+    });
 
     await model.importProjectZip(new ArrayBuffer(0));
 

--- a/src/state/project-store.ts
+++ b/src/state/project-store.ts
@@ -4,6 +4,7 @@ import { ProjectFileSystem } from '../fs/project-filesystem.ts';
 import { contentOf, type SerializableSource } from './project-source.ts';
 import { fetchSource } from '../utils.ts';
 import {
+  MAX_COMPRESSED_ZIP_BYTES,
   MAX_PROJECT_FILE_COUNT,
   MAX_PROJECT_TOTAL_BYTES,
   normalizeProjectPath,
@@ -102,14 +103,19 @@ export class ProjectStore {
    * Returns null when the archive contains no files.
    */
   async importZip(zipBuffer: ArrayBuffer): Promise<ProjectSnapshot | null> {
+    // Reject an absurdly large compressed archive before JSZip parses it.
+    if (zipBuffer.byteLength > MAX_COMPRESSED_ZIP_BYTES) {
+      throw new ProjectPathError('Archive is too large.');
+    }
     const zip = await JSZip.loadAsync(zipBuffer);
     const entries = Object.entries(zip.files).filter(([, zipObj]) => !zipObj.dir);
     if (entries.length > MAX_PROJECT_FILE_COUNT) {
       throw new ProjectPathError(`Archive has too many files (max ${MAX_PROJECT_FILE_COUNT}).`);
     }
-    // The size limit is an approximate cumulative guard over decoded entry
-    // lengths (UTF-16 units); a single entry is still fully decoded before its
-    // length is counted.
+    // Cumulative uncompressed-size guard over decoded entry lengths (UTF-16
+    // units). Each entry is decompressed as a stream and aborted the moment the
+    // running total would exceed the budget, so a zip bomb can't fully inflate
+    // in memory before the check trips.
     const files: [string, string][] = [];
     const seen = new Set<string>();
     let totalSize = 0;
@@ -119,11 +125,8 @@ export class ProjectStore {
         throw new ProjectPathError(`Duplicate path in archive: ${safePath}`);
       }
       seen.add(safePath);
-      const content = await zipObj.async('string');
+      const content = await readZipEntryWithinBudget(zipObj, MAX_PROJECT_TOTAL_BYTES - totalSize);
       totalSize += content.length;
-      if (totalSize > MAX_PROJECT_TOTAL_BYTES) {
-        throw new ProjectPathError('Archive exceeds the uncompressed size limit.');
-      }
       files.push([safePath, content]);
     }
     // Paths are validated above; FS write failures are best-effort and must not
@@ -171,4 +174,46 @@ export class ProjectStore {
     }
     return zip.generateAsync({ type: 'blob' });
   }
+}
+
+// JSZip's incremental decompression API (`internalStream`) is public at runtime
+// but missing from @types/jszip; declare the minimal surface we use.
+interface JSZipStringStream {
+  on(event: 'data', cb: (chunk: string) => void): JSZipStringStream;
+  on(event: 'error', cb: (err: unknown) => void): JSZipStringStream;
+  on(event: 'end', cb: () => void): JSZipStringStream;
+  resume(): JSZipStringStream;
+  pause(): JSZipStringStream;
+}
+
+/**
+ * Decompress one ZIP entry to a string, aborting as soon as the cumulative
+ * decoded length would exceed `budget` (UTF-16 units). Streaming the inflate and
+ * stopping early bounds a zip bomb's memory to roughly the budget plus one chunk,
+ * instead of fully inflating the entry before any size check.
+ */
+function readZipEntryWithinBudget(zipObj: JSZip.JSZipObject, budget: number): Promise<string> {
+  return new Promise<string>((resolve, reject) => {
+    let acc = '';
+    let len = 0;
+    const stream = (
+      zipObj as unknown as { internalStream(type: 'string'): JSZipStringStream }
+    ).internalStream('string');
+    // The Promise is natively settle-once, so a stray late event after the first
+    // settle is a harmless no-op; pausing on the over-budget chunk keeps `acc`
+    // from growing past the budget regardless.
+    stream
+      .on('data', (chunk: string) => {
+        len += chunk.length;
+        if (len > budget) {
+          stream.pause();
+          reject(new ProjectPathError('Archive exceeds the uncompressed size limit.'));
+          return;
+        }
+        acc += chunk;
+      })
+      .on('error', (err: unknown) => reject(err instanceof Error ? err : new Error(String(err))))
+      .on('end', () => resolve(acc))
+      .resume();
+  });
 }


### PR DESCRIPTION
## What

Two unbounded-buffering gaps let a hostile source exhaust memory **before** the size check tripped:

1. **External fetches** called `response.arrayBuffer()` and only then compared `byteLength` — so a response with no (or a lying) `content-length` buffered the entire body first. Now we stream via the body reader and abort (cancelling the download) the moment cumulative bytes exceed the budget, discarding the over-budget chunk. Falls back to a buffered read with the same cap when there's no stream body.

2. **ZIP import** fully decompressed each entry via `.async('string')` before counting it — so a zip bomb inflated entirely in memory before the cumulative limit tripped. Now each entry is decompressed through JSZip's `internalStream('string')` and aborted as the running total crosses the budget. Additionally, an archive whose **compressed** size exceeds `MAX_COMPRESSED_ZIP_BYTES` is rejected up front, before JSZip parses it.

## Adversarially reviewed

A reviewer subagent confirmed (no blockers): the cumulative checks are off-by-one-free and match the prior semantics; memory is genuinely bounded (the abort happens before retaining the over-budget chunk; `acc` is frozen on settle regardless of whether JSZip's `pause()` halts inflation); the per-entry budget arithmetic can't go negative or accept over-budget data; the compressed cap is checked before `loadAsync`; `internalStream('string')` counts UTF-16 units consistently with the old path; empty bodies/entries and multi-byte boundaries are unregressed; errors surface through the existing `ProjectPathError`/`Error` flows. Its one minor nit — `await reader.cancel()` could mask the "too large" error if cancel rejects/hangs — is fixed here (fire-and-forget with a swallowed rejection).

## Tests

Stream-abort, content-length pre-check, no-stream fallback (external); compressed cap, cumulative cross-entry budget, single oversized entry (ZIP). Shared the JSZip streaming test double across the two import test files. Full gate green: `npm run verify`, exit 0 (439 unit + 25 assembly).

Completes the #122 P2 hardening backlog. Refs #122