### PR TITLE
feat(embed): getArtifact by id + identity on render events (ADR 0008)

### DIFF
--- a/docs/EMBED.md
+++ b/docs/EMBED.md
@@ -13,6 +13,8 @@ The messaging protocol is versioned. The current version is **2** (`EMBED_PROTOC
 
 > **Breaking change (v1 → v2):** v1 accepted unversioned messages and, when `parentOrigin` was omitted, accepted control messages from any parent origin and broadcast outbound messages to `'*'`. v2 requires the version field, defaults to same-origin trust, never uses the wildcard, and replaces the `renderComplete` blob URL with durable metadata plus an explicit `getArtifact` request. Update integrations accordingly.
 
+> **Additive (still v2):** outputs now carry an immutable `artifactId`, surfaced on `renderComplete` and the `artifact` response, and accepted as an optional field on `getArtifact`. The `ready` message advertises a `capabilities` object (`artifactIdentity: true`). These are backward-compatible: unknown inbound fields are ignored and existing message shapes are supersets of v2, so no version bump is required.
+
 ## URL Parameters
 
 Embed mode is enabled with:
@@ -36,12 +38,12 @@ Supported embed-specific query parameters:
 
 Every inbound message must include `protocolVersion: 2`. A `requestId` is optional but recommended; it is echoed back on the corresponding `ack` / `error` / response.
 
-| Type          | Payload (in addition to `protocolVersion`, optional `requestId`) | Description                                    |
-| ------------- | ---------------------------------------------------------------- | ---------------------------------------------- |
-| `setModel`    | `{ type: 'setModel', source: string }`                           | Replace the current model with raw source text |
-| `setVar`      | `{ type: 'setVar', name: string, value: unknown }`               | Set one customizer variable                    |
-| `getVars`     | `{ type: 'getVars' }`                                            | Request the current effective variable map     |
-| `getArtifact` | `{ type: 'getArtifact' }`                                        | Request the bytes of the latest render output  |
+| Type          | Payload (in addition to `protocolVersion`, optional `requestId`) | Description                                                                   |
+| ------------- | ---------------------------------------------------------------- | ----------------------------------------------------------------------------- |
+| `setModel`    | `{ type: 'setModel', source: string }`                           | Replace the current model with raw source text                                |
+| `setVar`      | `{ type: 'setVar', name: string, value: unknown }`               | Set one customizer variable                                                   |
+| `getVars`     | `{ type: 'getVars' }`                                            | Request the current effective variable map                                    |
+| `getArtifact` | `{ type: 'getArtifact', artifactId? }`                           | Request artifact bytes — the latest render output, or a specific `artifactId` |
 
 Limits (oversized messages are rejected with a `too-large` error):
 
@@ -55,17 +57,17 @@ Notes:
 
 ### iframe → host
 
-| Type                 | Payload (in addition to `protocolVersion`)                                   | Description                                                       |
-| -------------------- | ---------------------------------------------------------------------------- | ----------------------------------------------------------------- |
-| `ready`              | `{ type: 'ready', vars, parameterSet? }`                                     | Initial embed state is ready for host interaction                 |
-| `ack`                | `{ type: 'ack', requestId? }`                                                | A `setModel` / `setVar` command was applied                       |
-| `error`              | `{ type: 'error', code, reason, requestId? }`                                | An inbound message was rejected (see error codes)                 |
-| `varsChanged`        | `{ type: 'varsChanged', vars }`                                              | Effective variable map changed                                    |
-| `parameterSetLoaded` | `{ type: 'parameterSetLoaded', parameterSet }`                               | Parameter metadata is available                                   |
-| `varsSnapshot`       | `{ type: 'varsSnapshot', vars, requestId? }`                                 | Response to `getVars`                                             |
-| `renderComplete`     | `{ type: 'renderComplete', artifact: { name, size, format } }`               | A render finished; metadata only — fetch bytes with `getArtifact` |
-| `artifact`           | `{ type: 'artifact', available, name?, size?, format?, bytes?, requestId? }` | Response to `getArtifact`; `bytes` is a transferred `ArrayBuffer` |
-| `stateChange`        | `{ type: 'stateChange', error }`                                             | Error event used for external model-load failures                 |
+| Type                 | Payload (in addition to `protocolVersion`)                                                                                           | Description                                                                          |
+| -------------------- | ------------------------------------------------------------------------------------------------------------------------------------ | ------------------------------------------------------------------------------------ |
+| `ready`              | `{ type: 'ready', vars, parameterSet?, capabilities }`                                                                               | Initial embed state is ready; `capabilities.artifactIdentity` flags identity support |
+| `ack`                | `{ type: 'ack', requestId? }`                                                                                                        | A `setModel` / `setVar` command was applied                                          |
+| `error`              | `{ type: 'error', code, reason, requestId? }`                                                                                        | An inbound message was rejected (see error codes)                                    |
+| `varsChanged`        | `{ type: 'varsChanged', vars }`                                                                                                      | Effective variable map changed                                                       |
+| `parameterSetLoaded` | `{ type: 'parameterSetLoaded', parameterSet }`                                                                                       | Parameter metadata is available                                                      |
+| `varsSnapshot`       | `{ type: 'varsSnapshot', vars, requestId? }`                                                                                         | Response to `getVars`                                                                |
+| `renderComplete`     | `{ type: 'renderComplete', artifact: { artifactId, operationId, sourceRevision, format, mediaType, size, name } }`                   | A render finished; durable metadata + identity — fetch bytes with `getArtifact`      |
+| `artifact`           | `{ type: 'artifact', available, artifactId?, operationId?, sourceRevision?, format?, mediaType?, size?, name?, bytes?, requestId? }` | Response to `getArtifact`; `bytes` is a transferred `ArrayBuffer`                    |
+| `stateChange`        | `{ type: 'stateChange', error }`                                                                                                     | Error event used for external model-load failures                                    |
 
 Error `code` values: `malformed`, `unsupported-version`, `unknown-type`, `invalid-payload`, `too-large`.
 
@@ -75,6 +77,7 @@ Notes:
 - `varsChanged` carries the current effective values, including parameter defaults when available.
 - `parameterSetLoaded` may arrive after `ready`. If the host needs a fully default-expanded variable map for a parameterized model, call `getVars` after `parameterSetLoaded`.
 - `renderComplete` no longer includes a blob URL. Call `getArtifact` to receive the output bytes as a transferred `ArrayBuffer` (`artifact.available === false` if no render output exists yet).
+- Each render/export output carries an immutable `artifactId` (advertised on `renderComplete` and the `artifact` response). Pass it to `getArtifact` to fetch that exact result rather than whatever is current; an `artifactId` that is unknown or has aged out of the per-session store returns `available: false`. Omitting `artifactId` returns the current output, unchanged from protocol v2.
 
 ## Security Model
 

--- a/src/components/elements/osc-embed-shell.ts
+++ b/src/components/elements/osc-embed-shell.ts
@@ -11,6 +11,7 @@ import type { Model } from '../../state/model.ts';
 import './osc-viewer-panel.ts';
 import './osc-customizer-panel.ts';
 import { validateInbound, outbound, isTrustedOrigin } from '../../embed/protocol.ts';
+import { outputArtifactRef } from '../../embed/artifact-event.ts';
 
 // ---------------------------------------------------------------------------
 // postMessage protocol — see src/embed/protocol.ts and docs/EMBED.md
@@ -38,16 +39,6 @@ function coerceUrlVars(vars: Record<string, string>): Record<string, unknown> {
     }
   }
   return result;
-}
-
-/** Durable artifact descriptor sent to the host instead of a blob URL. */
-function artifactMeta(file: File): Record<string, unknown> {
-  const dot = file.name.lastIndexOf('.');
-  return {
-    name: file.name,
-    size: file.size,
-    format: dot >= 0 ? file.name.slice(dot + 1).toLowerCase() : '',
-  };
 }
 
 function getVarsSnapshot(st: State): Record<string, unknown> {
@@ -133,6 +124,10 @@ export class OscEmbedShell extends LitElement {
     this._notifyHost('ready', {
       vars: getVarsSnapshot(st),
       ...(st.parameterSet ? { parameterSet: st.parameterSet } : {}),
+      // Feature flags so a host can detect this build's optional behaviours
+      // (ADR 0008). `artifactIdentity`: renderComplete/artifact carry immutable
+      // ids and `getArtifact` accepts an `artifactId`.
+      capabilities: { artifactIdentity: true },
     });
   }
   private _onState = (e: Event) => {
@@ -154,10 +149,11 @@ export class OscEmbedShell extends LitElement {
     if (st.output && !st.rendering && !st.previewing) {
       if (st.output.outFileURL !== this._lastSentRenderURL) {
         this._lastSentRenderURL = st.output.outFileURL;
-        // Send durable metadata only; the host fetches bytes on demand via
-        // `getArtifact`. A blob URL owned by the iframe document is not even
+        // Send durable metadata + immutable identity only; the host fetches
+        // bytes on demand via `getArtifact` (optionally by the advertised
+        // `artifactId`). A blob URL owned by the iframe document is not even
         // usable cross-origin, so it is never leaked into the event.
-        this._notifyHost('renderComplete', { artifact: artifactMeta(st.output.outFile) });
+        this._notifyHost('renderComplete', { artifact: outputArtifactRef(st.output) });
       }
     }
   };
@@ -192,29 +188,46 @@ export class OscEmbedShell extends LitElement {
         });
         break;
       case 'getArtifact':
-        void this._sendArtifact(requestId);
+        void this._sendArtifact(requestId, msg.artifactId);
         break;
     }
   };
 
-  /** Respond to `getArtifact` with the current render bytes (transferred). */
-  private async _sendArtifact(requestId: string | undefined) {
-    const output = this._model.state.output;
-    if (!output) {
+  /**
+   * Respond to `getArtifact` with bytes + immutable identity (transferred).
+   * With no `artifactId` this is the current output (byte-identical to v2); with
+   * one it is that specific artifact's exact bytes, or `available: false` if it
+   * is unknown or has been evicted from the per-session store (ADR 0008).
+   */
+  private async _sendArtifact(requestId: string | undefined, artifactId: string | undefined) {
+    const resolved = this._resolveArtifact(artifactId);
+    if (!resolved) {
       this._notifyHost('artifact', { available: false, ...(requestId ? { requestId } : {}) });
       return;
     }
-    const bytes = await output.outFile.arrayBuffer();
+    const bytes = await resolved.file.arrayBuffer();
     this._notifyHost(
       'artifact',
       {
         available: true,
-        ...artifactMeta(output.outFile),
+        ...resolved.ref,
         bytes,
         ...(requestId ? { requestId } : {}),
       },
       [bytes],
     );
+  }
+
+  /** The requested artifact's ref + File: a specific one from the store, or —
+   *  when no id is given — the current output read straight off state (never the
+   *  store, so a burst of previews cannot evict the live result). */
+  private _resolveArtifact(artifactId: string | undefined) {
+    if (artifactId !== undefined) {
+      const stored = this._model.getStoredArtifact(artifactId);
+      return stored ? { ref: stored.ref, file: stored.bytes } : undefined;
+    }
+    const output = this._model.state.output;
+    return output ? { ref: outputArtifactRef(output), file: output.outFile } : undefined;
   }
 
   override connectedCallback() {

--- a/src/embed/__tests__/artifact-event.test.ts
+++ b/src/embed/__tests__/artifact-event.test.ts
@@ -1,0 +1,43 @@
+import { describe, expect, it } from 'vitest';
+
+import type { FileOutput } from '../../state/app-state.ts';
+import { outputArtifactRef } from '../artifact-event.ts';
+
+function output(name: string, bytes = 'data'): FileOutput {
+  const outFile = new File([bytes], name);
+  return {
+    outFile,
+    outFileURL: 'blob:x',
+    elapsedMillis: 1,
+    formattedElapsedMillis: '1ms',
+    formattedOutFileSize: '4 B',
+    artifactId: 'art-1',
+    operationId: 'op-1',
+    sourceRevision: 7,
+  };
+}
+
+describe('outputArtifactRef', () => {
+  it('carries the committed identity and derives format + mediaType from the name', () => {
+    const ref = outputArtifactRef(output('model.stl'));
+    expect(ref).toEqual({
+      artifactId: 'art-1',
+      operationId: 'op-1',
+      sourceRevision: 7,
+      format: 'stl',
+      mediaType: 'model/stl',
+      size: 4,
+      name: 'model.stl',
+    });
+  });
+
+  it('falls back to octet-stream for an unknown extension', () => {
+    expect(outputArtifactRef(output('out.xyz')).mediaType).toBe('application/octet-stream');
+  });
+
+  it('handles an extensionless name (empty format)', () => {
+    const ref = outputArtifactRef(output('noext'));
+    expect(ref.format).toBe('');
+    expect(ref.mediaType).toBe('application/octet-stream');
+  });
+});

--- a/src/embed/__tests__/protocol.test.ts
+++ b/src/embed/__tests__/protocol.test.ts
@@ -172,7 +172,26 @@ describe('validateInbound — read commands', () => {
     });
     expect(validateInbound({ protocolVersion: V, type: 'getArtifact' })).toEqual({
       ok: true,
-      message: { type: 'getArtifact', requestId: undefined },
+      message: { type: 'getArtifact', requestId: undefined, artifactId: undefined },
+    });
+  });
+
+  it('carries an optional artifactId on getArtifact (ADR 0008), defaulting to undefined', () => {
+    expect(
+      validateInbound({
+        protocolVersion: V,
+        type: 'getArtifact',
+        requestId: 'a',
+        artifactId: 'xyz',
+      }),
+    ).toEqual({
+      ok: true,
+      message: { type: 'getArtifact', requestId: 'a', artifactId: 'xyz' },
+    });
+    // A non-string artifactId is ignored (treated as "current output"), never a rejection.
+    expect(validateInbound({ protocolVersion: V, type: 'getArtifact', artifactId: 123 })).toEqual({
+      ok: true,
+      message: { type: 'getArtifact', requestId: undefined, artifactId: undefined },
     });
   });
 });

--- a/src/embed/artifact-event.ts
+++ b/src/embed/artifact-event.ts
@@ -1,0 +1,26 @@
+// Builds the durable artifact-identity fields the embed sends to its host
+// (ADR 0008, Layer-1 slice 3). Kept DOM-light and free of the Lit shell so the
+// transform can be unit-tested in isolation.
+
+import { formatOfName, mediaTypeForFormat, type ArtifactRef } from '../runner/compile-contract.ts';
+import type { FileOutput } from '../state/app-state.ts';
+
+/**
+ * The current render/export output, as an immutable `ArtifactRef`. The committed
+ * `FileOutput` already carries the stable identity (artifactId / operationId /
+ * sourceRevision, ADR 0008); this derives the wire descriptor (format/mediaType
+ * from the file name) so `renderComplete` and the current-output `artifact`
+ * response advertise the same shape a by-id `getArtifact` returns.
+ */
+export function outputArtifactRef(output: FileOutput): ArtifactRef {
+  const format = formatOfName(output.outFile.name);
+  return {
+    artifactId: output.artifactId,
+    operationId: output.operationId,
+    sourceRevision: output.sourceRevision,
+    format,
+    mediaType: mediaTypeForFormat(format),
+    size: output.outFile.size,
+    name: output.outFile.name,
+  };
+}

--- a/src/embed/protocol.ts
+++ b/src/embed/protocol.ts
@@ -36,7 +36,7 @@ export type InboundMessage =
   | { type: 'setModel'; source: string; requestId?: string }
   | { type: 'setVar'; name: string; value: unknown; requestId?: string }
   | { type: 'getVars'; requestId?: string }
-  | { type: 'getArtifact'; requestId?: string };
+  | { type: 'getArtifact'; requestId?: string; artifactId?: string };
 
 /** Embed rejection codes are the shared protocol vocabulary. */
 export type EmbedErrorCode = ProtocolErrorCode;
@@ -125,8 +125,12 @@ export function validateInbound(data: unknown): ValidationResult {
     }
     case 'getVars':
       return { ok: true, message: { type: 'getVars', requestId } };
-    case 'getArtifact':
-      return { ok: true, message: { type: 'getArtifact', requestId } };
+    case 'getArtifact': {
+      // Optional: a specific artifact's immutable id (ADR 0008). Absent (or a
+      // non-string) means "the current output", byte-identical to v2 behaviour.
+      const artifactId = typeof data.artifactId === 'string' ? data.artifactId : undefined;
+      return { ok: true, message: { type: 'getArtifact', requestId, artifactId } };
+    }
     default:
       return { ok: false, code: 'unknown-type', reason: `unknown type "${data.type}"`, requestId };
   }

--- a/src/state/model.ts
+++ b/src/state/model.ts
@@ -15,7 +15,7 @@ import { ProjectStore } from './project-store.ts';
 import { HostAdapter, WebHostAdapter } from './web-host-adapter.ts';
 import { WasmWorkerBackend, type CompileBackend } from '../runner/openscad-runner.ts';
 import { newId } from '../runner/compile-contract.ts';
-import { ArtifactStore } from './artifact-store.ts';
+import { ArtifactStore, type StoredArtifact } from './artifact-store.ts';
 import { applyUserFacingError } from './apply-user-facing-error.ts';
 import { CompileCoordinator } from './services/compile-coordinator.ts';
 import { ExportService } from './services/export-service.ts';
@@ -119,11 +119,11 @@ export class Model extends EventTarget {
     }
   }
 
-  /** The exact bytes a prior operation produced, by immutable artifactId, or
-   *  undefined if unknown/evicted (ADR 0008). Lets a consumer (embed/MCP) fetch a
-   *  specific result rather than the racy "current output". */
-  getArtifact(artifactId: string): File | undefined {
-    return this.artifacts.get(artifactId)?.bytes;
+  /** A prior operation's exact bytes and immutable identity ref, by artifactId,
+   *  or undefined if unknown/evicted (ADR 0008). Lets a consumer (embed/MCP)
+   *  fetch a specific result rather than the racy "current output". */
+  getStoredArtifact(artifactId: string): StoredArtifact | undefined {
+    return this.artifacts.get(artifactId);
   }
 
   private setState(state: State) {

--- a/tests/e2e.spec.ts
+++ b/tests/e2e.spec.ts
@@ -754,11 +754,28 @@ test.describe('embed mode', () => {
     expect(errMsg?.data?.code).toBe('unsupported-version');
     expect(errMsg?.data?.requestId).toBe('bad-1');
 
+    // ready advertises the artifact-identity capability (ADR 0008).
+    const readyMsg = messages.find((m) => m.data?.type === 'ready');
+    expect(readyMsg?.data?.capabilities).toEqual(
+      expect.objectContaining({ artifactIdentity: true }),
+    );
+
     const renderComplete = messages.find((m) => m.data?.type === 'renderComplete');
+    // renderComplete now carries durable metadata PLUS immutable identity.
     expect(renderComplete?.data?.artifact).toEqual(
-      expect.objectContaining({ name: expect.any(String) }),
+      expect.objectContaining({
+        name: expect.any(String),
+        artifactId: expect.any(String),
+        operationId: expect.any(String),
+        sourceRevision: expect.any(Number),
+        mediaType: expect.any(String),
+      }),
     );
     expect('outFileURL' in (renderComplete?.data ?? {})).toBe(false);
+    const renderedArtifactId = (
+      renderComplete?.data?.artifact as { artifactId?: string } | undefined
+    )?.artifactId;
+    expect(typeof renderedArtifactId).toBe('string');
 
     // The transferred ArrayBuffer does not survive serialization back to Node,
     // so inspect it inside the page realm.
@@ -778,6 +795,74 @@ test.describe('embed mode', () => {
     });
     expect(artifact.available).toBe(true);
     expect(artifact.byteLength).toBeGreaterThan(0);
+
+    // Fetch the SAME render by its immutable artifactId (ADR 0008): the embed
+    // serves the exact bytes and echoes the id, not a racy "current output".
+    await page.evaluate((artifactId) => {
+      const iframe = document.getElementById('embed-frame') as HTMLIFrameElement | null;
+      iframe?.contentWindow?.postMessage(
+        { protocolVersion: 2, type: 'getArtifact', requestId: 'art-2', artifactId },
+        window.location.origin,
+      );
+    }, renderedArtifactId);
+    await waitForEmbedMessageCount(page, 'artifact', 2);
+
+    const byId = await page.evaluate(() => {
+      const messages = (
+        window as Window & {
+          __embedMessages?: Array<{
+            data?: {
+              type?: string;
+              requestId?: string;
+              available?: boolean;
+              artifactId?: string;
+              bytes?: ArrayBuffer;
+            };
+          }>;
+        }
+      ).__embedMessages;
+      const msg = messages?.find(
+        (m) => m?.data?.type === 'artifact' && m?.data?.requestId === 'art-2',
+      );
+      return {
+        available: msg?.data?.available ?? false,
+        artifactId: msg?.data?.artifactId ?? null,
+        byteLength: msg?.data?.bytes?.byteLength ?? 0,
+      };
+    });
+    expect(byId.available).toBe(true);
+    expect(byId.artifactId).toBe(renderedArtifactId);
+    expect(byId.byteLength).toBeGreaterThan(0);
+
+    // An unknown/evicted artifactId is a clean miss: available:false, no bytes —
+    // never a fallback to the current output (ADR 0008).
+    await page.evaluate(() => {
+      const iframe = document.getElementById('embed-frame') as HTMLIFrameElement | null;
+      iframe?.contentWindow?.postMessage(
+        { protocolVersion: 2, type: 'getArtifact', requestId: 'art-3', artifactId: 'no-such-id' },
+        window.location.origin,
+      );
+    });
+    await waitForEmbedMessageCount(page, 'artifact', 3);
+
+    const miss = await page.evaluate(() => {
+      const messages = (
+        window as Window & {
+          __embedMessages?: Array<{
+            data?: { type?: string; requestId?: string; available?: boolean; bytes?: ArrayBuffer };
+          }>;
+        }
+      ).__embedMessages;
+      const msg = messages?.find(
+        (m) => m?.data?.type === 'artifact' && m?.data?.requestId === 'art-3',
+      );
+      return {
+        available: msg?.data?.available ?? true,
+        hasBytes: msg?.data?.bytes !== undefined,
+      };
+    });
+    expect(miss.available).toBe(false);
+    expect(miss.hasBytes).toBe(false);
   });
 
   test('rejects host messages when parentOrigin does not match the real parent origin', async ({


### PR DESCRIPTION
## Layer-1 slice 3 of 4 — embed artifact identity (additive, still protocol v2)

Surfaces the immutable artifact identity (from slice 2's per-session store) over the public embed `postMessage` API. **No `EMBED_PROTOCOL_VERSION` bump** — every change is a field addition over v2, and inbound validation already ignores unknown fields, so existing v2 hosts are unaffected.

### What changed
- **`getArtifact` inbound** gains optional `artifactId?: string`. Absent (or non-string) → the current output, **byte-identical to v2**. A given id → that exact artifact's bytes, or `{ available: false }` when unknown / aged out of the bounded store.
- **`renderComplete` + `artifact` response** now carry full identity (`artifactId`, `operationId`, `sourceRevision`, `format`, `mediaType`, `size`, `name`) via a new pure `outputArtifactRef` helper. The current-output path reads `state.output` **directly** (never the LRU store), so a burst of previews can't evict the live result.
- **`ready`** advertises `capabilities: { artifactIdentity: true }` for feature detection.
- **`Model.getArtifact` → `getStoredArtifact`** (ref + bytes); the old method had no consumers.

### Tests
- `protocol.test.ts`: optional `artifactId` passthrough; non-string ignored.
- `artifact-event.test.ts` (new): `outputArtifactRef` format/mediaType derivation.
- `e2e.spec.ts`: by-id round-trip (same id + bytes), **unknown-id miss → `available:false`, no bytes**, advertised capability, and enriched `renderComplete`. Ran the embed e2e locally against Chromium — green.

### Verification
- `npm run verify` green (format, lint, typecheck, unit w/ coverage, assembly, build, budgets, publish-archive)
- `CI=true npm run test:unit` — 484 passed
- Embed e2e (`-g "serves artifact bytes on request"`) — passed locally

Adversarially reviewed (independent subagent): no blockers; backward-compat/byte-identity, no-store current-output path, validation, and ref-drift all confirmed. The one SHOULD-FIX (unknown-id miss coverage) was added.

Docs: `docs/EMBED.md` updated (additive-v2 note, new shapes, capability, eviction semantics). Refs ADR 0008.