### PR TITLE
feat(state): per-session artifact store with immutable id (ADR 0008)

### DIFF
--- a/src/state/__tests__/artifact-store.test.ts
+++ b/src/state/__tests__/artifact-store.test.ts
@@ -1,0 +1,73 @@
+import { describe, expect, it } from 'vitest';
+
+import type { ArtifactRef } from '../../runner/compile-contract.ts';
+import { ArtifactStore } from '../artifact-store.ts';
+
+function ref(artifactId: string, name = 'm.off'): ArtifactRef {
+  return {
+    artifactId,
+    operationId: 'op',
+    sourceRevision: 0,
+    format: 'off',
+    mediaType: 'text/plain',
+    size: 1,
+    name,
+  };
+}
+
+function file(bytes: string, name = 'm.off'): File {
+  return new File([bytes], name);
+}
+
+describe('ArtifactStore', () => {
+  it('returns the exact bytes stored under an artifactId', async () => {
+    const store = new ArtifactStore();
+    store.put(file('hello'), ref('a'));
+    const found = store.get('a');
+    expect(found?.ref.artifactId).toBe('a');
+    expect(await found?.bytes.text()).toBe('hello');
+  });
+
+  it('returns undefined for an unknown id', () => {
+    const store = new ArtifactStore();
+    expect(store.get('nope')).toBeUndefined();
+  });
+
+  it('keeps distinct ids isolated, returning each operation’s own bytes', async () => {
+    const store = new ArtifactStore();
+    store.put(file('first'), ref('a'));
+    store.put(file('second'), ref('b'));
+    expect(await store.get('a')?.bytes.text()).toBe('first');
+    expect(await store.get('b')?.bytes.text()).toBe('second');
+  });
+
+  it('re-putting the same id replaces the bytes', async () => {
+    const store = new ArtifactStore();
+    store.put(file('old'), ref('a'));
+    store.put(file('new'), ref('a'));
+    expect(store.size).toBe(1);
+    expect(await store.get('a')?.bytes.text()).toBe('new');
+  });
+
+  it('evicts the least-recently-used once over capacity', () => {
+    const store = new ArtifactStore(2);
+    store.put(file('1'), ref('a'));
+    store.put(file('2'), ref('b'));
+    store.put(file('3'), ref('c')); // evicts 'a'
+    expect(store.size).toBe(2);
+    expect(store.get('a')).toBeUndefined();
+    expect(store.get('b')).toBeDefined();
+    expect(store.get('c')).toBeDefined();
+  });
+
+  it('a get bumps recency, sparing that entry from the next eviction', () => {
+    const store = new ArtifactStore(2);
+    store.put(file('1'), ref('a'));
+    store.put(file('2'), ref('b'));
+    store.get('a'); // 'a' is now most-recent; 'b' is the LRU
+    store.put(file('3'), ref('c')); // evicts 'b', not 'a'
+    expect(store.get('a')).toBeDefined();
+    expect(store.get('b')).toBeUndefined();
+    expect(store.get('c')).toBeDefined();
+  });
+});

