### PR TITLE
refactor(runner): per-session compile schedulers — Gate B slice 2 (#123)

### DIFF
--- a/src/__tests__/model-checkingSyntax.test.ts
+++ b/src/__tests__/model-checkingSyntax.test.ts
@@ -2,10 +2,17 @@ import type { State } from '../state/app-state.ts';
 import { Model } from '../state/model.ts';
 import { defaultModelColor, defaultSourcePath } from '../state/initial-state.ts';
 
-vi.mock('../runner/actions.ts', () => ({
-  checkSyntax: vi.fn().mockReturnValue(vi.fn().mockRejectedValue(new Error('mock runner failure'))),
-  render: vi.fn(),
-}));
+vi.mock('../runner/actions.ts', () => {
+  const checkSyntax = vi
+    .fn()
+    .mockReturnValue(vi.fn().mockRejectedValue(new Error('mock runner failure')));
+  const render = vi.fn();
+  return {
+    createSyntaxDelayable: () => checkSyntax,
+    createRenderDelayable: () => render,
+    createRenderExportDelayable: () => vi.fn().mockReturnValue(vi.fn().mockResolvedValue({})),
+  };
+});
 
 describe('Model.checkSyntax', () => {
   const makeMockFs = () => ({

--- a/src/runner/actions.ts
+++ b/src/runner/actions.ts
@@ -27,7 +27,7 @@ type SyntaxCheckOutput = {
   parameterSet?: ParameterSet;
   revision?: number;
 };
-export const checkSyntax = turnIntoDelayableExecution(syntaxDelay, (sargs: SyntaxCheckArgs) => {
+const syntaxJob = (sargs: SyntaxCheckArgs) => {
   const { activePath, sources, revision } = sargs;
 
   const outFile = 'out.json';
@@ -82,7 +82,11 @@ export const checkSyntax = turnIntoDelayableExecution(syntaxDelay, (sargs: Synta
     })();
     return () => job.kill();
   });
-});
+};
+
+/** A fresh syntax-check scheduler (own debounce + supersession). One per session
+ *  so independent sessions don't cancel each other's checks (ADR 0007). */
+export const createSyntaxDelayable = () => turnIntoDelayableExecution(syntaxDelay, syntaxJob);
 
 const renderDelay = 1000;
 export type RenderOutput = {
@@ -306,12 +310,13 @@ const renderJob = (renderArgs: RenderArgs) => {
   });
 };
 
-// Preview and full render share one delayable instance: they debounce and
-// supersede each other (only one geometry compile should be live at a time).
-export const render = turnIntoDelayableExecution(renderDelay, renderJob);
+// Preview and full render share ONE delayable instance per coordinator: they
+// debounce and supersede each other (only one geometry compile should be live at
+// a time). One per session (ADR 0007).
+export const createRenderDelayable = () => turnIntoDelayableExecution(renderDelay, renderJob);
 
 // Export gets its OWN delayable instance so it does not share the supersession
 // signal with preview/render — an auto-preview must not cancel an in-flight
 // export, nor an export an in-flight preview. Callers pass `priority: 'export'`
 // for host-side scheduling precedence.
-export const renderExport = turnIntoDelayableExecution(renderDelay, renderJob);
+export const createRenderExportDelayable = () => turnIntoDelayableExecution(renderDelay, renderJob);

--- a/src/state/__tests__/fsapi-handle-scope.test.ts
+++ b/src/state/__tests__/fsapi-handle-scope.test.ts
@@ -12,13 +12,16 @@ vi.mock('../../runner/actions.ts', () => {
   const makeDelayable = (resolved: unknown) =>
     vi.fn().mockReturnValue(vi.fn().mockResolvedValue(resolved));
   return {
-    checkSyntax: makeDelayable({ logText: '', markers: [], parameterSet: undefined }),
-    render: makeDelayable({
-      outFile: new File([''], 't.off'),
-      logText: '',
-      markers: [],
-      elapsedMillis: 0,
-    }),
+    createSyntaxDelayable: () =>
+      makeDelayable({ logText: '', markers: [], parameterSet: undefined }),
+    createRenderDelayable: () =>
+      makeDelayable({
+        outFile: new File([''], 't.off'),
+        logText: '',
+        markers: [],
+        elapsedMillis: 0,
+      }),
+    createRenderExportDelayable: () => makeDelayable({}),
   };
 });
 vi.mock('../../io/import_off.ts', () => ({ parseOff: vi.fn() }));

--- a/src/state/__tests__/model.test.ts
+++ b/src/state/__tests__/model.test.ts
@@ -11,33 +11,35 @@ import { createOperationFailure } from '../../user-facing-errors.ts';
 // Module mocks — must be declared before any imports
 // ---------------------------------------------------------------------------
 
-// Mock the heavy runner actions so no Worker / WASM is touched.
-// checkSyntax and render are "turnable" factory functions: f(args) => g({now}) => Promise
-vi.mock('../../runner/actions.ts', () => {
-  const makeDelayable = (resolvedValue: unknown) =>
-    vi.fn().mockReturnValue(vi.fn().mockResolvedValue(resolvedValue));
-  return {
-    checkSyntax: makeDelayable({ logText: '', markers: [], parameterSet: undefined }),
-    render: makeDelayable({
-      outFile: new File(['content'], 'test.glb', { type: 'model/gltf-binary' }),
-      logText: '',
-      markers: [],
-      elapsedMillis: 0,
-    }),
-  };
-});
+// Mock the heavy runner actions so no Worker / WASM is touched. The schedulers
+// are created per service via factories now; each factory returns the same
+// singleton handle so the single Model under test routes all calls through it.
+// The handles are `mock`-prefixed so the hoisted vi.mock factory may close over
+// them, and the tests inspect them directly (no import-from-actions needed).
+const mockCheckSyntax = vi
+  .fn()
+  .mockReturnValue(
+    vi.fn().mockResolvedValue({ logText: '', markers: [], parameterSet: undefined }),
+  );
+const mockRender = vi.fn().mockReturnValue(
+  vi.fn().mockResolvedValue({
+    outFile: new File(['content'], 'test.glb', { type: 'model/gltf-binary' }),
+    logText: '',
+    markers: [],
+    elapsedMillis: 0,
+  }),
+);
+vi.mock('../../runner/actions.ts', () => ({
+  createSyntaxDelayable: () => mockCheckSyntax,
+  createRenderDelayable: () => mockRender,
+  // The Model also constructs ExportService, which creates its own export
+  // scheduler; a no-op delayable is enough (these tests don't drive export).
+  createRenderExportDelayable: () => vi.fn().mockReturnValue(vi.fn().mockResolvedValue({})),
+}));
 
 // Mock heavy IO that model.render() uses after a successful compile (avoided
 // because the mock render resolves immediately but we still need the symbols).
 vi.mock('../../io/import_off.ts', () => ({ parseOff: vi.fn() }));
-
-// ---------------------------------------------------------------------------
-// Import mocked actions so we can inspect call counts.
-// ---------------------------------------------------------------------------
-import { checkSyntax as _mockCheckSyntax, render as _mockRender } from '../../runner/actions.ts';
-
-const mockCheckSyntax = _mockCheckSyntax as ReturnType<typeof vi.fn>;
-const mockRender = _mockRender as ReturnType<typeof vi.fn>;
 
 // ---------------------------------------------------------------------------
 // Helpers

--- a/src/state/__tests__/scoped-persistence.test.ts
+++ b/src/state/__tests__/scoped-persistence.test.ts
@@ -10,13 +10,16 @@ vi.mock('../../runner/actions.ts', () => {
   const makeDelayable = (resolved: unknown) =>
     vi.fn().mockReturnValue(vi.fn().mockResolvedValue(resolved));
   return {
-    checkSyntax: makeDelayable({ logText: '', markers: [], parameterSet: undefined }),
-    render: makeDelayable({
-      outFile: new File([''], 't.off'),
-      logText: '',
-      markers: [],
-      elapsedMillis: 0,
-    }),
+    createSyntaxDelayable: () =>
+      makeDelayable({ logText: '', markers: [], parameterSet: undefined }),
+    createRenderDelayable: () =>
+      makeDelayable({
+        outFile: new File([''], 't.off'),
+        logText: '',
+        markers: [],
+        elapsedMillis: 0,
+      }),
+    createRenderExportDelayable: () => makeDelayable({}),
   };
 });
 vi.mock('../../io/import_off.ts', () => ({ parseOff: vi.fn() }));

--- a/src/state/__tests__/source-fetch-race.test.ts
+++ b/src/state/__tests__/source-fetch-race.test.ts
@@ -12,13 +12,16 @@ vi.mock('../../runner/actions.ts', () => {
   const makeDelayable = (resolvedValue: unknown) =>
     vi.fn().mockReturnValue(vi.fn().mockResolvedValue(resolvedValue));
   return {
-    checkSyntax: makeDelayable({ logText: '', markers: [], parameterSet: undefined }),
-    render: makeDelayable({
-      outFile: new File([''], 't.off'),
-      logText: '',
-      markers: [],
-      elapsedMillis: 0,
-    }),
+    createSyntaxDelayable: () =>
+      makeDelayable({ logText: '', markers: [], parameterSet: undefined }),
+    createRenderDelayable: () =>
+      makeDelayable({
+        outFile: new File([''], 't.off'),
+        logText: '',
+        markers: [],
+        elapsedMillis: 0,
+      }),
+    createRenderExportDelayable: () => makeDelayable({}),
   };
 });
 vi.mock('../../io/import_off.ts', () => ({ parseOff: vi.fn() }));

--- a/src/state/__tests__/web-host-adapter.test.ts
+++ b/src/state/__tests__/web-host-adapter.test.ts
@@ -10,13 +10,16 @@ vi.mock('../../runner/actions.ts', () => {
   const makeDelayable = (resolved: unknown) =>
     vi.fn().mockReturnValue(vi.fn().mockResolvedValue(resolved));
   return {
-    checkSyntax: makeDelayable({ logText: '', markers: [], parameterSet: undefined }),
-    render: makeDelayable({
-      outFile: new File(['off-bytes'], 'out.off'),
-      logText: '',
-      markers: [],
-      elapsedMillis: 1,
-    }),
+    createSyntaxDelayable: () =>
+      makeDelayable({ logText: '', markers: [], parameterSet: undefined }),
+    createRenderDelayable: () =>
+      makeDelayable({
+        outFile: new File(['off-bytes'], 'out.off'),
+        logText: '',
+        markers: [],
+        elapsedMillis: 1,
+      }),
+    createRenderExportDelayable: () => makeDelayable({}),
   };
 });
 vi.mock('../../io/import_off.ts', () => ({ parseOff: vi.fn() }));

--- a/src/state/__tests__/zip-import.test.ts
+++ b/src/state/__tests__/zip-import.test.ts
@@ -14,13 +14,16 @@ vi.mock('../../runner/actions.ts', () => {
   const makeDelayable = (resolvedValue: unknown) =>
     vi.fn().mockReturnValue(vi.fn().mockResolvedValue(resolvedValue));
   return {
-    checkSyntax: makeDelayable({ logText: '', markers: [], parameterSet: undefined }),
-    render: makeDelayable({
-      outFile: new File([''], 't.off'),
-      logText: '',
-      markers: [],
-      elapsedMillis: 0,
-    }),
+    createSyntaxDelayable: () =>
+      makeDelayable({ logText: '', markers: [], parameterSet: undefined }),
+    createRenderDelayable: () =>
+      makeDelayable({
+        outFile: new File([''], 't.off'),
+        logText: '',
+        markers: [],
+        elapsedMillis: 0,
+      }),
+    createRenderExportDelayable: () => makeDelayable({}),
   };
 });
 vi.mock('../../io/import_off.ts', () => ({ parseOff: vi.fn() }));

--- a/src/state/services/__tests__/compile-coordinator.test.ts
+++ b/src/state/services/__tests__/compile-coordinator.test.ts
@@ -10,8 +10,9 @@ const renderImpl = vi.fn();
 const checkSyntaxImpl = vi.fn();
 
 vi.mock('../../../runner/actions.ts', () => ({
-  render: (renderArgs: unknown) => (opts: unknown) => renderImpl(renderArgs, opts),
-  checkSyntax: (args: unknown) => (opts: unknown) => checkSyntaxImpl(args, opts),
+  createRenderDelayable: () => (renderArgs: unknown) => (opts: unknown) =>
+    renderImpl(renderArgs, opts),
+  createSyntaxDelayable: () => (args: unknown) => (opts: unknown) => checkSyntaxImpl(args, opts),
 }));
 
 function makeContext(revision: number) {

--- a/src/state/services/__tests__/export-service.test.ts
+++ b/src/state/services/__tests__/export-service.test.ts
@@ -1,15 +1,18 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
-// Mock the heavy compile/IO deps the format-conversion + 3MF paths touch.
+// Mock the heavy compile/IO deps the format-conversion + 3MF paths touch. The
+// export render scheduler is now created per ExportService via a factory; mock
+// the factory so it always returns the same handle the tests configure/assert on.
+const mockRenderExport = vi.fn().mockReturnValue(
+  vi.fn().mockResolvedValue({
+    outFile: new File(['converted'], 'model.stl'),
+    logText: '',
+    markers: [],
+    elapsedMillis: 1,
+  }),
+);
 vi.mock('../../../runner/actions.ts', () => ({
-  renderExport: vi.fn().mockReturnValue(
-    vi.fn().mockResolvedValue({
-      outFile: new File(['converted'], 'model.stl'),
-      logText: '',
-      markers: [],
-      elapsedMillis: 1,
-    }),
-  ),
+  createRenderExportDelayable: () => mockRenderExport,
 }));
 vi.mock('../../../io/import_off.ts', () => ({ parseOff: vi.fn(() => ({})) }));
 vi.mock('../../../io/export_3mf.ts', () => ({
@@ -20,14 +23,12 @@ vi.mock('../../../io/export_glb.ts', () => ({
 }));
 vi.mock('chroma-js', () => ({ default: vi.fn((c: string) => c) }));
 
-import { renderExport as _mockRenderExport, type RenderOutput } from '../../../runner/actions.ts';
+import { type RenderOutput } from '../../../runner/actions.ts';
 import type { State } from '../../app-state.ts';
 import { bubbleUpDeepMutations } from '../../deep-mutate.ts';
 import type { HostAdapter } from '../../web-host-adapter.ts';
 import { ExportService } from '../export-service.ts';
 import type { ServiceContext } from '../service-context.ts';
-
-const mockRenderExport = _mockRenderExport as ReturnType<typeof vi.fn>;
 
 /**
  * A renderExport mock whose inner thunk returns an AbortablePromise-shaped value

--- a/src/state/services/compile-coordinator.ts
+++ b/src/state/services/compile-coordinator.ts
@@ -1,4 +1,8 @@
-import { checkSyntax, render, type RenderArgs } from '../../runner/actions.ts';
+import {
+  createRenderDelayable,
+  createSyntaxDelayable,
+  type RenderArgs,
+} from '../../runner/actions.ts';
 import { isExpectedJobCancellation, type ProcessStreams } from '../../runner/openscad-runner.ts';
 import { isUserFacingOperationError, UserFacingOperationError } from '../../user-facing-errors.ts';
 import { fetchSource, formatBytes, formatMillis } from '../../utils.ts';
@@ -32,6 +36,12 @@ export class CompileCoordinator {
   private _previewSeq = 0;
   private _renderSeq = 0;
   private _syntaxSeq = 0;
+
+  // Per-coordinator (= per-session) schedulers so independent sessions never
+  // cross-cancel. One render delayable shared by preview + full render (they
+  // supersede each other); syntax has its own. See ADR 0007.
+  private readonly _render = createRenderDelayable();
+  private readonly _checkSyntax = createSyntaxDelayable();
 
   /**
    * Convert the typed sources to the flat wire shape, reading each project-local
@@ -146,7 +156,7 @@ export class CompileCoordinator {
     const isCurrent = () => this._syntaxSeq === token;
     this.ctx.mutate((s) => (s.checkingSyntax = true));
     try {
-      const checkerRun = await checkSyntax({
+      const checkerRun = await this._checkSyntax({
         activePath: this.ctx.getState().params.activePath,
         // The param/syntax pass never resolves `import()` (it's lazy, evaluated
         // only at geometry time), so a binary `local` asset is not needed here —
@@ -268,7 +278,7 @@ export class CompileCoordinator {
         backend: this.ctx.getState().params.backend,
         revision: this.ctx.getSourceRevision(),
       };
-      const output = await render(renderArgs)({ now });
+      const output = await this._render(renderArgs)({ now });
       if (!isCurrent()) return; // a newer render/preview superseded this one
       if (output.revision !== undefined && output.revision !== this.ctx.getSourceRevision()) {
         // Sources changed since this render was requested — drop the stale result.

--- a/src/state/services/export-service.ts
+++ b/src/state/services/export-service.ts
@@ -2,7 +2,7 @@ import chroma from 'chroma-js';
 
 import { export3MF } from '../../io/export_3mf.ts';
 import { parseOff } from '../../io/import_off.ts';
-import { renderExport, type RenderOutput } from '../../runner/actions.ts';
+import { createRenderExportDelayable, type RenderOutput } from '../../runner/actions.ts';
 import { isExpectedJobCancellation, type ProcessStreams } from '../../runner/openscad-runner.ts';
 import { isUserFacingOperationError } from '../../user-facing-errors.ts';
 import { formatBytes, formatMillis, type AbortablePromise } from '../../utils.ts';
@@ -23,6 +23,11 @@ export class ExportService {
   // the 3MF path which does not run through the delayable) must not clobber the
   // newer one's result/download when its async work finally settles.
   private _exportSeq = 0;
+
+  // This service's own export render scheduler (per session, ADR 0007), kept
+  // distinct from the coordinator's render delayable so an auto-preview never
+  // cancels an in-flight export.
+  private readonly _renderExport = createRenderExportDelayable();
 
   // The in-flight format-conversion render job, if any. The export-token logic
   // stops a superseded export from committing a stale result, but the branches
@@ -137,7 +142,7 @@ export class ExportService {
           markers: [],
         };
       } else {
-        const job = renderExport({
+        const job = this._renderExport({
           mountArchives: false,
           scadPath: '/export.scad',
           sources: [


### PR DESCRIPTION
Second slice of the instance-scoped session refactor (**ADR 0007**). Behavior-preserving for the single-session app.

## What
The three module-level delayable schedulers in `actions.ts` (`checkSyntax` / `render` / `renderExport`) become **factories** (`createSyntaxDelayable` / `createRenderDelayable` / `createRenderExportDelayable`). `CompileCoordinator` creates its own `_render` + `_checkSyntax`; `ExportService` creates its own `_renderExport`. Both services are already per-`Model`, so each session now has its own `cancelLive` — no cross-session cancellation.

## Invariants preserved
- **Preview ↔ full render still supersede** — one `_render` delayable per coordinator drives both `isPreview` paths (only one geometry compile live at a time).
- **`render` ≠ `renderExport`** — `ExportService._renderExport` is a separate instance, so an auto-preview never cancels an in-flight export (#149); the export-kill `_activeRender` ownership is unchanged.
- Single session = one of each delayable, same delays (syntax 300ms / render 1000ms), same jobs → byte-identical.

## Tests
The 9 `vi.mock('…/actions.ts')` test files now mock the factories instead of the singletons; all assertions (supersession, #149 export-kill, staleness) unchanged. Full gate green (464 unit + 25 assembly).

Part of #123 (ADR 0007). Next: slice 3 (OpenScadSession + provider).