### PR TITLE
refactor(state): one shared OpenScadValue type + validator (#122)

### DIFF
--- a/docs/EMBED.md
+++ b/docs/EMBED.md
@@ -41,7 +41,7 @@ Every inbound message must include `protocolVersion: 2`. A `requestId` is option
 | Type          | Payload (in addition to `protocolVersion`, optional `requestId`) | Description                                                                   |
 | ------------- | ---------------------------------------------------------------- | ----------------------------------------------------------------------------- |
 | `setModel`    | `{ type: 'setModel', source: string }`                           | Replace the current model with raw source text                                |
-| `setVar`      | `{ type: 'setVar', name: string, value: unknown }`               | Set one customizer variable                                                   |
+| `setVar`      | `{ type: 'setVar', name: string, value: OpenScadValue }`         | Set one customizer variable                                                   |
 | `getVars`     | `{ type: 'getVars' }`                                            | Request the current effective variable map                                    |
 | `getArtifact` | `{ type: 'getArtifact', artifactId? }`                           | Request artifact bytes — the latest render output, or a specific `artifactId` |
 
@@ -49,6 +49,7 @@ Limits (oversized messages are rejected with a `too-large` error):
 
 - `setModel.source` ≤ 5 MiB
 - `setVar.name` ≤ 256 chars; `setVar.value` ≤ 64 KiB JSON-encoded
+- `setVar.value` must be an **OpenSCAD value**: a string, a finite number, a boolean, or a (nested, ≤ 16 deep) array of those. Objects, `null`, and `NaN`/`Infinity` are rejected with `invalid-payload` — OpenSCAD cannot represent them, so they are refused at the boundary rather than failing mid-render.
 
 Notes:
 

--- a/src/__tests__/openscad-value.test.ts
+++ b/src/__tests__/openscad-value.test.ts
@@ -1,0 +1,134 @@
+import { describe, expect, it } from 'vitest';
+
+import { formatValue } from '../runner/actions.ts';
+import {
+  coerceUrlVar,
+  coerceUrlVars,
+  isOpenScadValue,
+  MAX_VALUE_DEPTH,
+} from '../openscad-value.ts';
+
+describe('isOpenScadValue', () => {
+  it('accepts primitives and nested vectors of them', () => {
+    expect(isOpenScadValue('hello')).toBe(true);
+    expect(isOpenScadValue(3.14)).toBe(true);
+    expect(isOpenScadValue(-7)).toBe(true);
+    expect(isOpenScadValue(0)).toBe(true);
+    expect(isOpenScadValue(true)).toBe(true);
+    expect(isOpenScadValue([1, 2, 3])).toBe(true);
+    expect(
+      isOpenScadValue([
+        [1, 2],
+        [3, 4],
+      ]),
+    ).toBe(true);
+    expect(isOpenScadValue(['a', 1, true, [2]])).toBe(true);
+    expect(isOpenScadValue([])).toBe(true);
+  });
+
+  it('rejects objects, null/undefined, and non-finite numbers', () => {
+    expect(isOpenScadValue({ a: 1 })).toBe(false); // OpenSCAD has no dict type
+    expect(isOpenScadValue(null)).toBe(false);
+    expect(isOpenScadValue(undefined)).toBe(false);
+    expect(isOpenScadValue(NaN)).toBe(false);
+    expect(isOpenScadValue(Infinity)).toBe(false);
+    expect(isOpenScadValue(-Infinity)).toBe(false);
+    expect(isOpenScadValue(() => 1)).toBe(false);
+    expect(isOpenScadValue(Symbol('x'))).toBe(false);
+    expect(isOpenScadValue(10n)).toBe(false);
+  });
+
+  it('rejects an object or non-finite nested inside a vector', () => {
+    expect(isOpenScadValue([1, { a: 1 }])).toBe(false);
+    expect(isOpenScadValue([1, NaN, 3])).toBe(false);
+    expect(isOpenScadValue([1, [2, null]])).toBe(false);
+  });
+
+  it('bounds array nesting at MAX_VALUE_DEPTH', () => {
+    const nest = (depth: number): unknown => (depth === 0 ? 1 : [nest(depth - 1)]);
+    expect(isOpenScadValue(nest(MAX_VALUE_DEPTH))).toBe(true);
+    expect(isOpenScadValue(nest(MAX_VALUE_DEPTH + 1))).toBe(false);
+  });
+});
+
+describe('isOpenScadValue agrees with the args builder (no divergence)', () => {
+  // The refactor's core guarantee: a value accepted by the boundary validator is
+  // exactly a value the `-D` formatter can render, and vice versa. Cross-check the
+  // two against a battery so they can never drift apart.
+  const formatThrows = (v: unknown) => {
+    try {
+      formatValue(v);
+      return false;
+    } catch {
+      return true;
+    }
+  };
+  const nest = (depth: number, leaf: unknown): unknown =>
+    depth === 0 ? leaf : [nest(depth - 1, leaf)];
+
+  const battery: unknown[] = [
+    'a',
+    '',
+    0,
+    -3.14,
+    1e308,
+    true,
+    false,
+    [1, 2, 3],
+    [['a', 1], [true]],
+    [],
+    nest(MAX_VALUE_DEPTH, 1),
+    nest(MAX_VALUE_DEPTH, []), // empty array exactly at the depth limit (the edge)
+    nest(MAX_VALUE_DEPTH + 1, 1),
+    {},
+    { a: 1 },
+    null,
+    undefined,
+    NaN,
+    Infinity,
+    -Infinity,
+    () => 1,
+    [1, {}],
+    [1, NaN],
+  ];
+
+  it('isOpenScadValue(v) === !formatValue-throws(v) for every battery value', () => {
+    for (const v of battery) {
+      expect(isOpenScadValue(v)).toBe(!formatThrows(v));
+    }
+  });
+});
+
+describe('coerceUrlVar', () => {
+  it('maps true/false strings to booleans', () => {
+    expect(coerceUrlVar('true')).toBe(true);
+    expect(coerceUrlVar('false')).toBe(false);
+  });
+
+  it('maps finite numeric strings to numbers', () => {
+    expect(coerceUrlVar('3.14')).toBe(3.14);
+    expect(coerceUrlVar('-7')).toBe(-7);
+    expect(coerceUrlVar('0')).toBe(0);
+  });
+
+  it('keeps non-finite and non-numeric strings as strings (the args-builder-safe choice)', () => {
+    // 'Infinity'/'NaN' must NOT become numbers — the args builder rejects those.
+    expect(coerceUrlVar('Infinity')).toBe('Infinity');
+    expect(coerceUrlVar('NaN')).toBe('NaN');
+    expect(coerceUrlVar('hello')).toBe('hello');
+    expect(coerceUrlVar('')).toBe(''); // empty stays empty string, not 0
+    expect(coerceUrlVar('  ')).toBe('  ');
+  });
+
+  it('every coerced value is a valid OpenScadValue', () => {
+    for (const raw of ['true', 'false', '3.14', 'Infinity', 'NaN', '', 'hello']) {
+      expect(isOpenScadValue(coerceUrlVar(raw))).toBe(true);
+    }
+  });
+});
+
+describe('coerceUrlVars', () => {
+  it('coerces each entry of a flat string map', () => {
+    expect(coerceUrlVars({ a: 'true', b: '2', c: 'x' })).toEqual({ a: true, b: 2, c: 'x' });
+  });
+});

--- a/src/components/elements/osc-customizer-panel.ts
+++ b/src/components/elements/osc-customizer-panel.ts
@@ -5,6 +5,7 @@ import { resolveSession } from '../../state/session-context.ts';
 import type { State } from '../../state/app-state.ts';
 import type { Model } from '../../state/model.ts';
 import type { Parameter, ParameterOption } from '../../state/customizer-types.ts';
+import type { OpenScadValue } from '../../openscad-value.ts';
 
 @customElement('osc-customizer-panel')
 export class OscCustomizerPanel extends LitElement {
@@ -122,8 +123,7 @@ export class OscCustomizerPanel extends LitElement {
     this._model?.removeEventListener('state', this._onState);
   }
 
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  private _handleChange(name: string, value: any) {
+  private _handleChange(name: string, value: OpenScadValue) {
     this._model.setVar(name, value);
   }
 

--- a/src/components/elements/osc-customizer-shell.ts
+++ b/src/components/elements/osc-customizer-shell.ts
@@ -9,19 +9,7 @@ import type { State } from '../../state/app-state.ts';
 import type { Model } from '../../state/model.ts';
 import './osc-viewer-panel.ts';
 import './osc-customizer-panel.ts';
-
-function coerceUrlVars(vars: Record<string, string>): Record<string, unknown> {
-  const result: Record<string, unknown> = {};
-  for (const [k, v] of Object.entries(vars)) {
-    if (v === 'true') result[k] = true;
-    else if (v === 'false') result[k] = false;
-    else {
-      const n = Number(v);
-      result[k] = v.trim() !== '' && !isNaN(n) ? n : v;
-    }
-  }
-  return result;
-}
+import { coerceUrlVars } from '../../openscad-value.ts';
 
 function buildEditorUrl(): string {
   const url = new URL(window.location.href);

--- a/src/components/elements/osc-embed-shell.ts
+++ b/src/components/elements/osc-embed-shell.ts
@@ -12,6 +12,7 @@ import './osc-viewer-panel.ts';
 import './osc-customizer-panel.ts';
 import { validateInbound, outbound, isTrustedOrigin } from '../../embed/protocol.ts';
 import { outputArtifactRef } from '../../embed/artifact-event.ts';
+import { coerceUrlVars } from '../../openscad-value.ts';
 
 // ---------------------------------------------------------------------------
 // postMessage protocol — see src/embed/protocol.ts and docs/EMBED.md
@@ -26,19 +27,6 @@ function notifyHost(
   if (window.parent !== window) {
     window.parent.postMessage(outbound(type, payload), targetOrigin, transfer ?? []);
   }
-}
-
-function coerceUrlVars(vars: Record<string, string>): Record<string, unknown> {
-  const result: Record<string, unknown> = {};
-  for (const [k, v] of Object.entries(vars)) {
-    if (v === 'true') result[k] = true;
-    else if (v === 'false') result[k] = false;
-    else {
-      const n = Number(v);
-      result[k] = v.trim() !== '' && !isNaN(n) ? n : v;
-    }
-  }
-  return result;
 }
 
 function getVarsSnapshot(st: State): Record<string, unknown> {
@@ -178,7 +166,7 @@ export class OscEmbedShell extends LitElement {
         this._notifyHost('ack', ack);
         break;
       case 'setVar':
-        this._model.setVar(msg.name, msg.value as never);
+        this._model.setVar(msg.name, msg.value);
         this._notifyHost('ack', ack);
         break;
       case 'getVars':

--- a/src/embed/__tests__/protocol.test.ts
+++ b/src/embed/__tests__/protocol.test.ts
@@ -153,14 +153,30 @@ describe('validateInbound — setVar', () => {
     ).toMatchObject({ ok: false, code: 'invalid-payload' });
   });
 
-  it('accepts plain nested JSON values (arrays/objects of primitives)', () => {
-    const r = validateInbound({
-      protocolVersion: V,
-      type: 'setVar',
-      name: 'vec',
-      value: { a: [1, 2, 3], b: { c: true, d: 'x' }, e: null },
-    });
-    expect(r).toMatchObject({ ok: true });
+  it('accepts OpenSCAD values: primitives and (nested) vectors of them', () => {
+    for (const value of [42, -3.14, true, 'hello', [1, 2, 3], [['a', 1], [true]]]) {
+      expect(
+        validateInbound({ protocolVersion: V, type: 'setVar', name: 'v', value }),
+      ).toMatchObject({ ok: true, message: { type: 'setVar', name: 'v', value } });
+    }
+  });
+
+  it('rejects objects, null, and non-finite numbers at the boundary (not deep in the render)', () => {
+    // OpenSCAD has no dict type and the args builder rejects these, so they must be
+    // refused HERE rather than accepted and failing mid-render (the prior bug).
+    for (const value of [
+      { a: 1 },
+      { a: [1, 2, 3] },
+      null,
+      NaN,
+      Infinity,
+      [1, { a: 1 }],
+      [1, NaN],
+    ]) {
+      expect(
+        validateInbound({ protocolVersion: V, type: 'setVar', name: 'n', value }),
+      ).toMatchObject({ ok: false, code: 'invalid-payload' });
+    }
   });
 });
 

--- a/src/embed/protocol.ts
+++ b/src/embed/protocol.ts
@@ -8,12 +8,8 @@
 // envelope/validation primitives live in `src/protocol/envelope.ts` (ADR 0005);
 // this module is one binding over that shared core.
 
-import {
-  isPlainJsonValue,
-  isRecord,
-  stampOutbound,
-  type ProtocolErrorCode,
-} from '../protocol/envelope.ts';
+import { isRecord, stampOutbound, type ProtocolErrorCode } from '../protocol/envelope.ts';
+import { isOpenScadValue, type OpenScadValue } from '../openscad-value.ts';
 
 // Origin checking is generic; re-export it so embed consumers keep one import.
 export { isTrustedOrigin } from '../protocol/envelope.ts';
@@ -34,7 +30,7 @@ export const MAX_VAR_VALUE_LENGTH = 64 * 1024; // setVar JSON-encoded value
 
 export type InboundMessage =
   | { type: 'setModel'; source: string; requestId?: string }
-  | { type: 'setVar'; name: string; value: unknown; requestId?: string }
+  | { type: 'setVar'; name: string; value: OpenScadValue; requestId?: string }
   | { type: 'getVars'; requestId?: string }
   | { type: 'getArtifact'; requestId?: string; artifactId?: string };
 
@@ -96,31 +92,26 @@ export function validateInbound(data: unknown): ValidationResult {
       if (data.name.length > MAX_VAR_NAME_LENGTH) {
         return { ok: false, code: 'too-large', reason: 'name exceeds size limit', requestId };
       }
-      const value = data.value ?? null;
-      let encoded: string | undefined;
-      try {
-        encoded = JSON.stringify(value);
-      } catch {
-        encoded = undefined; // circular reference
-      }
-      // `encoded` is `undefined` for functions/symbols/circular values; an
-      // exotic but cloneable type (ArrayBuffer, Map, …) stringifies to a tiny
-      // string while carrying a large payload, so also require a plain JSON
-      // shape rather than trusting the encoded length alone.
-      if (typeof encoded !== 'string' || !isPlainJsonValue(value)) {
+      const value = data.value;
+      // Reject anything that is not a valid OpenSCAD value (object, null, NaN/
+      // Infinity, exotic) HERE, at the boundary, rather than letting it pass and
+      // then throw deeper in the args builder (the prior divergence). This is the
+      // same predicate the URL coercion and `-D` formatter use.
+      if (!isOpenScadValue(value)) {
         return {
           ok: false,
           code: 'invalid-payload',
-          reason: 'value must be a JSON value',
+          reason: 'value must be an OpenSCAD value (string, number, boolean, or array of those)',
           requestId,
         };
       }
-      if (encoded.length > MAX_VAR_VALUE_LENGTH) {
+      // A valid value can still be enormous (a long string or big vector); bound it.
+      if (JSON.stringify(value).length > MAX_VAR_VALUE_LENGTH) {
         return { ok: false, code: 'too-large', reason: 'value exceeds size limit', requestId };
       }
       return {
         ok: true,
-        message: { type: 'setVar', name: data.name, value: data.value, requestId },
+        message: { type: 'setVar', name: data.name, value, requestId },
       };
     }
     case 'getVars':

--- a/src/openscad-value.ts
+++ b/src/openscad-value.ts
@@ -1,0 +1,57 @@
+// The canonical type of an OpenSCAD customizer/variable value — the things that
+// flow into `params.vars` and become `-D name=value` args. OpenSCAD accepts
+// primitives and (nested) vectors of them; it has no dictionary type, so objects
+// are excluded, as are `null`/`undefined` and non-finite numbers.
+//
+// One validator (`isOpenScadValue`) is shared by the embed `setVar` boundary, the
+// URL coercion, and the args builder, so a value accepted at one edge can never be
+// rejected deeper in the render pipeline — the divergence that previously let an
+// object or `Infinity` pass `setVar`/URL coercion and then throw at compile time.
+
+export type OpenScadValue = string | number | boolean | OpenScadValue[];
+
+/** Max array nesting accepted; shared with the args builder's guard. */
+export const MAX_VALUE_DEPTH = 16;
+
+/**
+ * Narrow an untrusted value to `OpenScadValue`: a string, a finite number, a
+ * boolean, or an array (≤ MAX_VALUE_DEPTH deep) of those. Rejects objects,
+ * `null`/`undefined`, `NaN`/`Infinity`, functions, and other exotics.
+ */
+export function isOpenScadValue(value: unknown, depth = 0): value is OpenScadValue {
+  // Depth-guard at the top, mirroring the args builder's `formatValue` exactly, so
+  // the two never disagree on a borderline value (the whole point of one validator).
+  if (depth > MAX_VALUE_DEPTH) return false;
+  switch (typeof value) {
+    case 'string':
+    case 'boolean':
+      return true;
+    case 'number':
+      return Number.isFinite(value);
+    case 'object':
+      // `typeof null === 'object'`, but `Array.isArray(null)` is false → rejected.
+      return Array.isArray(value) && value.every((item) => isOpenScadValue(item, depth + 1));
+    default:
+      return false;
+  }
+}
+
+/**
+ * Parse one URL/query string into an `OpenScadValue`: `'true'`/`'false'` become
+ * booleans, a non-empty string that parses to a FINITE number becomes that number
+ * (so `'Infinity'`/`'NaN'` stay strings rather than producing a value the args
+ * builder would reject), everything else stays a string.
+ */
+export function coerceUrlVar(raw: string): OpenScadValue {
+  if (raw === 'true') return true;
+  if (raw === 'false') return false;
+  const n = Number(raw);
+  return raw.trim() !== '' && Number.isFinite(n) ? n : raw;
+}
+
+/** Coerce a flat string→string URL var map to OpenSCAD values (see `coerceUrlVar`). */
+export function coerceUrlVars(vars: Record<string, string>): Record<string, OpenScadValue> {
+  const out: Record<string, OpenScadValue> = {};
+  for (const [key, raw] of Object.entries(vars)) out[key] = coerceUrlVar(raw);
+  return out;
+}

--- a/src/runner/actions.ts
+++ b/src/runner/actions.ts
@@ -1,6 +1,7 @@
 // Portions of this file are Copyright 2021 Google LLC, and licensed under GPL2+. See COPYING.
 
 import type { Diagnostic } from '../diagnostics.ts';
+import { MAX_VALUE_DEPTH, type OpenScadValue } from '../openscad-value.ts';
 import {
   ProcessStreams,
   isExpectedJobCancellation,
@@ -102,8 +103,7 @@ export type RenderOutput = {
 export type RenderArgs = {
   scadPath: string;
   sources: WireSource[];
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  vars?: { [name: string]: any };
+  vars?: Record<string, OpenScadValue>;
   features?: string[];
   extraArgs?: string[];
   isPreview: boolean;
@@ -119,9 +119,6 @@ export type RenderArgs = {
    */
   priority?: JobPriority;
 };
-
-/** Maximum array-nesting depth accepted for a customizer value. */
-const MAX_VALUE_DEPTH = 16;
 
 /**
  * Render an OpenSCAD customizer value into a `-D` literal. Only the value shapes
@@ -164,8 +161,7 @@ export interface OpenScadArgsRequest {
   /** Compute backend; omit for syntax/parameter passes that don't render geometry. */
   backend?: 'manifold' | 'cgal';
   /** Customizer variable overrides, emitted as `-D` literals. */
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  vars?: { [name: string]: any };
+  vars?: Record<string, OpenScadValue>;
   /** Experimental feature flags, emitted as `--enable=`. */
   features?: string[];
   /** Extra raw args appended verbatim. */

--- a/src/state/app-state.ts
+++ b/src/state/app-state.ts
@@ -1,6 +1,7 @@
 // Portions of this file are Copyright 2021 Google LLC, and licensed under GPL2+. See COPYING.
 
 import type { Diagnostic } from '../diagnostics.ts';
+import type { OpenScadValue } from '../openscad-value.ts';
 import { ParameterSet } from './customizer-types.ts';
 import { VALID_EXPORT_FORMATS_2D, VALID_EXPORT_FORMATS_3D } from './formats.ts';
 import type { SerializableSource } from './project-source.ts';
@@ -39,8 +40,7 @@ export interface State {
   params: {
     activePath: string;
     sources: SerializableSource[];
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    vars?: { [name: string]: any };
+    vars?: Record<string, OpenScadValue>;
     features: string[];
     exportFormat2D: keyof typeof VALID_EXPORT_FORMATS_2D;
     exportFormat3D: keyof typeof VALID_EXPORT_FORMATS_3D;

--- a/src/state/fragment-state.ts
+++ b/src/state/fragment-state.ts
@@ -1,6 +1,7 @@
 // Portions of this file are Copyright 2021 Google LLC, and licensed under GPL2+. See COPYING.
 
 import { resolveExternalSourceUrl } from '../external-source.ts';
+import { isOpenScadValue, type OpenScadValue } from '../openscad-value.ts';
 import { State } from './app-state.ts';
 import { VALID_EXPORT_FORMATS_2D, VALID_EXPORT_FORMATS_3D } from './formats.ts';
 import { validateArray, validateBoolean, validateString, validateStringEnum } from '../utils.ts';
@@ -9,11 +10,14 @@ import { createInitialState, defaultModelColor, defaultSourcePath } from './init
 
 function validateVars(v: unknown): State['params']['vars'] {
   if (v == null || typeof v !== 'object' || Array.isArray(v)) return undefined;
-  return Object.fromEntries(
-    Object.entries(v as Record<string, unknown>).filter(
-      ([k]) => typeof k === 'string' && k.length > 0,
-    ),
-  );
+  // Keep only well-formed entries: a non-empty key and an OpenSCAD-valid value, so
+  // a corrupt/hostile fragment can't inject a value (object, Infinity, …) that the
+  // args builder would later reject mid-render.
+  const out: Record<string, OpenScadValue> = {};
+  for (const [k, value] of Object.entries(v as Record<string, unknown>)) {
+    if (k.length > 0 && isOpenScadValue(value)) out[k] = value;
+  }
+  return out;
 }
 
 // Preserve tri-state: an absent boolean stays `undefined` (its "use the default"

--- a/src/state/model.ts
+++ b/src/state/model.ts
@@ -7,6 +7,7 @@ import {
   StatePersister,
 } from './app-state.ts';
 import { VALID_EXPORT_FORMATS_2D, VALID_EXPORT_FORMATS_3D } from './formats.ts';
+import type { OpenScadValue } from '../openscad-value.ts';
 import { bubbleUpDeepMutations } from './deep-mutate.ts';
 import { openLocalFile, saveViaHandle } from '../fs/filesystem.ts';
 import { ProjectFileSystem } from '../fs/project-filesystem.ts';
@@ -245,8 +246,7 @@ export class Model extends EventTarget {
       this.render({ isPreview: true, now: true });
     }
   }
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  setVar(name: string, value: any) {
+  setVar(name: string, value: OpenScadValue) {
     this.mutate((s) => (s.params.vars = { ...(s.params.vars ?? {}), [name]: value }));
     this.render({ isPreview: true, now: false });
   }


### PR DESCRIPTION
## #122 — unify customizer-value validation

Replaces the scattered, **divergent** value validation/coercion across state, URL, embed, and the args builder with one `OpenScadValue` type + `isOpenScadValue` validator.

`OpenScadValue = string | number | boolean | OpenScadValue[]` — no objects (OpenSCAD has no dict), no `null`, finite numbers only, nesting ≤ 16.

### Divergences fixed (each was an accept-here-but-throw-there bug)
1. **Objects/null**: embed `setVar` used `isPlainJsonValue` (accepts objects + null); the `-D` formatter throws on them → `setVar` succeeded, then the render failed. Now rejected at the boundary with `invalid-payload`.
2. **`Infinity`**: `coerceUrlVars` used `!isNaN(n)`, so `?x=Infinity` became the number `Infinity`, which the args builder rejects. The shared `coerceUrlVar` uses `Number.isFinite` → `'Infinity'`/`'NaN'` stay strings.
3. **`undefined`/`null`** likewise.

### What changed
- **New `src/openscad-value.ts`**: the type, `isOpenScadValue` (depth-guarded to mirror the args builder *exactly*), and `coerceUrlVar(s)` (dedups the two byte-identical copies in the embed + customizer shells, and fixes the `Infinity` bug at both).
- **Typed the value path end-to-end**: `app-state.params.vars` (`any` → `Record<string, OpenScadValue>`), `model.setVar`, `RenderArgs`/`OpenScadArgsRequest` vars, customizer panel `_handleChange`; dropped the now-unneeded `as never` cast. `MAX_VALUE_DEPTH` deduped into the shared module.
- **`fragment-state.validateVars`** now drops entries that aren't OpenSCAD-valid, so a corrupt/hostile shared link can't inject a value that breaks render.
- **Embed stays protocol v2** (no version bump): the tightening only rejects values that already failed at render. `docs/EMBED.md` updated.

### Tests
- `openscad-value.test.ts`: accept/reject matrix, depth boundary, `coerceUrlVar` cases, and a **cross-check that `isOpenScadValue(v) === !formatValue-throws(v)` for a battery** (incl. the empty-array-at-depth-16 edge) — proving the boundary validator and the args builder can never drift apart.
- Embed protocol tests updated: objects/`null`/`NaN`/`Infinity` now rejected; primitives + nested vectors accepted.

### Verification
- `npm run verify` green (format, lint, typecheck, unit w/ coverage, assembly, build, budgets, publish-archive).

Adversarially reviewed: the one finding (a depth off-by-one, in the *safe* — stricter — direction) was fixed and locked with the cross-check test before this PR; no accepted-then-throws regression. Refs #122.