--- a/src/state/artifact-store.ts
+++ b/src/state/artifact-store.ts
@@ -1,0 +1,52 @@
+import type { ArtifactRef } from '../runner/compile-contract.ts';
+
+// A per-session, bounded store of produced artifacts keyed by immutable
+// `artifactId` (ADR 0008). It holds ONLY the canonical bytes — it does NOT own
+// or revoke the viewer's object URL (`FileOutput.outFileURL` keeps that; moving
+// it here risked revoking a URL the SVG viewer/download still references). It
+// exists so `getArtifact(artifactId)` returns the EXACT bytes a given operation
+// produced, instead of a racy "current output".
+
+const DEFAULT_CAPACITY = 8;
+
+export interface StoredArtifact {
+  ref: ArtifactRef;
+  bytes: File;
+}
+
+/** A small LRU of `artifactId → File`. The current output's bytes are already
+ *  held by `state.output.outFile`, so the marginal retention is a handful of
+ *  recent artifacts. */
+export class ArtifactStore {
+  private readonly entries = new Map<string, StoredArtifact>();
+
+  constructor(private readonly capacity: number = DEFAULT_CAPACITY) {}
+
+  /** Record an artifact's bytes under its id, evicting the least-recently-used
+   *  once over capacity. */
+  put(bytes: File, ref: ArtifactRef): void {
+    this.entries.delete(ref.artifactId); // re-insert so it counts as most-recent
+    this.entries.set(ref.artifactId, { ref, bytes });
+    while (this.entries.size > this.capacity) {
+      const oldest = this.entries.keys().next().value;
+      if (oldest === undefined) break;
+      this.entries.delete(oldest);
+    }
+  }
+
+  /** The exact bytes for `artifactId`, or undefined if unknown/evicted. */
+  get(artifactId: string): StoredArtifact | undefined {
+    const found = this.entries.get(artifactId);
+    if (found) {
+      // Bump recency on access.
+      this.entries.delete(artifactId);
+      this.entries.set(artifactId, found);
+    }
+    return found;
+  }
+
+  /** Number of retained artifacts (diagnostics/tests). */
+  get size(): number {
+    return this.entries.size;
+  }
+}

--- a/src/state/model.ts
+++ b/src/state/model.ts
@@ -15,6 +15,7 @@ import { ProjectStore } from './project-store.ts';
 import { HostAdapter, WebHostAdapter } from './web-host-adapter.ts';
 import { WasmWorkerBackend, type CompileBackend } from '../runner/openscad-runner.ts';
 import { newId } from '../runner/compile-contract.ts';
+import { ArtifactStore } from './artifact-store.ts';
 import { applyUserFacingError } from './apply-user-facing-error.ts';
 import { CompileCoordinator } from './services/compile-coordinator.ts';
 import { ExportService } from './services/export-service.ts';
@@ -53,6 +54,8 @@ export class Model extends EventTarget {
     private backend: CompileBackend = new WasmWorkerBackend(),
     // This session's id, for operation/artifact correlation (ADR 0008).
     private sessionId: string = newId(),
+    // This session's artifact store (bytes by artifactId, ADR 0008).
+    private artifacts: ArtifactStore = new ArtifactStore(),
   ) {
     super();
     this.projectStore = new ProjectStore(fs);
@@ -75,6 +78,7 @@ export class Model extends EventTarget {
       fs: this.fs,
       backend: this.backend,
       sessionId: this.sessionId,
+      artifacts: this.artifacts,
     };
   }
 
@@ -113,6 +117,13 @@ export class Model extends EventTarget {
     ) {
       this.compile.processSource({ immediatePreview: true });
     }
+  }
+
+  /** The exact bytes a prior operation produced, by immutable artifactId, or
+   *  undefined if unknown/evicted (ADR 0008). Lets a consumer (embed/MCP) fetch a
+   *  specific result rather than the racy "current output". */
+  getArtifact(artifactId: string): File | undefined {
+    return this.artifacts.get(artifactId)?.bytes;
   }
 
   private setState(state: State) {

--- a/src/state/services/__tests__/compile-coordinator.test.ts
+++ b/src/state/services/__tests__/compile-coordinator.test.ts
@@ -2,6 +2,7 @@ import { beforeEach, describe, expect, it, vi } from 'vitest';
 
 import { CompileCoordinator } from '../compile-coordinator.ts';
 import type { ServiceContext } from '../service-context.ts';
+import { ArtifactStore } from '../../artifact-store.ts';
 import type { State } from '../../app-state.ts';
 
 // render() is `factory(renderArgs)({ now })` → Promise<RenderOutput>; we drive the
@@ -51,6 +52,7 @@ function makeContext(revision: number) {
     fs: {} as any,
     backend: { spawn: vi.fn(), cancel: vi.fn(), dispose: vi.fn() },
     sessionId: 'test-session',
+    artifacts: new ArtifactStore(),
   };
 
   return { ctx, state, host, setRevision: (n: number) => (rev = n) };
@@ -104,6 +106,7 @@ function makeBinaryContext(readFileSync: () => any) {
     fs: { readFileSync } as any,
     backend: { spawn: vi.fn(), cancel: vi.fn(), dispose: vi.fn() },
     sessionId: 'test-session',
+    artifacts: new ArtifactStore(),
   };
   return { ctx, state };
 }
