### PR TITLE
refactor(runner): per-session CompileBackend through schedulers — Gate B slice 3a (#123)

### DIFF
--- a/src/runner/__tests__/scheduler-backend-binding.test.ts
+++ b/src/runner/__tests__/scheduler-backend-binding.test.ts
@@ -1,0 +1,54 @@
+// Gate B slice 3a: a scheduler is bound to a specific CompileBackend, so a
+// compile reaches THAT session's engine — not a shared/global one. This is the
+// property that closes the engine-sharing gap left by slice 2.
+
+import { afterAll, beforeAll, describe, expect, it } from 'vitest';
+
+import { WasmWorkerBackend } from '../openscad-runner.ts';
+import { createRenderDelayable } from '../actions.ts';
+import type { RenderArgs } from '../actions.ts';
+
+// A worker that never responds, so submitted jobs stay observable in `pending`.
+class SilentWorker {
+  onmessage: ((e: MessageEvent) => void) | null = null;
+  onerror: ((e: ErrorEvent) => void) | null = null;
+  postMessage(): void {}
+  terminate(): void {}
+}
+
+const RENDER_ARGS: RenderArgs = {
+  scadPath: '/m.scad',
+  sources: [{ path: '/m.scad', content: 'cube();' }],
+  isPreview: true,
+  mountArchives: false,
+  renderFormat: 'off',
+  streamsCallback: () => {},
+};
+
+describe('scheduler ↔ backend binding', () => {
+  beforeAll(() => {
+    (globalThis as unknown as Record<string, unknown>).Worker = SilentWorker;
+  });
+  afterAll(() => {
+    delete (globalThis as unknown as Record<string, unknown>).Worker;
+  });
+
+  it('routes a compile to the backend its scheduler was created with', () => {
+    const a = new WasmWorkerBackend();
+    const b = new WasmWorkerBackend();
+    const renderA = createRenderDelayable(a);
+    const renderB = createRenderDelayable(b);
+
+    const pa = renderA(RENDER_ARGS)({ now: true }).catch(() => {});
+    expect(a.pending.size).toBe(1); // landed in a's engine
+    expect(b.pending.size).toBe(0); // not b's
+
+    const pb = renderB(RENDER_ARGS)({ now: true }).catch(() => {});
+    expect(b.pending.size).toBe(1); // landed in b's engine
+    expect(a.pending.size).toBe(1); // a untouched
+
+    a.dispose();
+    b.dispose();
+    return Promise.allSettled([pa, pb]);
+  });
+});

--- a/src/runner/actions.ts
+++ b/src/runner/actions.ts
@@ -4,7 +4,7 @@ import type { Diagnostic } from '../diagnostics.ts';
 import {
   ProcessStreams,
   isExpectedJobCancellation,
-  spawnOpenSCAD,
+  type CompileBackend,
   type JobPriority,
 } from './openscad-runner.ts';
 import { processMergedOutputs } from './output-parser.ts';
@@ -27,11 +27,11 @@ type SyntaxCheckOutput = {
   parameterSet?: ParameterSet;
   revision?: number;
 };
-const syntaxJob = (sargs: SyntaxCheckArgs) => {
+const syntaxJob = (backend: CompileBackend, sargs: SyntaxCheckArgs) => {
   const { activePath, sources, revision } = sargs;
 
   const outFile = 'out.json';
-  const job = spawnOpenSCAD(
+  const job = backend.spawn(
     {
       mountArchives: true,
       inputs: sources,
@@ -84,9 +84,11 @@ const syntaxJob = (sargs: SyntaxCheckArgs) => {
   });
 };
 
-/** A fresh syntax-check scheduler (own debounce + supersession). One per session
- *  so independent sessions don't cancel each other's checks (ADR 0007). */
-export const createSyntaxDelayable = () => turnIntoDelayableExecution(syntaxDelay, syntaxJob);
+/** A fresh syntax-check scheduler bound to `backend` (own debounce + supersession).
+ *  One per session so independent sessions don't cancel each other's checks and
+ *  each runs on its own engine (ADR 0007). */
+export const createSyntaxDelayable = (backend: CompileBackend) =>
+  turnIntoDelayableExecution(syntaxDelay, (sargs: SyntaxCheckArgs) => syntaxJob(backend, sargs));
 
 const renderDelay = 1000;
 export type RenderOutput = {
@@ -191,7 +193,7 @@ export function buildOpenScadArgs(request: OpenScadArgsRequest): string[] {
   return args;
 }
 
-const renderJob = (renderArgs: RenderArgs) => {
+const renderJob = (engine: CompileBackend, renderArgs: RenderArgs) => {
   const {
     scadPath,
     sources,
@@ -237,7 +239,7 @@ const renderJob = (renderArgs: RenderArgs) => {
     extraArgs,
   });
 
-  const job = spawnOpenSCAD(
+  const job = engine.spawn(
     {
       mountArchives: mountArchives,
       inputs: sources.map((s) => (s.path === scadPath ? { path: s.path, content } : s)),
@@ -312,11 +314,13 @@ const renderJob = (renderArgs: RenderArgs) => {
 
 // Preview and full render share ONE delayable instance per coordinator: they
 // debounce and supersede each other (only one geometry compile should be live at
-// a time). One per session (ADR 0007).
-export const createRenderDelayable = () => turnIntoDelayableExecution(renderDelay, renderJob);
+// a time). One per session, bound to that session's engine (ADR 0007).
+export const createRenderDelayable = (backend: CompileBackend) =>
+  turnIntoDelayableExecution(renderDelay, (args: RenderArgs) => renderJob(backend, args));
 
 // Export gets its OWN delayable instance so it does not share the supersession
 // signal with preview/render — an auto-preview must not cancel an in-flight
 // export, nor an export an in-flight preview. Callers pass `priority: 'export'`
 // for host-side scheduling precedence.
-export const createRenderExportDelayable = () => turnIntoDelayableExecution(renderDelay, renderJob);
+export const createRenderExportDelayable = (backend: CompileBackend) =>
+  turnIntoDelayableExecution(renderDelay, (args: RenderArgs) => renderJob(backend, args));

--- a/src/runner/openscad-runner.ts
+++ b/src/runner/openscad-runner.ts
@@ -107,13 +107,28 @@ let _pageFirstCompileRequested = false;
 let _pageFirstCompileCompleted = false;
 
 /**
+ * The compile engine boundary: submit a compile, cancel one, tear the engine
+ * down. The browser-WASM runner is one implementation; a future native backend
+ * implements the same shape without touching callers (ADR 0007).
+ */
+export interface CompileBackend {
+  spawn(
+    invocation: OpenSCADInvocation,
+    streamsCallback: (ps: ProcessStreams) => void,
+    priority?: JobPriority,
+  ): AbortablePromise<OpenSCADInvocationResults>;
+  cancel(id: string, reason?: string): void;
+  dispose(): void;
+}
+
+/**
  * The browser-WASM compile engine: owns one persistent Worker plus the pending
  * jobs, id space, worker generation, and queue/exec timeout timers that drive
  * it. Instance-scoped so independent sessions get fully isolated engines (ADR
- * 0007). The app runs a single `defaultBackend`; `spawnOpenSCAD` delegates to it,
- * so behavior is identical to the previous module-singleton.
+ * 0007). The app runs one backend per session; `spawnOpenSCAD` + `defaultBackend`
+ * remain for the direct-importing runner tests.
  */
-export class WasmWorkerBackend {
+export class WasmWorkerBackend implements CompileBackend {
   /** @internal Pending jobs by id; exposed for cross-instance isolation tests. */
   readonly pending = new Map<string, PendingJob>();
   /** @internal Monotonic job id counter (per backend). */

--- a/src/state/model.ts
+++ b/src/state/model.ts
@@ -13,6 +13,7 @@ import { ProjectFileSystem } from '../fs/project-filesystem.ts';
 import { contentOf, isProbablyTextPath } from './project-source.ts';
 import { ProjectStore } from './project-store.ts';
 import { HostAdapter, WebHostAdapter } from './web-host-adapter.ts';
+import { WasmWorkerBackend, type CompileBackend } from '../runner/openscad-runner.ts';
 import { applyUserFacingError } from './apply-user-facing-error.ts';
 import { CompileCoordinator } from './services/compile-coordinator.ts';
 import { ExportService } from './services/export-service.ts';
@@ -46,6 +47,9 @@ export class Model extends EventTarget {
     private setStateCallback?: (state: State) => void,
     private statePersister?: StatePersister,
     private host: HostAdapter = new WebHostAdapter(),
+    // This session's compile engine. Default-constructed so a lone `new Model`
+    // (and tests) keep working; OpenScadSession passes its own (ADR 0007).
+    private backend: CompileBackend = new WasmWorkerBackend(),
   ) {
     super();
     this.projectStore = new ProjectStore(fs);
@@ -66,6 +70,7 @@ export class Model extends EventTarget {
       getActiveSource: () => this.source,
       host: this.host,
       fs: this.fs,
+      backend: this.backend,
     };
   }
 

--- a/src/state/services/__tests__/compile-coordinator.test.ts
+++ b/src/state/services/__tests__/compile-coordinator.test.ts
@@ -49,6 +49,7 @@ function makeContext(revision: number) {
     host: host as any,
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     fs: {} as any,
+    backend: { spawn: vi.fn(), cancel: vi.fn(), dispose: vi.fn() },
   };
 
   return { ctx, state, host, setRevision: (n: number) => (rev = n) };
@@ -100,6 +101,7 @@ function makeBinaryContext(readFileSync: () => any) {
     host: host as any,
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     fs: { readFileSync } as any,
+    backend: { spawn: vi.fn(), cancel: vi.fn(), dispose: vi.fn() },
   };
   return { ctx, state };
 }

--- a/src/state/services/__tests__/export-service.test.ts
+++ b/src/state/services/__tests__/export-service.test.ts
@@ -109,6 +109,7 @@ function makeCtx(partial: Partial<State['params']> & { is2D?: boolean; output?: 
     getActiveSource: () => '',
     host,
     fs: { readFileSync: vi.fn(), writeFile: vi.fn() },
+    backend: { spawn: vi.fn(), cancel: vi.fn(), dispose: vi.fn() },
   };
   return { ctx, host, getState: () => state };
 }

--- a/src/state/services/__tests__/layout-controller.test.ts
+++ b/src/state/services/__tests__/layout-controller.test.ts
@@ -35,6 +35,7 @@ function makeCtx(layout: State['view']['layout'], logs = false) {
       baseUrl: () => '',
     },
     fs: { readFileSync: () => new Uint8Array(), writeFile: () => {} },
+    backend: { spawn: () => ({}) as never, cancel: () => {}, dispose: () => {} },
   };
   return { ctx, getState: () => state };
 }

--- a/src/state/services/compile-coordinator.ts
+++ b/src/state/services/compile-coordinator.ts
@@ -26,7 +26,14 @@ import type { ServiceContext } from './service-context.ts';
  * the host adapter; it never touches the DOM directly.
  */
 export class CompileCoordinator {
-  constructor(private ctx: ServiceContext) {}
+  constructor(private ctx: ServiceContext) {
+    // Built in the constructor body, reading the `ctx` PARAMETER (always bound at
+    // call time), rather than a field initializer reading `this.ctx` — whose
+    // ordering vs the `ctx` parameter-property assignment depends on
+    // `useDefineForClassFields`. Reading the parameter is unconditionally correct.
+    this._render = createRenderDelayable(ctx.backend);
+    this._checkSyntax = createSyntaxDelayable(ctx.backend);
+  }
 
   // Sequence counters identifying the latest in-flight operation of each kind.
   // checkSyntax/render debounce and supersede one another (turnIntoDelayableExecution),
@@ -37,11 +44,12 @@ export class CompileCoordinator {
   private _renderSeq = 0;
   private _syntaxSeq = 0;
 
-  // Per-coordinator (= per-session) schedulers so independent sessions never
-  // cross-cancel. One render delayable shared by preview + full render (they
-  // supersede each other); syntax has its own. See ADR 0007.
-  private readonly _render = createRenderDelayable();
-  private readonly _checkSyntax = createSyntaxDelayable();
+  // Per-coordinator (= per-session) schedulers, bound to this session's engine,
+  // so independent sessions never cross-cancel and run on their own worker. One
+  // render delayable shared by preview + full render (they supersede each other);
+  // syntax has its own. See ADR 0007.
+  private readonly _render: ReturnType<typeof createRenderDelayable>;
+  private readonly _checkSyntax: ReturnType<typeof createSyntaxDelayable>;
 
   /**
    * Convert the typed sources to the flat wire shape, reading each project-local

--- a/src/state/services/export-service.ts
+++ b/src/state/services/export-service.ts
@@ -17,17 +17,22 @@ import type { ServiceContext } from './service-context.ts';
  * through the host adapter).
  */
 export class ExportService {
-  constructor(private ctx: ServiceContext) {}
+  constructor(private ctx: ServiceContext) {
+    // Built here reading the `ctx` PARAMETER (always bound), not a field
+    // initializer reading `this.ctx` — unconditionally correct regardless of
+    // `useDefineForClassFields` ordering.
+    this._renderExport = createRenderExportDelayable(ctx.backend);
+  }
 
   // Identifies the latest export. A superseded export (e.g. a second click, or
   // the 3MF path which does not run through the delayable) must not clobber the
   // newer one's result/download when its async work finally settles.
   private _exportSeq = 0;
 
-  // This service's own export render scheduler (per session, ADR 0007), kept
-  // distinct from the coordinator's render delayable so an auto-preview never
-  // cancels an in-flight export.
-  private readonly _renderExport = createRenderExportDelayable();
+  // This service's own export render scheduler (per session, ADR 0007), bound to
+  // this session's engine and kept distinct from the coordinator's render
+  // delayable so an auto-preview never cancels an in-flight export.
+  private readonly _renderExport: ReturnType<typeof createRenderExportDelayable>;
 
   // The in-flight format-conversion render job, if any. The export-token logic
   // stops a superseded export from committing a stale result, but the branches

--- a/src/state/services/service-context.ts
+++ b/src/state/services/service-context.ts
@@ -1,4 +1,5 @@
 import type { ProjectFileSystem } from '../../fs/project-filesystem.ts';
+import type { CompileBackend } from '../../runner/openscad-runner.ts';
 import type { State } from '../app-state.ts';
 import type { HostAdapter } from '../web-host-adapter.ts';
 
@@ -27,4 +28,6 @@ export interface ServiceContext {
   readonly host: HostAdapter;
   /** The project filesystem (narrow read/write surface). */
   readonly fs: ProjectFileSystem;
+  /** This session's compile engine; the schedulers submit jobs to it (ADR 0007). */
+  readonly backend: CompileBackend;
 }


### PR DESCRIPTION
Slice 3a of ADR 0007 — closes the engine-sharing gap and is the load-bearing isolation fix (no UI change, fully unit-testable, byte-identical single-session).

## The gap (from slice 2)
Per-session schedulers existed, but they wrapped jobs that called the module-level `spawnOpenSCAD` → the single `defaultBackend`. So two sessions had independent `cancelLive` but **still shared one worker**. This slice makes the engine per-session.

## What
- Declare a `CompileBackend` interface (`spawn`/`cancel`/`dispose`); `WasmWorkerBackend implements` it.
- `renderJob`/`syntaxJob` take a `CompileBackend` and call `engine.spawn(...)`; the three scheduler factories take a backend and bind it into the job closure.
- `ServiceContext` carries the session's `backend`; `Model` accepts one (default-constructs a fresh `WasmWorkerBackend`) and puts it on the context — so the coordinator and export service share the **same** engine per session.
- Schedulers move to the **constructor body** (not field initializers) so they can read `ctx.backend` after the `ctx` parameter property is assigned.

## Preserved
Single-session behavior unchanged (the app's one Model uses its own `WasmWorkerBackend` — same class as the old `defaultBackend`). `spawnOpenSCAD`/`defaultBackend` stay for the direct-importing runner tests. The page-global first-compile perf marks remain page-global.

## Tests
New `scheduler-backend-binding.test.ts` proves a compile routes to the backend its scheduler was created with (two backends, the job lands in the right `pending` map). Full gate green (465 unit + 25 assembly).

Part of #123 (ADR 0007). Next: 3b/3c (OpenScadSession + provider migration).