### PR TITLE
fix(editor): binary assets read-only + dropped from syntax inputs (#153)

### DIFF
--- a/src/components/elements/osc-editor-panel.ts
+++ b/src/components/elements/osc-editor-panel.ts
@@ -634,6 +634,7 @@ export class OscEditorPanel extends LitElement {
           : html`<textarea
               class="osc-editor-textarea"
               aria-label="OpenSCAD source editor"
+              ?readonly=${this._isActiveBinary(st)}
               .value=${this._model?.source ?? ''}
               @input=${(e: Event) => {
                 this._model.source = (e.target as HTMLTextAreaElement).value;

--- a/src/components/elements/osc-editor-panel.ts
+++ b/src/components/elements/osc-editor-panel.ts
@@ -8,6 +8,7 @@ import * as monacoTypes from 'monaco-editor/esm/vs/editor/editor.api';
 import 'monaco-editor/min/vs/editor/editor.main.css';
 import { getModel } from '../../state/model-context.ts';
 import { isProjectScopedPath, staleModelPaths } from './editor-model-ownership.ts';
+import { isProbablyTextPath } from '../../state/project-source.ts';
 import { getFS } from '../../state/fs-context.ts';
 import { zipArchives } from '../../fs/zip-archives.generated.ts';
 import { getParentDir, join } from '../../fs/filesystem.ts';
@@ -75,6 +76,10 @@ export class OscEditorPanel extends LitElement {
       // A project replace (e.g. ZIP import) swaps the source set; drop the models
       // for files that are no longer part of the project so they don't leak.
       this._pruneOwnedModels(st);
+
+      // A binary asset has no editable text; keep the editor read-only on it so
+      // typing can't convert it to a text source (the model also guards this).
+      this._editor.updateOptions({ readOnly: this._isActiveBinary(st) });
 
       const checkerRun = st.lastCheckerRun;
       if (checkerRun) {
@@ -208,6 +213,7 @@ export class OscEditorPanel extends LitElement {
       automaticLayout: true,
       fontSize: 16,
       lineNumbers: st.view.lineNumbers ? 'on' : 'off',
+      readOnly: this._isActiveBinary(st),
     });
     this._editor = editor;
 
@@ -276,6 +282,13 @@ export class OscEditorPanel extends LitElement {
 
     markPerf('osc:editor-mount-end');
     measurePerf('osc:editor-mount', 'osc:editor-mount-start', 'osc:editor-mount-end');
+  }
+
+  /** Whether the active source is a binary asset (a `local` source with a
+   *  non-text extension) — it has no editable text, so the editor is read-only. */
+  private _isActiveBinary(st: State): boolean {
+    const active = st.params.sources.find((s) => s.path === st.params.activePath);
+    return active?.kind === 'local' && !isProbablyTextPath(active.path);
   }
 
   private _buildFileOptions(): Array<{ path: string; label: string; group: string }> {

--- a/src/state/__tests__/model.test.ts
+++ b/src/state/__tests__/model.test.ts
@@ -182,6 +182,23 @@ describe('Model — render triggering', () => {
     expect(mockRender).not.toHaveBeenCalled();
   });
 
+  it('ignores source writes to a binary local asset (no conversion to text) (#153)', async () => {
+    // Make a binary asset the active source.
+    model.mutate((s) => {
+      s.params.sources = [{ kind: 'local', path: '/home/part.stl' }];
+      s.params.activePath = '/home/part.stl';
+    });
+    mockRender.mockClear();
+
+    model.source = 'cube(1);'; // a stray edit must not stick
+    await nextTicks();
+
+    const active = model.state.params.sources.find((s) => s.path === '/home/part.stl');
+    expect(active?.kind).toBe('local'); // still binary, not converted to text
+    expect('content' in (active ?? {})).toBe(false);
+    expect(mockRender).not.toHaveBeenCalled();
+  });
+
   it('triggers render when activePath changes via openFile', async () => {
     // Pre-populate the second source so openFile can switch to it
     model.mutate((s) => {

--- a/src/state/model.ts
+++ b/src/state/model.ts
@@ -10,7 +10,7 @@ import { VALID_EXPORT_FORMATS_2D, VALID_EXPORT_FORMATS_3D } from './formats.ts';
 import { bubbleUpDeepMutations } from './deep-mutate.ts';
 import { openLocalFile, saveViaHandle } from '../fs/filesystem.ts';
 import { ProjectFileSystem } from '../fs/project-filesystem.ts';
-import { contentOf } from './project-source.ts';
+import { contentOf, isProbablyTextPath } from './project-source.ts';
 import { ProjectStore } from './project-store.ts';
 import { HostAdapter, WebHostAdapter } from './web-host-adapter.ts';
 import { applyUserFacingError } from './apply-user-facing-error.ts';
@@ -277,6 +277,11 @@ export class Model extends EventTarget {
     return this.projectStore.activeContent(this.state.params.sources, this.state.params.activePath);
   }
   set source(source: string) {
+    // A binary `local` asset has no text representation; ignore writes to it so
+    // no edit path converts it into a `{kind:'text'}` source and drops the asset
+    // (the editor also keeps it read-only). See #153 / ADR 0006.
+    const active = this.state.params.sources.find((s) => s.path === this.state.params.activePath);
+    if (active?.kind === 'local' && !isProbablyTextPath(active.path)) return;
     if (
       this.mutate((s) => {
         s.params.sources = this.projectStore.withActiveContent(

--- a/src/state/services/__tests__/compile-coordinator.test.ts
+++ b/src/state/services/__tests__/compile-coordinator.test.ts
@@ -7,10 +7,11 @@ import type { State } from '../../app-state.ts';
 // render() is `factory(renderArgs)({ now })` → Promise<RenderOutput>; we drive the
 // promise it returns and the source revision to exercise the staleness drop.
 const renderImpl = vi.fn();
+const checkSyntaxImpl = vi.fn();
 
 vi.mock('../../../runner/actions.ts', () => ({
   render: (renderArgs: unknown) => (opts: unknown) => renderImpl(renderArgs, opts),
-  checkSyntax: vi.fn(),
+  checkSyntax: (args: unknown) => (opts: unknown) => checkSyntaxImpl(args, opts),
 }));
 
 function makeContext(revision: number) {
@@ -135,6 +136,21 @@ describe('CompileCoordinator binary-asset materialization (#121)', () => {
 
     expect(String(state.error)).toMatch(/Asset not available/);
     expect(renderImpl).not.toHaveBeenCalled();
+  });
+
+  it('excludes binary local assets from the syntax-check inputs, keeping .scad sources (#153)', async () => {
+    const { ctx } = makeBinaryContext(() => new Uint8Array());
+    checkSyntaxImpl.mockReset();
+    checkSyntaxImpl.mockResolvedValue({ markers: [], parameterSet: undefined, revision: 1 });
+
+    await new CompileCoordinator(ctx).checkSyntax();
+
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const args = checkSyntaxImpl.mock.calls[0][0] as any;
+    const paths = args.sources.map((s: { path: string }) => s.path);
+    expect(paths).toContain('/home/main.scad'); // active .scad kept
+    expect(paths).toContain('/libraries/foo/bar.scad'); // a .scad local is text → kept
+    expect(paths).not.toContain('/home/part.stl'); // binary local dropped (no worker noise)
   });
 });
 

--- a/src/state/services/compile-coordinator.ts
+++ b/src/state/services/compile-coordinator.ts
@@ -148,7 +148,13 @@ export class CompileCoordinator {
     try {
       const checkerRun = await checkSyntax({
         activePath: this.ctx.getState().params.activePath,
-        sources: this.ctx.getState().params.sources,
+        // The param/syntax pass never resolves `import()` (it's lazy, evaluated
+        // only at geometry time), so a binary `local` asset is not needed here —
+        // and sending it content-less makes the worker log "File … does not
+        // exist". Drop binary locals; text/.scad sources are kept (#153).
+        sources: this.ctx
+          .getState()
+          .params.sources.filter((s) => !(s.kind === 'local' && !isProbablyTextPath(s.path))),
         revision: this.ctx.getSourceRevision(),
       })({ now: false });
       if (!isCurrent()) return; // a newer syntax check superseded this one


### PR DESCRIPTION
The two binary-import UX follow-ups from the #121 review.

## 1. A binary asset was editable as text (data-loss)
Selecting an imported binary in the file dropdown and **typing** rewrote its `{kind:'local'}` source into `{kind:'text', content}`, dropping the asset reference and compiling the typed text.

- **`Model.set source` guard** (the correctness backstop): ignore writes when the active source is a binary `local` — the single choke point every edit path (Monaco, textarea, future callers) funnels through.
- **Monaco `readOnly`** when the active source is a binary `local` (`_isActiveBinary`), recomputed on every active-file switch — so keystrokes are visibly blocked, not silently swallowed.

## 2. Syntax-check console noise
A `.scad` that `import()`s a binary still ran `checkSyntax`, which passed sources **un-materialized**, so the worker logged `File … does not exist` on every check. The param/syntax pass never resolves `import()` (it's lazy), so the asset isn't needed there — filter binary `local` sources out of the syntax-check inputs (`.scad`/text sources kept).

## Tests
- `set source` no-ops on a binary local (stays `local`, no recompile-as-text).
- `checkSyntax` inputs exclude the binary local, keep the active `.scad` and a `.scad` local.
- Full gate green (463 unit + 25 assembly).

Closes #153.