### PR TITLE
feat(state): emit terminal OperationResult per operation (ADR 0008)

### DIFF
--- a/src/runner/__tests__/compile-contract.test.ts
+++ b/src/runner/__tests__/compile-contract.test.ts
@@ -1,6 +1,16 @@
 import { describe, expect, it } from 'vitest';
 
-import { formatOfName, mediaTypeForFormat, newId } from '../compile-contract.ts';
+import {
+  formatOfName,
+  mediaTypeForFormat,
+  newId,
+  operationCancelled,
+  operationFailure,
+  operationSuccess,
+  L1_PROTOCOL_VERSION,
+  OPERATION_FAILED,
+  type OperationBase,
+} from '../compile-contract.ts';
 
 describe('newId', () => {
   it('mints unique, well-formed v4 UUIDs', () => {
@@ -25,5 +35,50 @@ describe('formatOfName', () => {
     expect(formatOfName('part.STL')).toBe('stl');
     expect(formatOfName('model.scad')).toBe('scad');
     expect(formatOfName('noext')).toBe('');
+  });
+});
+
+describe('OperationResult builders (ADR 0008 slice 4)', () => {
+  const base: OperationBase = {
+    sessionId: 's',
+    operationId: 'o',
+    sourceRevision: 3,
+    kind: 'render',
+    elapsedMillis: 42,
+    diagnostics: [],
+    logText: 'log',
+  };
+
+  it('operationSuccess stamps version + status and carries an optional artifact', () => {
+    const artifact = {
+      artifactId: 'a',
+      operationId: 'o',
+      sourceRevision: 3,
+      format: 'off',
+      mediaType: 'text/plain',
+      size: 5,
+      name: 'm.off',
+    };
+    const result = operationSuccess(base, artifact);
+    expect(result.protocolVersion).toBe(L1_PROTOCOL_VERSION);
+    expect(result.status).toBe('success');
+    expect(result.operationId).toBe('o');
+    expect(result.artifact).toBe(artifact);
+    // No artifact for an artifact-less operation (e.g. a syntax check).
+    expect(operationSuccess(base).artifact).toBeUndefined();
+  });
+
+  it('operationFailure carries the code + reason', () => {
+    const result = operationFailure(base, OPERATION_FAILED, 'it broke');
+    expect(result.status).toBe('error');
+    expect(result.code).toBe(OPERATION_FAILED);
+    expect(result.reason).toBe('it broke');
+  });
+
+  it('operationCancelled has no artifact/code/reason', () => {
+    const result = operationCancelled(base);
+    expect(result.status).toBe('cancelled');
+    expect(result.protocolVersion).toBe(L1_PROTOCOL_VERSION);
+    expect('artifact' in result).toBe(false);
   });
 });

--- a/src/runner/compile-contract.ts
+++ b/src/runner/compile-contract.ts
@@ -57,6 +57,42 @@ export interface OperationCancelled extends OperationResultBase {
 export type OperationResult = OperationSuccess | OperationFailure | OperationCancelled;
 
 /**
+ * Layer-1 envelope version (ADR 0005 axis). Distinct from `EMBED_PROTOCOL_VERSION`
+ * — that versions the embed *wire*; this versions the host-side operation result.
+ */
+export const L1_PROTOCOL_VERSION = 1;
+
+/** Coarse failure code pending a real taxonomy when the MCP binding needs to
+ *  branch on it; `reason` carries the user-facing message today. */
+export const OPERATION_FAILED = 'operation_failed';
+
+/** The shared, status-independent fields of a terminal result. */
+export type OperationBase = Omit<OperationResultBase, 'protocolVersion'>;
+
+export function operationSuccess(base: OperationBase, artifact?: ArtifactRef): OperationSuccess {
+  // Omit the key entirely when artifact-less (e.g. a syntax check), so `'artifact'
+  // in result` is a reliable "has bytes" probe rather than always-true.
+  return {
+    protocolVersion: L1_PROTOCOL_VERSION,
+    status: 'success',
+    ...base,
+    ...(artifact ? { artifact } : {}),
+  };
+}
+
+export function operationFailure(
+  base: OperationBase,
+  code: string,
+  reason: string,
+): OperationFailure {
+  return { protocolVersion: L1_PROTOCOL_VERSION, status: 'error', ...base, code, reason };
+}
+
+export function operationCancelled(base: OperationBase): OperationCancelled {
+  return { protocolVersion: L1_PROTOCOL_VERSION, status: 'cancelled', ...base };
+}
+
+/**
  * An immutable handle to a produced artifact's exact bytes. `artifactId` keys a
  * per-session store so `getArtifact(artifactId)` returns those exact bytes — not a
  * racy "current output".

--- a/src/state/services/__tests__/compile-coordinator.test.ts
+++ b/src/state/services/__tests__/compile-coordinator.test.ts
@@ -3,6 +3,7 @@ import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { CompileCoordinator } from '../compile-coordinator.ts';
 import type { ServiceContext } from '../service-context.ts';
 import { ArtifactStore } from '../../artifact-store.ts';
+import type { OperationResult } from '../../../runner/compile-contract.ts';
 import type { State } from '../../app-state.ts';
 
 // render() is `factory(renderArgs)({ now })` → Promise<RenderOutput>; we drive the
@@ -16,7 +17,7 @@ vi.mock('../../../runner/actions.ts', () => ({
   createSyntaxDelayable: () => (args: unknown) => (opts: unknown) => checkSyntaxImpl(args, opts),
 }));
 
-function makeContext(revision: number) {
+function makeContext(revision: number, onResult?: (r: OperationResult) => void) {
   const state = {
     params: {
       sources: [{ kind: 'text', path: '/main.scad', content: 'cube();' }],
@@ -38,6 +39,7 @@ function makeContext(revision: number) {
   };
 
   let rev = revision;
+  const results: OperationResult[] = [];
   const ctx: ServiceContext = {
     getState: () => state,
     mutate: (f) => {
@@ -53,9 +55,10 @@ function makeContext(revision: number) {
     backend: { spawn: vi.fn(), cancel: vi.fn(), dispose: vi.fn() },
     sessionId: 'test-session',
     artifacts: new ArtifactStore(),
+    onOperationResult: onResult ?? ((r) => results.push(r)),
   };
 
-  return { ctx, state, host, setRevision: (n: number) => (rev = n) };
+  return { ctx, state, host, results, setRevision: (n: number) => (rev = n) };
 }
 
 function renderOutput(revision: number) {
@@ -168,7 +171,7 @@ describe('CompileCoordinator render staleness', () => {
   });
 
   it('commits the result and revokes nothing on the happy path', async () => {
-    const { ctx, state, host } = makeContext(1);
+    const { ctx, state, host, results } = makeContext(1);
     renderImpl.mockResolvedValue(renderOutput(1));
 
     await new CompileCoordinator(ctx).render({ isPreview: false, now: true });
@@ -184,12 +187,23 @@ describe('CompileCoordinator render staleness', () => {
     // The same artifactId resolves in the store to the exact committed File —
     // the slice's central guarantee (shared id, byte-identical write-through).
     expect(ctx.artifacts.get(state.output!.artifactId)?.bytes).toBe(state.output!.outFile);
+    // Exactly one terminal OperationResult: a success keyed to the operation, its
+    // artifact ref matching the committed output (ADR 0008 slice 4).
+    expect(results).toHaveLength(1);
+    const result = results[0];
+    expect(result.status).toBe('success');
+    expect(result.kind).toBe('render');
+    expect(result.operationId).toBe(state.output?.operationId);
+    if (result.status === 'success') {
+      expect(result.artifact?.artifactId).toBe(state.output?.artifactId);
+      expect(result.artifact?.operationId).toBe(state.output?.operationId);
+    }
   });
 
   it('drops a result whose revision is stale and never creates a blob URL', async () => {
     // The render was requested at revision 1, but the sources moved to 2 by the
     // time the result arrives (e.g. the user edited while rendering).
-    const { ctx, state, host } = makeContext(2);
+    const { ctx, state, host, results } = makeContext(2);
     renderImpl.mockResolvedValue(renderOutput(1));
 
     await new CompileCoordinator(ctx).render({ isPreview: false, now: true });
@@ -201,6 +215,10 @@ describe('CompileCoordinator render staleness', () => {
     expect(host.revokeObjectURL).not.toHaveBeenCalled();
     expect(host.playCompletionChime).not.toHaveBeenCalled();
     expect(state.rendering).toBe(false);
+    // The stale-drop still terminates the operation — exactly one cancelled result.
+    expect(results).toHaveLength(1);
+    expect(results[0].status).toBe('cancelled');
+    expect(results[0].kind).toBe('render');
   });
 
   it('revokes the previous output blob URL when committing a new result', async () => {
@@ -223,5 +241,111 @@ describe('CompileCoordinator render staleness', () => {
 
     expect(host.revokeObjectURL).toHaveBeenCalledWith('blob:old-url');
     expect(state.output?.outFileURL).toBe('blob:fake-url');
+  });
+});
+
+describe('CompileCoordinator terminal OperationResult (ADR 0008 slice 4)', () => {
+  beforeEach(() => {
+    renderImpl.mockReset();
+    checkSyntaxImpl.mockReset();
+  });
+
+  it('emits one error result when the render rejects', async () => {
+    const { ctx, results } = makeContext(1);
+    renderImpl.mockRejectedValue(new Error('boom'));
+
+    await new CompileCoordinator(ctx).render({ isPreview: false, now: true });
+
+    expect(results).toHaveLength(1);
+    const result = results[0];
+    expect(result.status).toBe('error');
+    expect(result.kind).toBe('render');
+    if (result.status === 'error') {
+      expect(result.code).toBe('operation_failed');
+      expect(typeof result.reason).toBe('string');
+      expect(result.reason.length).toBeGreaterThan(0);
+    }
+  });
+
+  it('a superseded render terminates as cancelled while the newer one succeeds', async () => {
+    const { ctx, results } = makeContext(1);
+    let resolveFirst: (v: unknown) => void = () => {};
+    renderImpl.mockReturnValueOnce(new Promise((r) => (resolveFirst = r)));
+    renderImpl.mockResolvedValueOnce(renderOutput(1));
+    const coord = new CompileCoordinator(ctx);
+
+    const first = coord.render({ isPreview: false, now: true });
+    const second = coord.render({ isPreview: false, now: true }); // supersedes the first
+    resolveFirst(renderOutput(1));
+    await Promise.all([first, second]);
+
+    expect(results).toHaveLength(2);
+    const statuses = results.map((r) => r.status).sort();
+    expect(statuses).toEqual(['cancelled', 'success']);
+    // Distinct operations: the cancelled and the success never share an id.
+    expect(results[0].operationId).not.toBe(results[1].operationId);
+  });
+
+  it('the 2D/3D dimension retry is a distinct second operation (two results, two ids)', async () => {
+    const { ctx, results } = makeContext(1);
+    // The first render logs a dimension mismatch via the streams callback, which
+    // triggers exactly one retry (a recursive render with its own operationId).
+    renderImpl.mockImplementationOnce((renderArgs: { streamsCallback: (p: unknown) => void }) => {
+      renderArgs.streamsCallback({ stderr: 'Current top level object is not a 3D object.' });
+      return Promise.resolve(renderOutput(1));
+    });
+    renderImpl.mockResolvedValueOnce(renderOutput(1));
+
+    await new CompileCoordinator(ctx).render({ isPreview: false, now: true });
+    // The retry is dispatched without await (fire-and-return), so let its own
+    // async commit settle before asserting.
+    await new Promise((r) => setTimeout(r, 0));
+
+    expect(results).toHaveLength(2);
+    expect(results.every((r) => r.status === 'success')).toBe(true);
+    expect(results[0].operationId).not.toBe(results[1].operationId);
+  });
+
+  it('checkSyntax emits one success result with no artifact', async () => {
+    const { ctx, results } = makeContext(1);
+    checkSyntaxImpl.mockResolvedValue({ revision: 1, markers: [], logText: '' });
+
+    await new CompileCoordinator(ctx).checkSyntax();
+
+    expect(results).toHaveLength(1);
+    const result = results[0];
+    expect(result.status).toBe('success');
+    expect(result.kind).toBe('syntaxCheck');
+    if (result.status === 'success') {
+      expect(result.artifact).toBeUndefined();
+    }
+  });
+
+  it('checkSyntax emits one error result when the check rejects', async () => {
+    const { ctx, results } = makeContext(1);
+    checkSyntaxImpl.mockRejectedValue(new Error('parse failure'));
+
+    await new CompileCoordinator(ctx).checkSyntax();
+
+    expect(results).toHaveLength(1);
+    expect(results[0].status).toBe('error');
+    expect(results[0].kind).toBe('syntaxCheck');
+  });
+
+  it('a throwing sink cannot corrupt the committed render or surface an error', async () => {
+    // The result sink throws; emitResult must swallow it so the success commit is
+    // not re-entered by the catch (no clobbered output, no spurious error).
+    const { ctx, state } = makeContext(1, () => {
+      throw new Error('sink boom');
+    });
+    renderImpl.mockResolvedValue(renderOutput(1));
+
+    await expect(
+      new CompileCoordinator(ctx).render({ isPreview: false, now: true }),
+    ).resolves.toBeUndefined();
+
+    expect(state.output?.outFileURL).toBe('blob:fake-url');
+    expect(state.error).toBeUndefined();
+    expect(state.rendering).toBe(false);
   });
 });

--- a/src/state/services/__tests__/export-service.test.ts
+++ b/src/state/services/__tests__/export-service.test.ts
@@ -30,6 +30,7 @@ import type { HostAdapter } from '../../web-host-adapter.ts';
 import { ExportService } from '../export-service.ts';
 import type { ServiceContext } from '../service-context.ts';
 import { ArtifactStore } from '../../artifact-store.ts';
+import type { OperationResult } from '../../../runner/compile-contract.ts';
 
 /**
  * A renderExport mock whose inner thunk returns an AbortablePromise-shaped value
@@ -74,6 +75,7 @@ function fileOutput(name: string, url = 'blob:out'): State['output'] {
 }
 
 function makeCtx(partial: Partial<State['params']> & { is2D?: boolean; output?: State['output'] }) {
+  const results: OperationResult[] = [];
   let state: State = {
     params: {
       activePath: '/a.scad',
@@ -116,15 +118,16 @@ function makeCtx(partial: Partial<State['params']> & { is2D?: boolean; output?: 
     backend: { spawn: vi.fn(), cancel: vi.fn(), dispose: vi.fn() },
     sessionId: 'test-session',
     artifacts: new ArtifactStore(),
+    onOperationResult: (r) => results.push(r),
   };
-  return { ctx, host, getState: () => state };
+  return { ctx, host, results, getState: () => state };
 }
 
 describe('ExportService', () => {
   beforeEach(() => vi.clearAllMocks());
 
   it('downloads the rendered file directly on an svg pass-through (2D)', async () => {
-    const { ctx, host } = makeCtx({
+    const { ctx, host, results } = makeCtx({
       is2D: true,
       exportFormat2D: 'svg',
       output: fileOutput('m.svg'),
@@ -132,6 +135,15 @@ describe('ExportService', () => {
     await new ExportService(ctx).export();
     expect(host.download).toHaveBeenCalledWith('blob:out', 'm.svg');
     expect(mockRenderExport).not.toHaveBeenCalled();
+    // One terminal success that INHERITS the render's artifact identity (same
+    // bytes), keyed to this export operation (ADR 0008 slice 4).
+    expect(results).toHaveLength(1);
+    expect(results[0].status).toBe('success');
+    expect(results[0].kind).toBe('export');
+    if (results[0].status === 'success') {
+      expect(results[0].artifact?.artifactId).toBe('art');
+      expect(results[0].artifact?.operationId).toBe('op');
+    }
   });
 
   it('converts to glb in-browser (no worker render) and downloads a .glb', async () => {
@@ -148,7 +160,7 @@ describe('ExportService', () => {
   });
 
   it('opens the multimaterial picker for 3mf without extruder colors', async () => {
-    const { ctx, getState } = makeCtx({
+    const { ctx, getState, results } = makeCtx({
       is2D: false,
       exportFormat3D: '3mf',
       output: fileOutput('m.off'),
@@ -156,6 +168,11 @@ describe('ExportService', () => {
     await new ExportService(ctx).export();
     expect(getState().view.extruderPickerVisibility).toBe('exporting');
     expect(mockRenderExport).not.toHaveBeenCalled();
+    // The picker defers the real export to a second call; this op terminates as
+    // cancelled so every minted operationId resolves exactly once (ADR 0008).
+    expect(results).toHaveLength(1);
+    expect(results[0].status).toBe('cancelled');
+    expect(results[0].kind).toBe('export');
   });
 
   it('converts to 3mf when extruder colors are set, then downloads', async () => {
@@ -172,7 +189,7 @@ describe('ExportService', () => {
   });
 
   it('renders a format conversion for non-passthrough formats (e.g. stl)', async () => {
-    const { ctx, host, getState } = makeCtx({
+    const { ctx, host, getState, results } = makeCtx({
       is2D: false,
       exportFormat3D: 'stl',
       output: fileOutput('m.off'),
@@ -186,10 +203,16 @@ describe('ExportService', () => {
     // (shared id, byte-identical write-through — ADR 0008).
     const exported = getState().export!;
     expect(ctx.artifacts.get(exported.artifactId)?.bytes).toBe(exported.outFile);
+    // One terminal success whose fresh artifact ref matches the committed export.
+    expect(results).toHaveLength(1);
+    expect(results[0].status).toBe('success');
+    if (results[0].status === 'success') {
+      expect(results[0].artifact?.artifactId).toBe(exported.artifactId);
+    }
   });
 
   it('drops a superseded export result instead of clobbering the newer one', async () => {
-    const { ctx, host, getState } = makeCtx({
+    const { ctx, host, getState, results } = makeCtx({
       is2D: false,
       exportFormat3D: 'stl',
       output: fileOutput('m.off'),
@@ -223,6 +246,8 @@ describe('ExportService', () => {
     // Only the newer export downloaded; the stale one was dropped.
     expect(host.download.mock.calls.map((c) => c[1])).toEqual(['second.stl']);
     expect(getState().exporting).toBe(false);
+    // Two terminal results: the superseded op is cancelled, the newer succeeds.
+    expect(results.map((r) => r.status).sort()).toEqual(['cancelled', 'success']);
   });
 
   it('treats a superseded (cancelled) export as supersession, not a user-facing error', async () => {
@@ -343,9 +368,17 @@ describe('ExportService', () => {
   });
 
   it('clears exporting and surfaces an error when there is no output to convert', async () => {
-    const { ctx, getState } = makeCtx({ is2D: false, exportFormat3D: 'stl', output: undefined });
+    const { ctx, getState, results } = makeCtx({
+      is2D: false,
+      exportFormat3D: 'stl',
+      output: undefined,
+    });
     await new ExportService(ctx).export();
     expect(getState().exporting).toBe(false);
     expect(getState().error).toBeTruthy();
+    // The failed export terminates as exactly one error result (ADR 0008 slice 4).
+    expect(results).toHaveLength(1);
+    expect(results[0].status).toBe('error');
+    expect(results[0].kind).toBe('export');
   });
 });

--- a/src/state/services/compile-coordinator.ts
+++ b/src/state/services/compile-coordinator.ts
@@ -3,9 +3,23 @@ import {
   createSyntaxDelayable,
   type RenderArgs,
 } from '../../runner/actions.ts';
-import { formatOfName, mediaTypeForFormat, newId } from '../../runner/compile-contract.ts';
+import {
+  formatOfName,
+  mediaTypeForFormat,
+  newId,
+  operationCancelled,
+  operationFailure,
+  operationSuccess,
+  OPERATION_FAILED,
+  type OperationBase,
+  type OperationResult,
+} from '../../runner/compile-contract.ts';
 import { isExpectedJobCancellation, type ProcessStreams } from '../../runner/openscad-runner.ts';
-import { isUserFacingOperationError, UserFacingOperationError } from '../../user-facing-errors.ts';
+import {
+  isUserFacingOperationError,
+  normalizeOperationFailure,
+  UserFacingOperationError,
+} from '../../user-facing-errors.ts';
 import { fetchSource, formatBytes, formatMillis } from '../../utils.ts';
 import { applyUserFacingError } from '../apply-user-facing-error.ts';
 import type { State } from '../app-state.ts';
@@ -34,6 +48,18 @@ export class CompileCoordinator {
     // `useDefineForClassFields`. Reading the parameter is unconditionally correct.
     this._render = createRenderDelayable(ctx.backend);
     this._checkSyntax = createSyntaxDelayable(ctx.backend);
+  }
+
+  /** Route a terminal result to the optional sink, guarding the commit path: a
+   *  throwing sink must never corrupt committed state or double-emit, so its
+   *  exception is swallowed here rather than re-entering an operation's control
+   *  flow (ADR 0008). No-op when no sink is wired. */
+  private emitResult(result: OperationResult) {
+    try {
+      this.ctx.onOperationResult?.(result);
+    } catch (err) {
+      console.error('onOperationResult sink threw:', err);
+    }
   }
 
   // Sequence counters identifying the latest in-flight operation of each kind.
@@ -163,6 +189,21 @@ export class CompileCoordinator {
   async checkSyntax() {
     const token = ++this._syntaxSeq;
     const isCurrent = () => this._syntaxSeq === token;
+    // One operation id + terminal-result base for this syntax check (ADR 0008).
+    // The revision is captured at submit time (not lazily at emit) so a cancelled
+    // result echoes the revision the op was submitted at, matching the contract.
+    const operationId = newId();
+    const submittedRevision = this.ctx.getSourceRevision();
+    const base = (over: Partial<OperationBase> = {}): OperationBase => ({
+      sessionId: this.ctx.sessionId,
+      operationId,
+      sourceRevision: submittedRevision,
+      kind: 'syntaxCheck',
+      elapsedMillis: 0,
+      diagnostics: [],
+      logText: '',
+      ...over,
+    });
     this.ctx.mutate((s) => (s.checkingSyntax = true));
     try {
       const checkerRun = await this._checkSyntax({
@@ -176,11 +217,15 @@ export class CompileCoordinator {
           .params.sources.filter((s) => !(s.kind === 'local' && !isProbablyTextPath(s.path))),
         revision: this.ctx.getSourceRevision(),
       })({ now: false });
-      if (!isCurrent()) return; // a newer syntax check superseded this one
+      if (!isCurrent()) {
+        this.emitResult(operationCancelled(base())); // superseded
+        return; // a newer syntax check superseded this one
+      }
       if (
         checkerRun?.revision !== undefined &&
         checkerRun.revision !== this.ctx.getSourceRevision()
       ) {
+        this.emitResult(operationCancelled(base())); // revision stale-drop
         return; // sources changed since this check was requested — drop the stale result
       }
       this.ctx.mutate((s) => {
@@ -188,8 +233,17 @@ export class CompileCoordinator {
         s.parameterSet = checkerRun?.parameterSet;
         s.checkingSyntax = false;
       });
+      // A syntax check carries diagnostics but never an artifact (ADR 0008).
+      this.emitResult(
+        operationSuccess(
+          base({ diagnostics: checkerRun?.markers ?? [], logText: checkerRun?.logText ?? '' }),
+        ),
+      );
     } catch (err) {
-      if (!isCurrent()) return; // superseded — the newer check owns checkingSyntax
+      if (!isCurrent()) {
+        this.emitResult(operationCancelled(base())); // superseded
+        return; // superseded — the newer check owns checkingSyntax
+      }
       if (!isExpectedJobCancellation(err)) {
         if (!isUserFacingOperationError(err)) {
           console.error('Error while checking syntax:', err);
@@ -198,6 +252,15 @@ export class CompileCoordinator {
           applyUserFacingError(s, err, 'syntax');
         });
       }
+      this.emitResult(
+        isExpectedJobCancellation(err)
+          ? operationCancelled(base())
+          : operationFailure(
+              base(),
+              OPERATION_FAILED,
+              normalizeOperationFailure(err, 'syntax').message,
+            ),
+      );
     } finally {
       if (isCurrent()) {
         this.ctx.mutate((s) => {
@@ -237,6 +300,22 @@ export class CompileCoordinator {
     // One operation id per scheduler invocation (ADR 0008). The dimension retry
     // is a distinct recursive render(), so it mints its own — never shared.
     const operationId = newId();
+    // The status-independent fields for this operation's single terminal result.
+    // The revision is captured at submit time (not lazily at emit), so a cancelled
+    // stale-drop echoes the submitted revision rather than the newer one that
+    // superseded it. Emits route through emitResult so a throwing sink cannot
+    // disturb the byte-identical live commit (ADR 0008).
+    const submittedRevision = this.ctx.getSourceRevision();
+    const base = (over: Partial<OperationBase> = {}): OperationBase => ({
+      sessionId: this.ctx.sessionId,
+      operationId,
+      sourceRevision: submittedRevision,
+      kind: isPreview ? 'preview' : 'render',
+      elapsedMillis: 0,
+      diagnostics: [],
+      logText: '',
+      ...over,
+    });
     const setRendering = (s: State, value: boolean) => {
       if (isPreview) {
         s.previewing = value;
@@ -291,13 +370,17 @@ export class CompileCoordinator {
         revision: this.ctx.getSourceRevision(),
       };
       const output = await this._render(renderArgs)({ now });
-      if (!isCurrent()) return; // a newer render/preview superseded this one
+      if (!isCurrent()) {
+        this.emitResult(operationCancelled(base())); // superseded
+        return; // a newer render/preview superseded this one
+      }
       if (output.revision !== undefined && output.revision !== this.ctx.getSourceRevision()) {
         // Sources changed since this render was requested — drop the stale result.
         // Unlike the supersession case above, no newer call owns this spinner
         // flag, so we must clear it ourselves or it stays stuck (e.g. after
         // newFile(), which bumps the revision without dispatching a new render).
         this.ctx.mutate((s) => setRendering(s, false));
+        this.emitResult(operationCancelled(base())); // revision stale-drop
         return;
       }
       is2D = output.outFile.name.endsWith('.svg') || output.outFile.name.endsWith('.dxf');
@@ -310,7 +393,7 @@ export class CompileCoordinator {
       const artifactId = newId();
       const sourceRevision = output.revision ?? this.ctx.getSourceRevision();
       const format = formatOfName(output.outFile.name);
-      this.ctx.artifacts.put(output.outFile, {
+      const artifactRef = {
         artifactId,
         operationId,
         sourceRevision,
@@ -318,7 +401,8 @@ export class CompileCoordinator {
         mediaType: mediaTypeForFormat(format),
         size: output.outFile.size,
         name: output.outFile.name,
-      });
+      };
+      this.ctx.artifacts.put(output.outFile, artifactRef);
       this.ctx.mutate((s) => {
         setRendering(s, false);
         s.error = undefined;
@@ -348,8 +432,22 @@ export class CompileCoordinator {
           this.ctx.host.playCompletionChime();
         }
       });
+      this.emitResult(
+        operationSuccess(
+          base({
+            sourceRevision,
+            elapsedMillis: output.elapsedMillis,
+            diagnostics: output.markers ?? [],
+            logText: output.logText,
+          }),
+          artifactRef,
+        ),
+      );
     } catch (err) {
-      if (!isCurrent()) return; // superseded — the newer call owns the spinner state
+      if (!isCurrent()) {
+        this.emitResult(operationCancelled(base())); // superseded
+        return; // superseded — the newer call owns the spinner state
+      }
       this.ctx.mutate((s) => {
         setRendering(s, false);
         if (!isExpectedJobCancellation(err)) {
@@ -359,6 +457,17 @@ export class CompileCoordinator {
           applyUserFacingError(s, err, isPreview ? 'preview' : 'render');
         }
       });
+      // A cancelled job is not a failure (priority preemption, etc.); everything
+      // else is a real error carrying the user-facing reason.
+      this.emitResult(
+        isExpectedJobCancellation(err)
+          ? operationCancelled(base())
+          : operationFailure(
+              base(),
+              OPERATION_FAILED,
+              normalizeOperationFailure(err, isPreview ? 'preview' : 'render').message,
+            ),
+      );
     }
     if (retryInOtherDim) {
       let is2D: boolean | undefined;

--- a/src/state/services/export-service.ts
+++ b/src/state/services/export-service.ts
@@ -3,9 +3,19 @@ import chroma from 'chroma-js';
 import { export3MF } from '../../io/export_3mf.ts';
 import { parseOff } from '../../io/import_off.ts';
 import { createRenderExportDelayable, type RenderOutput } from '../../runner/actions.ts';
-import { formatOfName, mediaTypeForFormat, newId } from '../../runner/compile-contract.ts';
+import {
+  formatOfName,
+  mediaTypeForFormat,
+  newId,
+  operationCancelled,
+  operationFailure,
+  operationSuccess,
+  OPERATION_FAILED,
+  type OperationBase,
+  type OperationResult,
+} from '../../runner/compile-contract.ts';
 import { isExpectedJobCancellation, type ProcessStreams } from '../../runner/openscad-runner.ts';
-import { isUserFacingOperationError } from '../../user-facing-errors.ts';
+import { isUserFacingOperationError, normalizeOperationFailure } from '../../user-facing-errors.ts';
 import { formatBytes, formatMillis, type AbortablePromise } from '../../utils.ts';
 import { applyUserFacingError } from '../apply-user-facing-error.ts';
 import type { ServiceContext } from './service-context.ts';
@@ -57,6 +67,17 @@ export class ExportService {
     });
   }
 
+  /** Route a terminal result to the optional sink, guarding the commit path: a
+   *  throwing sink must never corrupt committed state or double-emit (ADR 0008).
+   *  No-op when no sink is wired. */
+  private emitResult(result: OperationResult) {
+    try {
+      this.ctx.onOperationResult?.(result);
+    } catch (err) {
+      console.error('onOperationResult sink threw:', err);
+    }
+  }
+
   async export() {
     const { mutate, host } = this.ctx;
     // Claim the export token at entry — before any early return — so that EVERY
@@ -67,6 +88,21 @@ export class ExportService {
     const token = ++this._exportSeq;
     const isCurrent = () => this._exportSeq === token;
     const operationId = newId(); // one per export() invocation (ADR 0008)
+    // The status-independent fields for this export's single terminal result. The
+    // revision is captured at submit time so a cancelled result echoes the
+    // revision the op was submitted at; emits route through emitResult so a
+    // throwing sink cannot disturb the byte-identical commit (ADR 0008).
+    const submittedRevision = this.ctx.getSourceRevision();
+    const base = (over: Partial<OperationBase> = {}): OperationBase => ({
+      sessionId: this.ctx.sessionId,
+      operationId,
+      sourceRevision: submittedRevision,
+      kind: 'export',
+      elapsedMillis: 0,
+      diagnostics: [],
+      logText: '',
+      ...over,
+    });
     // Cancel any in-flight conversion render so a superseding export — including
     // a pass-through or picker branch that never calls renderExport — drops a
     // still-queued render and promptly settles the previous export's await with a
@@ -87,11 +123,26 @@ export class ExportService {
       if (normalPassThrough) {
         // Synchronous, so this export stays current through commit. Clear
         // `exporting` to take ownership from any async export it just superseded.
+        const passThrough = state.output;
         mutate((s) => {
           s.exporting = false;
           s.export = s.output;
         });
-        host.download(state.output.outFileURL, state.output.outFile.name);
+        host.download(passThrough.outFileURL, passThrough.outFile.name);
+        // Inherits the render's immutable artifact identity (same bytes, ADR 0008);
+        // the result is keyed to THIS export op.
+        const passFormat = formatOfName(passThrough.outFile.name);
+        this.emitResult(
+          operationSuccess(base(), {
+            artifactId: passThrough.artifactId,
+            operationId: passThrough.operationId,
+            sourceRevision: passThrough.sourceRevision,
+            format: passFormat,
+            mediaType: mediaTypeForFormat(passFormat),
+            size: passThrough.outFile.size,
+            name: passThrough.outFile.name,
+          }),
+        );
         return;
       }
     }
@@ -102,6 +153,9 @@ export class ExportService {
           s.exporting = false;
           s.view.extruderPickerVisibility = 'exporting';
         });
+        // No artifact produced — the real export is a second export() once the
+        // user picks colors; this minted op terminates as cancelled (ADR 0008).
+        this.emitResult(operationCancelled(base()));
         return;
       }
     }
@@ -181,7 +235,10 @@ export class ExportService {
 
       // A newer export superseded this one while its conversion ran; it owns the
       // exporting flag and will commit/download its own result. Drop this one.
-      if (!isCurrent()) return;
+      if (!isCurrent()) {
+        this.emitResult(operationCancelled(base()));
+        return;
+      }
 
       const outFileURL = host.createObjectURL(output.outFile);
       // One immutable artifact id, shared by state.export and the store entry, so
@@ -189,7 +246,7 @@ export class ExportService {
       const artifactId = newId();
       const sourceRevision = this.ctx.getSourceRevision();
       const format = formatOfName(output.outFile.name);
-      this.ctx.artifacts.put(output.outFile, {
+      const artifactRef = {
         artifactId,
         operationId,
         sourceRevision,
@@ -197,7 +254,8 @@ export class ExportService {
         mediaType: mediaTypeForFormat(format),
         size: output.outFile.size,
         name: output.outFile.name,
-      });
+      };
+      this.ctx.artifacts.put(output.outFile, artifactRef);
       mutate((s) => {
         s.exporting = false;
         if (s.export?.outFileURL?.startsWith('blob:') ?? false) {
@@ -215,13 +273,20 @@ export class ExportService {
         };
         host.download(s.export.outFileURL, output.outFile.name);
       });
+      this.emitResult(operationSuccess(base({ elapsedMillis: output.elapsedMillis }), artifactRef));
     } catch (err) {
       // A superseded export rejects with the delayable's cancellation; that is
       // expected supersession, not a failure — the newer export owns the spinner.
-      if (isExpectedJobCancellation(err)) return;
+      if (isExpectedJobCancellation(err)) {
+        this.emitResult(operationCancelled(base()));
+        return;
+      }
       // A stale export that fails for any other reason must not clobber the
       // current export's spinner or surface its obsolete error.
-      if (!isCurrent()) return;
+      if (!isCurrent()) {
+        this.emitResult(operationCancelled(base()));
+        return;
+      }
       mutate((s) => {
         s.exporting = false;
         if (!isUserFacingOperationError(err)) {
@@ -229,6 +294,13 @@ export class ExportService {
         }
         applyUserFacingError(s, err, 'export');
       });
+      this.emitResult(
+        operationFailure(
+          base(),
+          OPERATION_FAILED,
+          normalizeOperationFailure(err, 'export').message,
+        ),
+      );
     }
   }
 }

--- a/src/state/services/service-context.ts
+++ b/src/state/services/service-context.ts
@@ -1,4 +1,5 @@
 import type { ProjectFileSystem } from '../../fs/project-filesystem.ts';
+import type { OperationResult } from '../../runner/compile-contract.ts';
 import type { CompileBackend } from '../../runner/openscad-runner.ts';
 import type { ArtifactStore } from '../artifact-store.ts';
 import type { State } from '../app-state.ts';
@@ -35,4 +36,12 @@ export interface ServiceContext {
   readonly sessionId: string;
   /** This session's artifact store — bytes by immutable artifactId (ADR 0008). */
   readonly artifacts: ArtifactStore;
+  /**
+   * Optional sink for the one terminal `OperationResult` each operation produces
+   * (ADR 0008). When unset the emit short-circuits, so the deploy-critical commit
+   * path stays byte-identical; wiring it (e.g. to a Model event for the future MCP
+   * binding) is a one-line change. The UI commit and embed events are unchanged —
+   * they still derive from `FileOutput`; this is the correlated parallel record.
+   */
+  readonly onOperationResult?: (result: OperationResult) => void;
 }


### PR DESCRIPTION
## Layer-1 slice 4 of 4 — terminal OperationResult (completes the contract)

Builds a typed, correlated **terminal result** (`success | error | cancelled`) for every render, syntax check, and export. Each `operationId` now has exactly one terminal result, ready for the future MCP binding to correlate on (`operationId` ↔ tool-call id).

### Design (minimal-first)
- The result is routed through an **optional** `onOperationResult?` sink on `ServiceContext`, **left unwired in production**. JS optional-call short-circuits, so the deploy-critical commit path is byte-identical — no state mutation, object-URL revoke (#145), completion chime, export token (#125/#149), or revision stale-drop (#56/#99) was moved or altered. Wiring the sink (e.g. to a `Model` event) is a one-line change when a consumer lands. The UI/embed still derive from `FileOutput`; this is the parallel correlated record, not a commit rewrite.
- Pure builders `operationSuccess/operationFailure/operationCancelled` + `L1_PROTOCOL_VERSION` live in `compile-contract.ts`.

### Per-path classification
- **render()**: success on commit (carries the artifact ref); cancelled on supersession / revision stale-drop / expected job cancellation; error otherwise. The 2D/3D **dimension retry** mints its own `operationId` → distinct second result, never a double-emit.
- **checkSyntax()**: success (no artifact); cancelled on supersession/stale-drop; error on failure; `finally` does not emit.
- **export()**: pass-through → success inheriting the render's immutable artifact id; picker → cancelled; no-output → error; supersession/expected-cancellation → cancelled; conversion commit → success.

### Robustness (from adversarial review)
- Emits route through a guarded `emitResult()` so a **throwing sink can never re-enter** an operation's control flow — a good commit can't be clobbered into an error or double-terminated (latent the moment the sink is wired).
- The **submitted revision** is captured at op start, so a cancelled stale-drop echoes the revision the op was *submitted at*, matching `OperationResult.sourceRevision`'s documented meaning.
- `operationSuccess` omits the `artifact` key when absent (symmetry with cancelled).

### Tests
One-result-per-op length assertions on every path; cancelled-on-supersession (render + export); distinct `operationId`s on the dimension retry; error classification; a throwing-sink isolation test (commit survives, no error, no reject); and pure builder coverage. **488 → 497 unit tests.**

### Verification
- `npm run verify` green (format, lint, typecheck, unit w/ coverage, assembly, build, budgets, publish-archive)
- Existing coordinator/export suites unchanged and green — the byte-identical regression oracle.

Adversarially reviewed; both SHOULD-FIX items (throwing-sink isolation, submitted-revision fidelity) addressed before this PR. Refs ADR 0008.