@@ -178,6 +181,9 @@ describe('CompileCoordinator render staleness', () => {
     expect(state.output?.artifactId).toMatch(/[0-9a-f-]{36}/);
     expect(state.output?.operationId).toMatch(/[0-9a-f-]{36}/);
     expect(state.output?.sourceRevision).toBe(1);
+    // The same artifactId resolves in the store to the exact committed File —
+    // the slice's central guarantee (shared id, byte-identical write-through).
+    expect(ctx.artifacts.get(state.output!.artifactId)?.bytes).toBe(state.output!.outFile);
   });
 
   it('drops a result whose revision is stale and never creates a blob URL', async () => {

--- a/src/state/services/__tests__/export-service.test.ts
+++ b/src/state/services/__tests__/export-service.test.ts
@@ -29,6 +29,7 @@ import { bubbleUpDeepMutations } from '../../deep-mutate.ts';
 import type { HostAdapter } from '../../web-host-adapter.ts';
 import { ExportService } from '../export-service.ts';
 import type { ServiceContext } from '../service-context.ts';
+import { ArtifactStore } from '../../artifact-store.ts';
 
 /**
  * A renderExport mock whose inner thunk returns an AbortablePromise-shaped value
@@ -114,6 +115,7 @@ function makeCtx(partial: Partial<State['params']> & { is2D?: boolean; output?: 
     fs: { readFileSync: vi.fn(), writeFile: vi.fn() },
     backend: { spawn: vi.fn(), cancel: vi.fn(), dispose: vi.fn() },
     sessionId: 'test-session',
+    artifacts: new ArtifactStore(),
   };
   return { ctx, host, getState: () => state };
 }
@@ -170,7 +172,7 @@ describe('ExportService', () => {
   });
 
   it('renders a format conversion for non-passthrough formats (e.g. stl)', async () => {
-    const { ctx, host } = makeCtx({
+    const { ctx, host, getState } = makeCtx({
       is2D: false,
       exportFormat3D: 'stl',
       output: fileOutput('m.off'),
@@ -180,6 +182,10 @@ describe('ExportService', () => {
     // Export runs on its own scheduling priority (preempts background compiles).
     expect(mockRenderExport.mock.calls[0][0].priority).toBe('export');
     expect(host.download).toHaveBeenCalledWith('blob:new', 'model.stl');
+    // The committed export's artifactId resolves in the store to the exact File
+    // (shared id, byte-identical write-through — ADR 0008).
+    const exported = getState().export!;
+    expect(ctx.artifacts.get(exported.artifactId)?.bytes).toBe(exported.outFile);
   });
 
   it('drops a superseded export result instead of clobbering the newer one', async () => {

--- a/src/state/services/__tests__/layout-controller.test.ts
+++ b/src/state/services/__tests__/layout-controller.test.ts
@@ -4,6 +4,7 @@ import type { State } from '../../app-state.ts';
 import { bubbleUpDeepMutations } from '../../deep-mutate.ts';
 import { LayoutController } from '../layout-controller.ts';
 import type { ServiceContext } from '../service-context.ts';
+import { ArtifactStore } from '../../artifact-store.ts';
 
 function makeCtx(layout: State['view']['layout'], logs = false) {
   let state: State = {
@@ -37,6 +38,7 @@ function makeCtx(layout: State['view']['layout'], logs = false) {
     fs: { readFileSync: () => new Uint8Array(), writeFile: () => {} },
     backend: { spawn: () => ({}) as never, cancel: () => {}, dispose: () => {} },
     sessionId: 'test-session',
+    artifacts: new ArtifactStore(),
   };
   return { ctx, getState: () => state };
 }

--- a/src/state/services/compile-coordinator.ts
+++ b/src/state/services/compile-coordinator.ts
@@ -3,7 +3,7 @@ import {
   createSyntaxDelayable,
   type RenderArgs,
 } from '../../runner/actions.ts';
-import { newId } from '../../runner/compile-contract.ts';
+import { formatOfName, mediaTypeForFormat, newId } from '../../runner/compile-contract.ts';
 import { isExpectedJobCancellation, type ProcessStreams } from '../../runner/openscad-runner.ts';
 import { isUserFacingOperationError, UserFacingOperationError } from '../../user-facing-errors.ts';
 import { fetchSource, formatBytes, formatMillis } from '../../utils.ts';
@@ -305,6 +305,20 @@ export class CompileCoordinator {
       // synchronous (the viewer reads the OFF File directly and uses outFileURL
       // for SVG), so no newer render can land in between — no recheck needed.
       const outFileURL = this.ctx.host.createObjectURL(output.outFile);
+      // One immutable artifact id, shared by state.output and the store entry, so
+      // getArtifact(artifactId) returns these exact bytes (ADR 0008).
+      const artifactId = newId();
+      const sourceRevision = output.revision ?? this.ctx.getSourceRevision();
+      const format = formatOfName(output.outFile.name);
+      this.ctx.artifacts.put(output.outFile, {
+        artifactId,
+        operationId,
+        sourceRevision,
+        format,
+        mediaType: mediaTypeForFormat(format),
+        size: output.outFile.size,
+        name: output.outFile.name,
+      });
       this.ctx.mutate((s) => {
         setRendering(s, false);
         s.error = undefined;
@@ -325,9 +339,9 @@ export class CompileCoordinator {
           elapsedMillis: output.elapsedMillis,
           formattedElapsedMillis: formatMillis(output.elapsedMillis),
           formattedOutFileSize: formatBytes(output.outFile.size),
-          artifactId: newId(),
+          artifactId,
           operationId,
-          sourceRevision: output.revision ?? this.ctx.getSourceRevision(),
+          sourceRevision,
         };
 
         if (!isPreview) {

--- a/src/state/services/export-service.ts
+++ b/src/state/services/export-service.ts
@@ -3,7 +3,7 @@ import chroma from 'chroma-js';
 import { export3MF } from '../../io/export_3mf.ts';
 import { parseOff } from '../../io/import_off.ts';
 import { createRenderExportDelayable, type RenderOutput } from '../../runner/actions.ts';
-import { newId } from '../../runner/compile-contract.ts';
+import { formatOfName, mediaTypeForFormat, newId } from '../../runner/compile-contract.ts';
 import { isExpectedJobCancellation, type ProcessStreams } from '../../runner/openscad-runner.ts';
 import { isUserFacingOperationError } from '../../user-facing-errors.ts';
 import { formatBytes, formatMillis, type AbortablePromise } from '../../utils.ts';
@@ -184,6 +184,20 @@ export class ExportService {
       if (!isCurrent()) return;
 
       const outFileURL = host.createObjectURL(output.outFile);
+      // One immutable artifact id, shared by state.export and the store entry, so
+      // getArtifact(artifactId) returns these exact exported bytes (ADR 0008).
+      const artifactId = newId();
+      const sourceRevision = this.ctx.getSourceRevision();
+      const format = formatOfName(output.outFile.name);
+      this.ctx.artifacts.put(output.outFile, {
+        artifactId,
+        operationId,
+        sourceRevision,
+        format,
+        mediaType: mediaTypeForFormat(format),
+        size: output.outFile.size,
+        name: output.outFile.name,
+      });
       mutate((s) => {
         s.exporting = false;
         if (s.export?.outFileURL?.startsWith('blob:') ?? false) {
@@ -195,9 +209,9 @@ export class ExportService {
           elapsedMillis: output.elapsedMillis,
           formattedElapsedMillis: formatMillis(output.elapsedMillis),
           formattedOutFileSize: formatBytes(output.outFile.size),
-          artifactId: newId(),
+          artifactId,
           operationId,
-          sourceRevision: this.ctx.getSourceRevision(),
+          sourceRevision,
         };
         host.download(s.export.outFileURL, output.outFile.name);
       });

--- a/src/state/services/service-context.ts
+++ b/src/state/services/service-context.ts
@@ -1,5 +1,6 @@
 import type { ProjectFileSystem } from '../../fs/project-filesystem.ts';
 import type { CompileBackend } from '../../runner/openscad-runner.ts';
+import type { ArtifactStore } from '../artifact-store.ts';
 import type { State } from '../app-state.ts';
 import type { HostAdapter } from '../web-host-adapter.ts';
 
@@ -32,4 +33,6 @@ export interface ServiceContext {
   readonly backend: CompileBackend;
   /** This session's id, for operation/artifact correlation (ADR 0008). */
   readonly sessionId: string;
+  /** This session's artifact store — bytes by immutable artifactId (ADR 0008). */
+  readonly artifacts: ArtifactStore;
 }

--- a/src/state/session.ts
+++ b/src/state/session.ts
@@ -1,6 +1,7 @@
 import { Model } from './model.ts';
 import { WasmWorkerBackend, type CompileBackend } from '../runner/openscad-runner.ts';
 import { newId } from '../runner/compile-contract.ts';
+import { ArtifactStore } from './artifact-store.ts';
 import type { ProjectFileSystem } from '../fs/project-filesystem.ts';
 import type { State, StatePersister } from './app-state.ts';
 import type { HostAdapter } from './web-host-adapter.ts';
@@ -16,6 +17,7 @@ export class OpenScadSession {
   /** Stable session id, for routing/debug correlation of operations/artifacts. */
   readonly id = newId();
   readonly backend: CompileBackend;
+  readonly artifacts = new ArtifactStore();
   readonly model: Model;
 
   constructor(
@@ -34,6 +36,7 @@ export class OpenScadSession {
       host,
       this.backend,
       this.id,
+      this.artifacts,
     );
   }
 


### PR DESCRIPTION
## Layer-1 slice 2 of 4 — per-session artifact store + identity

Adds a per-session, bounded **ArtifactStore** keyed by the immutable `artifactId` introduced in slice 1, and writes through to it at the render and export commits. This lets a consumer (embed / future MCP) fetch the **exact bytes** a given operation produced, fixing the race where "current output" can change underfoot.

### What changed
- **`ArtifactStore`** (`src/state/artifact-store.ts`): bounded LRU `Map<artifactId, {ref, bytes:File}>`, capacity 8, recency-bump on `get`. Holds **bytes only** — it never owns or revokes object URLs; `FileOutput.outFileURL` keeps that responsibility (#145).
- **Wiring**: `OpenScadSession` owns the store → passes to `Model` (defaulted ctor param) → exposed on `ServiceContext.artifacts`. `Model.getArtifact(id): File | undefined` reads it back.
- **Write-through**: `render()` and `export()` hoist one `artifactId` shared by both the committed `FileOutput` and the `store.put(...)` entry, placed **after** the supersession + revision-staleness guards so a stale operation never populates the store.

### Tests
- `artifact-store.test.ts`: byte-identity (reads `.text()`), eviction at capacity, recency-bump sparing, re-put replace, unknown-id → undefined.
- Integration assertions in `compile-coordinator.test.ts` / `export-service.test.ts` tying `state.output`/`state.export` `artifactId` to the committed `File` in the store (the slice's central guarantee).

### Verification
- `tsc --noEmit` clean
- `CI=true npm run test:unit` — 476 passed, coverage thresholds met
- `npm run verify` green (incl. publish-archive)

Adversarially reviewed (independent subagent): no blockers; the integration assertions were added in response to the one SHOULD-FIX.

Refs ADR 0008 (`docs/architecture/adr/0008-layer1-compile-contract.md`).