### PR TITLE
feat(contract): Layer-1 types + artifact identity on FileOutput — ADR 0008 slice 1 (#123)

### DIFF
--- a/src/runner/__tests__/compile-contract.test.ts
+++ b/src/runner/__tests__/compile-contract.test.ts
@@ -1,0 +1,29 @@
+import { describe, expect, it } from 'vitest';
+
+import { formatOfName, mediaTypeForFormat, newId } from '../compile-contract.ts';
+
+describe('newId', () => {
+  it('mints unique, well-formed v4 UUIDs', () => {
+    const ids = new Set(Array.from({ length: 1000 }, () => newId()));
+    expect(ids.size).toBe(1000); // no collisions
+    const uuid = /^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/;
+    for (const id of ids) expect(id).toMatch(uuid);
+  });
+});
+
+describe('mediaTypeForFormat', () => {
+  it('maps known formats and defaults unknown ones to octet-stream', () => {
+    expect(mediaTypeForFormat('svg')).toBe('image/svg+xml');
+    expect(mediaTypeForFormat('GLB')).toBe('model/gltf-binary'); // case-insensitive
+    expect(mediaTypeForFormat('3mf')).toBe('model/3mf');
+    expect(mediaTypeForFormat('wat')).toBe('application/octet-stream');
+  });
+});
+
+describe('formatOfName', () => {
+  it('extracts the lower-cased extension', () => {
+    expect(formatOfName('part.STL')).toBe('stl');
+    expect(formatOfName('model.scad')).toBe('scad');
+    expect(formatOfName('noext')).toBe('');
+  });
+});

--- a/src/runner/compile-contract.ts
+++ b/src/runner/compile-contract.ts
@@ -1,0 +1,111 @@
+// Layer-1 compile contract (ADR 0008): a host-side, DOM-free description of a
+// compile operation and its result, sitting ABOVE the CompileBackend boundary.
+// The worker protocol is unchanged; these types are derived host-side and are the
+// unit the host / embed / (future) MCP correlate on.
+
+import type { Diagnostic } from '../diagnostics.ts';
+
+export type OperationKind = 'syntaxCheck' | 'preview' | 'render' | 'export';
+
+export interface OperationCommand {
+  /** Shared envelope version (ADR 0005). */
+  protocolVersion: number;
+  sessionId: string;
+  /** v4 UUID minted per scheduler invocation (render / checkSyntax / export). */
+  operationId: string;
+  /** The source/project revision the operation was submitted at (#56/#99). */
+  sourceRevision: number;
+  kind: OperationKind;
+  // Kind-specific payload (entry path, vars, features, format) is turned into the
+  // actual OpenSCAD args by the existing buildOpenScadArgs — unchanged.
+}
+
+export interface CancelCommand {
+  protocolVersion: number;
+  sessionId: string;
+  /** The operation to cancel. */
+  operationId: string;
+}
+
+interface OperationResultBase {
+  protocolVersion: number;
+  sessionId: string;
+  operationId: string;
+  /** Echoed from the command; the #56/#99 stale-drop is unchanged. */
+  sourceRevision: number;
+  kind: OperationKind;
+  elapsedMillis: number;
+  /** Host-neutral markers (ADR 0001). */
+  diagnostics: Diagnostic[];
+  logText: string;
+}
+
+export interface OperationSuccess extends OperationResultBase {
+  status: 'success';
+  artifact?: ArtifactRef;
+}
+export interface OperationFailure extends OperationResultBase {
+  status: 'error';
+  code: string;
+  reason: string;
+}
+export interface OperationCancelled extends OperationResultBase {
+  status: 'cancelled';
+}
+
+/** Exactly one terminal result per `operationId`. */
+export type OperationResult = OperationSuccess | OperationFailure | OperationCancelled;
+
+/**
+ * An immutable handle to a produced artifact's exact bytes. `artifactId` keys a
+ * per-session store so `getArtifact(artifactId)` returns those exact bytes — not a
+ * racy "current output".
+ */
+export interface ArtifactRef {
+  artifactId: string; // v4 UUID; immutable
+  operationId: string;
+  sourceRevision: number;
+  format: string; // 'off' | 'svg' | 'stl' | '3mf' | 'glb' | …
+  mediaType: string;
+  size: number;
+  name: string;
+}
+
+/**
+ * A globally-unique id (v4 UUID). Uses `crypto.randomUUID` when available, falling
+ * back to `getRandomValues` — `randomUUID` requires a secure context and Safari
+ * ≥ 15.4, which a LAN-IP dev preview or an older browser may not satisfy.
+ */
+export function newId(): string {
+  const c = globalThis.crypto;
+  if (c && typeof c.randomUUID === 'function') return c.randomUUID();
+  // RFC 4122 v4 from 16 random bytes.
+  const b = new Uint8Array(16);
+  c.getRandomValues(b);
+  b[6] = (b[6] & 0x0f) | 0x40;
+  b[8] = (b[8] & 0x3f) | 0x80;
+  const h = [...b].map((x) => x.toString(16).padStart(2, '0'));
+  return `${h.slice(0, 4).join('')}-${h.slice(4, 6).join('')}-${h.slice(6, 8).join('')}-${h.slice(8, 10).join('')}-${h.slice(10, 16).join('')}`;
+}
+
+const MEDIA_TYPES: Record<string, string> = {
+  off: 'text/plain',
+  svg: 'image/svg+xml',
+  dxf: 'image/vnd.dxf',
+  stl: 'model/stl',
+  '3mf': 'model/3mf',
+  glb: 'model/gltf-binary',
+  amf: 'application/octet-stream',
+};
+
+/** The media type for an output format; opaque bytes when unknown. The exported
+ *  Files for 3MF/GLB carry no `File.type`, so this is the source of truth. */
+export function mediaTypeForFormat(format: string): string {
+  return MEDIA_TYPES[format.toLowerCase()] ?? 'application/octet-stream';
+}
+
+/** The output format (lower-cased extension) of an artifact file name. */
+export function formatOfName(name: string): string {
+  const dot = name.lastIndexOf('.');
+  return dot >= 0 ? name.slice(dot + 1).toLowerCase() : '';
+}

--- a/src/state/__tests__/web-host-adapter.test.ts
+++ b/src/state/__tests__/web-host-adapter.test.ts
@@ -124,6 +124,9 @@ describe('Model routes side effects through the host (#59)', () => {
       elapsedMillis: 1,
       formattedElapsedMillis: '1ms',
       formattedOutFileSize: '3 bytes',
+      artifactId: 'art',
+      operationId: 'op',
+      sourceRevision: 0,
     } as State['output'];
     const model = new Model(makeFs(), state, undefined, undefined, host);
 

--- a/src/state/app-state.ts
+++ b/src/state/app-state.ts
@@ -27,6 +27,12 @@ export interface FileOutput {
   elapsedMillis: number;
   formattedElapsedMillis: string;
   formattedOutFileSize: string;
+  // Immutable artifact identity (ADR 0008). `outFile`/`outFileURL` still own the
+  // bytes + viewer URL; these add stable correlation so getArtifact(artifactId)
+  // can return the exact bytes. Transient — never persisted.
+  artifactId: string;
+  operationId: string;
+  sourceRevision: number;
 }
 
 export interface State {

--- a/src/state/model.ts
+++ b/src/state/model.ts
@@ -14,6 +14,7 @@ import { contentOf, isProbablyTextPath } from './project-source.ts';
 import { ProjectStore } from './project-store.ts';
 import { HostAdapter, WebHostAdapter } from './web-host-adapter.ts';
 import { WasmWorkerBackend, type CompileBackend } from '../runner/openscad-runner.ts';
+import { newId } from '../runner/compile-contract.ts';
 import { applyUserFacingError } from './apply-user-facing-error.ts';
 import { CompileCoordinator } from './services/compile-coordinator.ts';
 import { ExportService } from './services/export-service.ts';
@@ -50,6 +51,8 @@ export class Model extends EventTarget {
     // This session's compile engine. Default-constructed so a lone `new Model`
     // (and tests) keep working; OpenScadSession passes its own (ADR 0007).
     private backend: CompileBackend = new WasmWorkerBackend(),
+    // This session's id, for operation/artifact correlation (ADR 0008).
+    private sessionId: string = newId(),
   ) {
     super();
     this.projectStore = new ProjectStore(fs);
@@ -71,6 +74,7 @@ export class Model extends EventTarget {
       host: this.host,
       fs: this.fs,
       backend: this.backend,
+      sessionId: this.sessionId,
     };
   }
 

--- a/src/state/services/__tests__/compile-coordinator.test.ts
+++ b/src/state/services/__tests__/compile-coordinator.test.ts
@@ -50,6 +50,7 @@ function makeContext(revision: number) {
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     fs: {} as any,
     backend: { spawn: vi.fn(), cancel: vi.fn(), dispose: vi.fn() },
+    sessionId: 'test-session',
   };
 
   return { ctx, state, host, setRevision: (n: number) => (rev = n) };
@@ -102,6 +103,7 @@ function makeBinaryContext(readFileSync: () => any) {
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     fs: { readFileSync } as any,
     backend: { spawn: vi.fn(), cancel: vi.fn(), dispose: vi.fn() },
+    sessionId: 'test-session',
   };
   return { ctx, state };
 }
@@ -172,6 +174,10 @@ describe('CompileCoordinator render staleness', () => {
     expect(host.revokeObjectURL).not.toHaveBeenCalled();
     expect(host.playCompletionChime).toHaveBeenCalledTimes(1);
     expect(state.rendering).toBe(false);
+    // The committed output carries immutable artifact identity (ADR 0008).
+    expect(state.output?.artifactId).toMatch(/[0-9a-f-]{36}/);
+    expect(state.output?.operationId).toMatch(/[0-9a-f-]{36}/);
+    expect(state.output?.sourceRevision).toBe(1);
   });
 
   it('drops a result whose revision is stale and never creates a blob URL', async () => {
@@ -201,6 +207,9 @@ describe('CompileCoordinator render staleness', () => {
       elapsedMillis: 0,
       formattedElapsedMillis: '0ms',
       formattedOutFileSize: '1 B',
+      artifactId: 'art',
+      operationId: 'op',
+      sourceRevision: 0,
     };
     renderImpl.mockResolvedValue(renderOutput(1));
 

--- a/src/state/services/__tests__/export-service.test.ts
+++ b/src/state/services/__tests__/export-service.test.ts
@@ -66,6 +66,9 @@ function fileOutput(name: string, url = 'blob:out'): State['output'] {
     elapsedMillis: 0,
     formattedElapsedMillis: '0ms',
     formattedOutFileSize: '1 B',
+    artifactId: 'art',
+    operationId: 'op',
+    sourceRevision: 0,
   };
 }
 
@@ -110,6 +113,7 @@ function makeCtx(partial: Partial<State['params']> & { is2D?: boolean; output?: 
     host,
     fs: { readFileSync: vi.fn(), writeFile: vi.fn() },
     backend: { spawn: vi.fn(), cancel: vi.fn(), dispose: vi.fn() },
+    sessionId: 'test-session',
   };
   return { ctx, host, getState: () => state };
 }

--- a/src/state/services/__tests__/layout-controller.test.ts
+++ b/src/state/services/__tests__/layout-controller.test.ts
@@ -36,6 +36,7 @@ function makeCtx(layout: State['view']['layout'], logs = false) {
     },
     fs: { readFileSync: () => new Uint8Array(), writeFile: () => {} },
     backend: { spawn: () => ({}) as never, cancel: () => {}, dispose: () => {} },
+    sessionId: 'test-session',
   };
   return { ctx, getState: () => state };
 }

--- a/src/state/services/compile-coordinator.ts
+++ b/src/state/services/compile-coordinator.ts
@@ -3,6 +3,7 @@ import {
   createSyntaxDelayable,
   type RenderArgs,
 } from '../../runner/actions.ts';
+import { newId } from '../../runner/compile-contract.ts';
 import { isExpectedJobCancellation, type ProcessStreams } from '../../runner/openscad-runner.ts';
 import { isUserFacingOperationError, UserFacingOperationError } from '../../user-facing-errors.ts';
 import { fetchSource, formatBytes, formatMillis } from '../../utils.ts';
@@ -233,6 +234,9 @@ export class CompileCoordinator {
     // superseded call cannot turn off the spinner a newer call is still driving.
     const token = isPreview ? ++this._previewSeq : ++this._renderSeq;
     const isCurrent = () => (isPreview ? this._previewSeq : this._renderSeq) === token;
+    // One operation id per scheduler invocation (ADR 0008). The dimension retry
+    // is a distinct recursive render(), so it mints its own — never shared.
+    const operationId = newId();
     const setRendering = (s: State, value: boolean) => {
       if (isPreview) {
         s.previewing = value;
@@ -321,6 +325,9 @@ export class CompileCoordinator {
           elapsedMillis: output.elapsedMillis,
           formattedElapsedMillis: formatMillis(output.elapsedMillis),
           formattedOutFileSize: formatBytes(output.outFile.size),
+          artifactId: newId(),
+          operationId,
+          sourceRevision: output.revision ?? this.ctx.getSourceRevision(),
         };
 
         if (!isPreview) {

--- a/src/state/services/export-service.ts
+++ b/src/state/services/export-service.ts
@@ -3,6 +3,7 @@ import chroma from 'chroma-js';
 import { export3MF } from '../../io/export_3mf.ts';
 import { parseOff } from '../../io/import_off.ts';
 import { createRenderExportDelayable, type RenderOutput } from '../../runner/actions.ts';
+import { newId } from '../../runner/compile-contract.ts';
 import { isExpectedJobCancellation, type ProcessStreams } from '../../runner/openscad-runner.ts';
 import { isUserFacingOperationError } from '../../user-facing-errors.ts';
 import { formatBytes, formatMillis, type AbortablePromise } from '../../utils.ts';
@@ -65,6 +66,7 @@ export class ExportService {
     // result nor leave the spinner stuck.
     const token = ++this._exportSeq;
     const isCurrent = () => this._exportSeq === token;
+    const operationId = newId(); // one per export() invocation (ADR 0008)
     // Cancel any in-flight conversion render so a superseding export — including
     // a pass-through or picker branch that never calls renderExport — drops a
     // still-queued render and promptly settles the previous export's await with a
@@ -193,6 +195,9 @@ export class ExportService {
           elapsedMillis: output.elapsedMillis,
           formattedElapsedMillis: formatMillis(output.elapsedMillis),
           formattedOutFileSize: formatBytes(output.outFile.size),
+          artifactId: newId(),
+          operationId,
+          sourceRevision: this.ctx.getSourceRevision(),
         };
         host.download(s.export.outFileURL, output.outFile.name);
       });

--- a/src/state/services/service-context.ts
+++ b/src/state/services/service-context.ts
@@ -30,4 +30,6 @@ export interface ServiceContext {
   readonly fs: ProjectFileSystem;
   /** This session's compile engine; the schedulers submit jobs to it (ADR 0007). */
   readonly backend: CompileBackend;
+  /** This session's id, for operation/artifact correlation (ADR 0008). */
+  readonly sessionId: string;
 }

--- a/src/state/session.ts
+++ b/src/state/session.ts
@@ -1,5 +1,6 @@
 import { Model } from './model.ts';
 import { WasmWorkerBackend, type CompileBackend } from '../runner/openscad-runner.ts';
+import { newId } from '../runner/compile-contract.ts';
 import type { ProjectFileSystem } from '../fs/project-filesystem.ts';
 import type { State, StatePersister } from './app-state.ts';
 import type { HostAdapter } from './web-host-adapter.ts';
@@ -12,6 +13,8 @@ import type { HostAdapter } from './web-host-adapter.ts';
  * multi-document hosts construct N.
  */
 export class OpenScadSession {
+  /** Stable session id, for routing/debug correlation of operations/artifacts. */
+  readonly id = newId();
   readonly backend: CompileBackend;
   readonly model: Model;
 
@@ -23,7 +26,15 @@ export class OpenScadSession {
     host?: HostAdapter,
   ) {
     this.backend = new WasmWorkerBackend();
-    this.model = new Model(fs, state, setStateCallback, statePersister, host, this.backend);
+    this.model = new Model(
+      fs,
+      state,
+      setStateCallback,
+      statePersister,
+      host,
+      this.backend,
+      this.id,
+    );
   }
 
   /** Kick off the initial compile (delegates to the model). */


### PR DESCRIPTION
First slice of the Layer-1 compile contract (ADR 0008). **Types + identity plumbing only — nothing consumes them yet, so runtime is byte-identical.**

- New DOM-free `src/runner/compile-contract.ts`: `Operation*` command/result types, `ArtifactRef`, a `newId()` v4-UUID helper (`crypto.randomUUID` with a `getRandomValues` fallback for non-secure-context / old Safari), and a format→mediaType map. `Operation*` naming avoids the worker `CompileResult` collision.
- `OpenScadSession` gains a stable `id`; `Model` accepts a `sessionId`; `ServiceContext` exposes it.
- `FileOutput` gains `artifactId`/`operationId`/`sourceRevision` (**transient — never persisted**). `operationId` minted per scheduler invocation (the dimension retry is a distinct render → its own id); `artifactId` per fresh commit; the export pass-through inherits the output's id (same bytes ⇒ same id). The #145 object-URL logic is **unchanged** — these are pure additive correlation fields.

Tests: `newId` uniqueness/format, mediaType/format helpers, and the render commit carrying identity. Full gate green (470 unit + 25 assembly).

Part of #123 / ADR 0008. Next: slice 2 (per-session artifact store + getArtifact(id)).