### PR TITLE
refactor(state): shared durable-state validator + schema version (#122)

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -107,7 +107,7 @@ window.addEventListener('load', async () => {
 
   if (isInStandaloneMode()) {
     const bfs: FS = getBrowserFS().BFSRequire('fs');
-    persistedState = readPersistedState(bfs);
+    persistedState = readPersistedState(bfs, window.location.href);
     statePersister = {
       set: async (state) => writePersistedState(bfs, state),
     };

--- a/src/state/__tests__/durable-state.test.ts
+++ b/src/state/__tests__/durable-state.test.ts
@@ -1,0 +1,124 @@
+import { describe, expect, it } from 'vitest';
+
+import { DURABLE_SCHEMA_VERSION, validateDurableState } from '../durable-state.ts';
+
+const BASE = 'http://localhost/';
+
+// A minimal well-formed durable blob; spread overrides onto params/view per test.
+function blob(
+  over: { params?: object; view?: object; preview?: unknown; schemaVersion?: unknown } = {},
+) {
+  return {
+    schemaVersion: DURABLE_SCHEMA_VERSION,
+    params: {
+      activePath: '/home/main.scad',
+      sources: [{ path: '/home/main.scad', content: 'cube();' }],
+      features: ['lazy-union'],
+      exportFormat2D: 'svg',
+      exportFormat3D: 'stl',
+      ...over.params,
+    },
+    view: {
+      layout: { mode: 'multi', editor: true, viewer: true, customizer: false },
+      color: '#abcdef',
+      ...over.view,
+    },
+    ...('preview' in over ? { preview: over.preview } : {}),
+    ...('schemaVersion' in over ? { schemaVersion: over.schemaVersion } : {}),
+  };
+}
+
+describe('validateDurableState', () => {
+  it('passes a well-formed blob through, classifying flat sources into the union', () => {
+    const state = validateDurableState(blob(), { baseUrl: BASE });
+    expect(state.params.activePath).toBe('/home/main.scad');
+    expect(state.params.sources).toEqual([
+      { kind: 'text', path: '/home/main.scad', content: 'cube();' },
+    ]);
+    expect(state.view.layout.mode).toBe('multi');
+    expect(state.view.color).toBe('#abcdef');
+  });
+
+  it('drops vars that are not OpenSCAD-valid, keeping the valid ones', () => {
+    const state = validateDurableState(
+      blob({ params: { vars: { good: 3, bad: { a: 1 }, inf: Infinity, vec: [1, 2] } } }),
+      { baseUrl: BASE },
+    );
+    expect(state.params.vars).toEqual({ good: 3, vec: [1, 2] });
+  });
+
+  it('defaults an unknown enum and rejects an unknown backend', () => {
+    const state = validateDurableState(
+      blob({ params: { exportFormat3D: 'not-a-format', backend: 'wgpu' } }),
+      { baseUrl: BASE },
+    );
+    expect(state.params.exportFormat3D).toBe('stl'); // fell back to the default
+    expect(state.params.backend).toBeUndefined(); // unknown backend dropped
+  });
+
+  it('drops a malformed camera but keeps a well-formed one', () => {
+    const bad = validateDurableState(blob({ view: { camera: { position: [1, 2] } } }), {
+      baseUrl: BASE,
+    });
+    expect(bad.view.camera).toBeUndefined();
+
+    const ok = validateDurableState(
+      blob({ view: { camera: { position: [1, 2, 3], target: [0, 0, 0], zoom: 1.5 } } }),
+      { baseUrl: BASE },
+    );
+    expect(ok.view.camera).toEqual({ position: [1, 2, 3], target: [0, 0, 0], zoom: 1.5 });
+  });
+
+  it('preserves the autoCompile tri-state (absent stays undefined, not false)', () => {
+    expect(validateDurableState(blob(), { baseUrl: BASE }).params.autoCompile).toBeUndefined();
+    expect(
+      validateDurableState(blob({ params: { autoCompile: false } }), { baseUrl: BASE }).params
+        .autoCompile,
+    ).toBe(false);
+  });
+
+  it('reads legacy data with no schemaVersion (treated as the same shape)', () => {
+    const legacy = blob({ schemaVersion: undefined });
+    delete (legacy as { schemaVersion?: unknown }).schemaVersion;
+    const state = validateDurableState(legacy, { baseUrl: BASE });
+    expect(state.params.sources).toHaveLength(1);
+    expect(state.view.layout.mode).toBe('multi');
+  });
+
+  it('reads a newer schemaVersion best-effort rather than discarding it', () => {
+    const state = validateDurableState(blob({ schemaVersion: DURABLE_SCHEMA_VERSION + 5 }), {
+      baseUrl: BASE,
+    });
+    expect(state.params.activePath).toBe('/home/main.scad');
+  });
+
+  it('throws on an irrecoverable blob (no layout mode) so callers fall back to defaults', () => {
+    expect(() => validateDurableState({ params: {}, view: {} }, { baseUrl: BASE })).toThrow();
+    expect(() => validateDurableState({}, { baseUrl: BASE })).toThrow();
+  });
+
+  it('drops one out-of-policy source URL without discarding its valid siblings', () => {
+    // A cross-origin remote (e.g. saved before an origin change) must NOT take the
+    // whole durable state down with it — it degrades to a path-only source.
+    const state = validateDurableState(
+      blob({
+        params: {
+          sources: [
+            { path: '/home/main.scad', content: 'cube();' },
+            { path: '/home/remote.scad', url: 'https://evil.example.com/x.scad' },
+          ],
+        },
+      }),
+      { baseUrl: BASE },
+    );
+    expect(state.params.sources).toHaveLength(2);
+    // The valid text sibling survives intact.
+    expect(state.params.sources[0]).toEqual({
+      kind: 'text',
+      path: '/home/main.scad',
+      content: 'cube();',
+    });
+    // The disallowed remote lost its URL (degraded), not the whole state.
+    expect(JSON.stringify(state.params.sources[1])).not.toContain('evil.example.com');
+  });
+});

--- a/src/state/__tests__/persisted-state-compat.test.ts
+++ b/src/state/__tests__/persisted-state-compat.test.ts
@@ -58,7 +58,7 @@ describe('persisted-state on-disk compatibility (#56)', () => {
     const { fs } = fakeFs();
 
     writePersistedState(fs, baseState(sources));
-    const restored = readPersistedState(fs);
+    const restored = readPersistedState(fs, 'http://localhost/');
 
     expect(restored?.params.sources).toEqual(sources);
   });
@@ -84,7 +84,7 @@ describe('persisted-state on-disk compatibility (#56)', () => {
     });
     const { fs } = fakeFs({ [STATE_PATH]: legacy });
 
-    const restored = readPersistedState(fs);
+    const restored = readPersistedState(fs, 'http://localhost/');
 
     // The flat on-disk sources are classified into the typed union on read —
     // the load-bearing normalization for existing standalone users.
@@ -92,6 +92,22 @@ describe('persisted-state on-disk compatibility (#56)', () => {
       { kind: 'text', path: '/home/playground.scad', content: 'sphere(5);' },
       { kind: 'remote', path: '/home/remote.scad', url: 'http://localhost/remote.scad' },
     ]);
+  });
+
+  it('round-trips valid view flags + camera through the validating read path', () => {
+    const { fs } = fakeFs();
+    const state = baseState([{ kind: 'text', path: '/home/a.scad', content: 'cube();' }]);
+    state.view.showAxes = false;
+    state.view.lineNumbers = true;
+    state.view.color = '#123456';
+    state.view.camera = { position: [1, 2, 3], target: [0, 0, 0], zoom: 1.25 };
+    writePersistedState(fs, state);
+
+    const restored = readPersistedState(fs, 'http://localhost/');
+    expect(restored?.view.showAxes).toBe(false);
+    expect(restored?.view.lineNumbers).toBe(true);
+    expect(restored?.view.color).toBe('#123456');
+    expect(restored?.view.camera).toEqual({ position: [1, 2, 3], target: [0, 0, 0], zoom: 1.25 });
   });
 
   it('writes the durable slice as flat JSON with no discriminant keys', () => {
@@ -102,7 +118,8 @@ describe('persisted-state on-disk compatibility (#56)', () => {
     );
 
     const onDisk = JSON.parse(files.get(STATE_PATH)!);
-    expect(Object.keys(onDisk).sort()).toEqual(['params', 'preview', 'view']);
+    expect(Object.keys(onDisk).sort()).toEqual(['params', 'preview', 'schemaVersion', 'view']);
+    expect(onDisk.schemaVersion).toBe(1);
     expect(onDisk.params.sources).toEqual([{ path: '/home/a.scad', content: 'cube();' }]);
     // No `kind` discriminant must leak onto disk.
     expect(JSON.stringify(onDisk)).not.toContain('"kind"');
@@ -124,7 +141,32 @@ describe('persisted-state on-disk compatibility (#56)', () => {
   });
 
   it('returns null when state.json is missing or corrupt', () => {
-    expect(readPersistedState(fakeFs().fs)).toBeNull();
-    expect(readPersistedState(fakeFs({ [STATE_PATH]: 'not json{' }).fs)).toBeNull();
+    expect(readPersistedState(fakeFs().fs, 'http://localhost/')).toBeNull();
+    expect(
+      readPersistedState(fakeFs({ [STATE_PATH]: 'not json{' }).fs, 'http://localhost/'),
+    ).toBeNull();
+  });
+
+  it('sanitizes a tampered/corrupt on-disk state on read (shared validator)', () => {
+    // A state.json with an object-valued var, an unknown backend, and a bad enum —
+    // the persisted path used to trust these verbatim; now it self-heals like the
+    // fragment path does, instead of injecting data that breaks the app.
+    const tampered = JSON.stringify({
+      params: {
+        activePath: '/home/playground.scad',
+        sources: [{ path: '/home/playground.scad', content: 'cube();' }],
+        features: ['lazy-union'],
+        exportFormat2D: 'svg',
+        exportFormat3D: 'bogus',
+        backend: 'wgpu',
+        vars: { good: 2, bad: { nested: 1 } },
+      },
+      view: { layout: { mode: 'multi', editor: true, viewer: true, customizer: false } },
+    });
+    const restored = readPersistedState(fakeFs({ [STATE_PATH]: tampered }).fs, 'http://localhost/');
+
+    expect(restored?.params.exportFormat3D).toBe('stl'); // bad enum → default
+    expect(restored?.params.backend).toBeUndefined(); // unknown backend dropped
+    expect(restored?.params.vars).toEqual({ good: 2 }); // object-valued var dropped
   });
 });

--- a/src/state/durable-state.ts
+++ b/src/state/durable-state.ts
@@ -1,0 +1,174 @@
+// The single validator for DURABLE app state, shared by both persistence seams:
+// the URL fragment (shared links — untrusted) and `/home/state.json` (standalone
+// PWA storage). Both decode an untyped JSON blob into a `State`, and historically
+// only the fragment path validated it while the persisted path trusted the disk
+// verbatim. Routing both through one validator removes that divergence: a corrupt
+// or hostile blob (object-valued vars, non-finite numbers, malformed camera, an
+// unknown enum, a cross-origin source URL) self-heals to safe defaults on either
+// path instead of injecting bad data that fails deeper in the app.
+
+import { resolveExternalSourceUrl } from '../external-source.ts';
+import { isOpenScadValue, type OpenScadValue } from '../openscad-value.ts';
+import type { State } from './app-state.ts';
+import { VALID_EXPORT_FORMATS_2D, VALID_EXPORT_FORMATS_3D } from './formats.ts';
+import { validateArray, validateBoolean, validateString, validateStringEnum } from '../utils.ts';
+import { fromFragment, type FragmentSource } from './project-source.ts';
+import { defaultSourcePath, defaultModelColor } from './initial-state.ts';
+
+/**
+ * The durable-state schema version, stamped onto every write. Absent (legacy
+ * pre-version data) is read as 0; 0 and 1 share the same field shape, so no
+ * migration is needed yet. A future breaking change branches on this in
+ * `validateDurableState` before validating; the field is stamped now so that
+ * future reader can tell old data apart.
+ */
+export const DURABLE_SCHEMA_VERSION = 1;
+
+function validateVars(v: unknown): State['params']['vars'] {
+  if (v == null || typeof v !== 'object' || Array.isArray(v)) return undefined;
+  // Keep only well-formed entries: a non-empty key and an OpenSCAD-valid value, so
+  // a corrupt/hostile blob can't inject a value (object, Infinity, …) that the
+  // args builder would later reject mid-render.
+  const out: Record<string, OpenScadValue> = {};
+  for (const [k, value] of Object.entries(v as Record<string, unknown>)) {
+    if (k.length > 0 && isOpenScadValue(value)) out[k] = value;
+  }
+  return out;
+}
+
+// Preserve tri-state: an absent boolean stays `undefined` (its "use the default"
+// meaning) rather than collapsing to `false`. validateBoolean() coerces absent to
+// false, which would, e.g., wrongly disable autoCompile (default-on) for any
+// shared URL / saved state that never set it.
+function validateOptionalBoolean(value: unknown): boolean | undefined {
+  return typeof value === 'boolean' ? value : undefined;
+}
+
+function validateCamera(value: unknown): State['view']['camera'] {
+  if (value == null || typeof value !== 'object') return undefined;
+  const c = value as Record<string, unknown>;
+  const triple = (t: unknown): [number, number, number] | undefined =>
+    Array.isArray(t) &&
+    t.length === 3 &&
+    t.every((n) => typeof n === 'number' && Number.isFinite(n))
+      ? [t[0], t[1], t[2]]
+      : undefined;
+  const position = triple(c.position);
+  const target = triple(c.target);
+  const zoom = typeof c.zoom === 'number' && Number.isFinite(c.zoom) ? c.zoom : undefined;
+  if (!position || !target || zoom === undefined) return undefined;
+  return { position, target, zoom };
+}
+
+function validateSourceUrl(value: unknown, baseUrl: string): string | undefined {
+  if (typeof value !== 'string') return undefined;
+  try {
+    return resolveExternalSourceUrl(value, { baseUrl }).href;
+  } catch {
+    // An out-of-policy or unparseable URL (e.g. a cross-origin remote, or an
+    // absolute same-origin URL after the app's origin changed — custom domain,
+    // fork, PR preview) drops to undefined so the source degrades to a path-only
+    // reference, instead of throwing and discarding the user's ENTIRE durable
+    // state along with its valid sibling sources.
+    return undefined;
+  }
+}
+
+function validateSources(value: unknown, baseUrl: string): State['params']['sources'] {
+  // Validate into the flat wire shape, then classify into the typed union. The
+  // on-the-wire shape stays flat (no `kind`); see `toFragment`.
+  const flat = validateArray(
+    value as FragmentSource[],
+    (src): FragmentSource => ({
+      path: validateString(src?.path, () => defaultSourcePath),
+      content: src?.content != null ? validateString(src.content) : undefined,
+      url: validateSourceUrl(src?.url, baseUrl),
+    }),
+    () => [{ path: defaultSourcePath, content: '' }],
+  );
+  return flat.map(fromFragment);
+}
+
+/**
+ * Validate an untyped, JSON-decoded durable-state blob into a `State`. The
+ * `baseUrl` resolves/origin-checks any remote source URLs. Throws only on an
+ * irrecoverably malformed required field (e.g. a missing layout mode); callers
+ * treat a throw as "no usable persisted state" and fall back to defaults.
+ */
+export function validateDurableState(raw: unknown, opts: { baseUrl: string }): State {
+  /* eslint-disable @typescript-eslint/no-explicit-any */
+  // The blob is structurally untyped (JSON); each field validator below narrows
+  // and defaults its own field, so a loose `any` accessor is the right input type.
+  const obj = (raw ?? {}) as any;
+  const { params, view, preview } = obj;
+  /* eslint-enable @typescript-eslint/no-explicit-any */
+  const schemaVersion = typeof obj.schemaVersion === 'number' ? obj.schemaVersion : 0;
+  if (schemaVersion > DURABLE_SCHEMA_VERSION) {
+    // Forward-compat: read newer data best-effort rather than discarding it — the
+    // field validators default anything they don't recognise.
+    console.warn(
+      `durable state schemaVersion ${schemaVersion} is newer than ${DURABLE_SCHEMA_VERSION}; reading best-effort`,
+    );
+  }
+  const { baseUrl } = opts;
+  return {
+    params: {
+      activePath: validateString(params?.activePath, () => defaultSourcePath),
+      features: validateArray(params?.features, validateString),
+      vars: validateVars(params?.vars),
+      // Source deserialization also handles legacy links (source + sourcePath).
+      sources: validateSources(
+        params?.sources ??
+          (params?.source ? [{ path: params?.sourcePath, content: params?.source }] : undefined),
+        baseUrl,
+      ),
+      exportFormat2D: validateStringEnum(
+        params?.exportFormat2D,
+        Object.keys(VALID_EXPORT_FORMATS_2D),
+        (_s) => 'svg',
+      ),
+      exportFormat3D: validateStringEnum(
+        params?.exportFormat3D,
+        Object.keys(VALID_EXPORT_FORMATS_3D),
+        (_s) => 'stl',
+      ),
+      extruderColors: Array.isArray(params?.extruderColors)
+        ? validateArray(params.extruderColors, validateString)
+        : undefined,
+      backend: validateStringEnum(params?.backend, ['manifold', 'cgal'], (_s) => undefined),
+      autoCompile: validateOptionalBoolean(params?.autoCompile),
+      skipMultimaterialPrompt: validateOptionalBoolean(params?.skipMultimaterialPrompt),
+    },
+    preview: preview
+      ? {
+          thumbhash: preview.thumbhash ? validateString(preview.thumbhash) : undefined,
+          blurhash: preview.blurhash ? validateString(preview.blurhash) : undefined,
+        }
+      : undefined,
+    view: {
+      logs: validateBoolean(view?.logs),
+      extruderPickerVisibility: validateStringEnum(
+        view?.extruderPickerVisibility,
+        ['editing', 'exporting'],
+        (_s) => undefined,
+      ),
+      layout: {
+        mode: validateStringEnum(view?.layout?.mode, ['multi', 'single']),
+        focus: validateStringEnum(
+          view?.layout?.focus,
+          ['editor', 'viewer', 'customizer'],
+          (_s) => false,
+        ),
+        editor: validateBoolean(view?.layout?.['editor']),
+        viewer: validateBoolean(view?.layout?.['viewer']),
+        customizer: validateBoolean(view?.layout?.['customizer']),
+      },
+      collapsedCustomizerTabs: validateArray(view?.collapsedCustomizerTabs, validateString),
+      customizerGroupsCollapsed: validateOptionalBoolean(view?.customizerGroupsCollapsed),
+      camera: validateCamera(view?.camera),
+      color: validateString(view?.color, () => defaultModelColor),
+      showAxes: validateBoolean(view?.showAxes, () => true),
+      lineNumbers: validateBoolean(view?.lineNumbers, () => false),
+    },
+  };
+}

--- a/src/state/fragment-state.ts
+++ b/src/state/fragment-state.ts
@@ -1,70 +1,10 @@
 // Portions of this file are Copyright 2021 Google LLC, and licensed under GPL2+. See COPYING.
 
 import { resolveExternalSourceUrl } from '../external-source.ts';
-import { isOpenScadValue, type OpenScadValue } from '../openscad-value.ts';
 import { State } from './app-state.ts';
-import { VALID_EXPORT_FORMATS_2D, VALID_EXPORT_FORMATS_3D } from './formats.ts';
-import { validateArray, validateBoolean, validateString, validateStringEnum } from '../utils.ts';
-import { fromFragment, toFragment, type FragmentSource } from './project-source.ts';
-import { createInitialState, defaultModelColor, defaultSourcePath } from './initial-state.ts';
-
-function validateVars(v: unknown): State['params']['vars'] {
-  if (v == null || typeof v !== 'object' || Array.isArray(v)) return undefined;
-  // Keep only well-formed entries: a non-empty key and an OpenSCAD-valid value, so
-  // a corrupt/hostile fragment can't inject a value (object, Infinity, …) that the
-  // args builder would later reject mid-render.
-  const out: Record<string, OpenScadValue> = {};
-  for (const [k, value] of Object.entries(v as Record<string, unknown>)) {
-    if (k.length > 0 && isOpenScadValue(value)) out[k] = value;
-  }
-  return out;
-}
-
-// Preserve tri-state: an absent boolean stays `undefined` (its "use the default"
-// meaning) rather than collapsing to `false`. validateBoolean() coerces absent to
-// false, which would, e.g., wrongly disable autoCompile (default-on) for any
-// shared URL that never set it.
-function validateOptionalBoolean(value: unknown): boolean | undefined {
-  return typeof value === 'boolean' ? value : undefined;
-}
-
-function validateCamera(value: unknown): State['view']['camera'] {
-  if (value == null || typeof value !== 'object') return undefined;
-  const c = value as Record<string, unknown>;
-  const triple = (t: unknown): [number, number, number] | undefined =>
-    Array.isArray(t) &&
-    t.length === 3 &&
-    t.every((n) => typeof n === 'number' && Number.isFinite(n))
-      ? [t[0] as number, t[1] as number, t[2] as number]
-      : undefined;
-  const position = triple(c.position);
-  const target = triple(c.target);
-  const zoom = typeof c.zoom === 'number' && Number.isFinite(c.zoom) ? c.zoom : undefined;
-  if (!position || !target || zoom === undefined) return undefined;
-  return { position, target, zoom };
-}
-
-function validateSourceUrl(value: unknown): string | undefined {
-  if (typeof value !== 'string') return undefined;
-  return resolveExternalSourceUrl(value, {
-    baseUrl: window.location.href,
-  }).href;
-}
-
-function validateSources(value: unknown): State['params']['sources'] {
-  // Validate into the flat wire shape, then classify into the typed union. The
-  // on-the-wire fragment stays flat (no `kind`); see encodeStateParamsAsFragment.
-  const flat = validateArray(
-    value as FragmentSource[],
-    (src): FragmentSource => ({
-      path: validateString(src?.path, () => defaultSourcePath),
-      content: src?.content != null ? validateString(src.content) : undefined,
-      url: validateSourceUrl(src?.url),
-    }),
-    () => [{ path: defaultSourcePath, content: '' }],
-  );
-  return flat.map(fromFragment);
-}
+import { toFragment } from './project-source.ts';
+import { createInitialState } from './initial-state.ts';
+import { DURABLE_SCHEMA_VERSION, validateDurableState } from './durable-state.ts';
 
 export async function buildUrlForStateParams(state: State) {
   return `${location.protocol}//${location.host}${location.pathname}#${await encodeStateParamsAsFragment(state)}`;
@@ -107,6 +47,7 @@ async function decompressString(compressedInput: string): Promise<string> {
 
 export function encodeStateParamsAsFragment(state: State) {
   const json = JSON.stringify({
+    schemaVersion: DURABLE_SCHEMA_VERSION,
     // Flatten the typed source union back to the flat on-the-wire shape so the
     // encoded fragment stays byte-compatible with previously-shared URLs.
     params: { ...state.params, sources: state.params.sources.map(toFragment) },
@@ -144,68 +85,8 @@ export async function readStateFromFragment(): Promise<State | null> {
         // Backwards compatibility
         obj = JSON.parse(decodeURIComponent(serialized));
       }
-      const { params, view, preview } = obj;
-      return {
-        params: {
-          activePath: validateString(params?.activePath, () => defaultSourcePath),
-          features: validateArray(params?.features, validateString),
-          vars: validateVars(params?.vars),
-          // Source deserialization also handles legacy links (source + sourcePath)
-          sources: validateSources(
-            params?.sources ??
-              (params?.source
-                ? [{ path: params?.sourcePath, content: params?.source }]
-                : undefined),
-          ),
-          exportFormat2D: validateStringEnum(
-            params?.exportFormat2D,
-            Object.keys(VALID_EXPORT_FORMATS_2D),
-            (_s) => 'svg',
-          ),
-          exportFormat3D: validateStringEnum(
-            params?.exportFormat3D,
-            Object.keys(VALID_EXPORT_FORMATS_3D),
-            (_s) => 'stl',
-          ),
-          extruderColors: Array.isArray(params?.extruderColors)
-            ? validateArray(params.extruderColors, validateString)
-            : undefined,
-          backend: validateStringEnum(params?.backend, ['manifold', 'cgal'], (_s) => undefined),
-          autoCompile: validateOptionalBoolean(params?.autoCompile),
-          skipMultimaterialPrompt: validateOptionalBoolean(params?.skipMultimaterialPrompt),
-        },
-        preview: preview
-          ? {
-              thumbhash: preview.thumbhash ? validateString(preview.thumbhash) : undefined,
-              blurhash: preview.blurhash ? validateString(preview.blurhash) : undefined,
-            }
-          : undefined,
-        view: {
-          logs: validateBoolean(view?.logs),
-          extruderPickerVisibility: validateStringEnum(
-            view?.extruderPickerVisibility,
-            ['editing', 'exporting'],
-            (_s) => undefined,
-          ),
-          layout: {
-            mode: validateStringEnum(view?.layout?.mode, ['multi', 'single']),
-            focus: validateStringEnum(
-              view?.layout?.focus,
-              ['editor', 'viewer', 'customizer'],
-              (_s) => false,
-            ),
-            editor: validateBoolean(view?.layout['editor']),
-            viewer: validateBoolean(view?.layout['viewer']),
-            customizer: validateBoolean(view?.layout['customizer']),
-          },
-          collapsedCustomizerTabs: validateArray(view?.collapsedCustomizerTabs, validateString),
-          customizerGroupsCollapsed: validateOptionalBoolean(view?.customizerGroupsCollapsed),
-          camera: validateCamera(view?.camera),
-          color: validateString(view?.color, () => defaultModelColor),
-          showAxes: validateBoolean(view?.showAxes, () => true),
-          lineNumbers: validateBoolean(view?.lineNumbers, () => false),
-        },
-      };
+      // One shared validator for both durable surfaces (fragment + state.json).
+      return validateDurableState(obj, { baseUrl: window.location.href });
     } catch (e) {
       console.error(e);
     }

--- a/src/state/persisted-state.ts
+++ b/src/state/persisted-state.ts
@@ -5,32 +5,29 @@
 // migration — the app is a static GitHub Pages deploy — so the on-disk JSON
 // shape must stay backward-compatible across releases. Routing the read/write
 // through this single seam (instead of inline in index.ts) makes that contract
-// explicit and unit-testable, and gives a later source-shape change exactly one
-// place to add a normalization shim.
+// explicit and unit-testable.
 //
-// The read path intentionally performs no normalization today: it returns the
-// persisted {view, params, preview} verbatim, matching the historical behavior.
+// The read path runs the SAME `validateDurableState` as the URL-fragment path, so
+// a corrupt/tampered state.json self-heals to safe defaults instead of injecting
+// bad data — and the two durable surfaces can never validate the same field
+// differently. The flat on-disk source shape is classified into the typed union
+// there (the load-bearing normalization for existing users' state.json).
 
 import { ProjectFileSystem } from '../fs/project-filesystem.ts';
 import type { State } from './app-state.ts';
-import { fromFragment, toFragment, type FragmentSource } from './project-source.ts';
+import { toFragment } from './project-source.ts';
+import { DURABLE_SCHEMA_VERSION, validateDurableState } from './durable-state.ts';
 
 const STATE_PATH = '/home/state.json';
 
 /**
- * Read the persisted durable state, or null if absent/unreadable. The on-disk
- * sources are the flat `{ path, url?, content? }` shape; classify them into the
- * typed union so in-memory state is well-formed (this is the load-bearing
- * normalization for existing users' state.json).
+ * Read and validate the persisted durable state, or null if absent/unreadable.
+ * `baseUrl` resolves/origin-checks any remote source URLs (the app's own origin).
  */
-export function readPersistedState(fs: ProjectFileSystem): State | null {
+export function readPersistedState(fs: ProjectFileSystem, baseUrl: string): State | null {
   try {
     const data = JSON.parse(new TextDecoder('utf-8').decode(fs.readFileSync(STATE_PATH)));
-    const { view, params, preview } = data;
-    if (params && Array.isArray(params.sources)) {
-      params.sources = (params.sources as FragmentSource[]).map(fromFragment);
-    }
-    return { view, params, preview };
+    return validateDurableState(data, { baseUrl });
   } catch (e) {
     console.log('Failed to read the persisted state from local storage.', e);
     return null;
@@ -40,5 +37,8 @@ export function readPersistedState(fs: ProjectFileSystem): State | null {
 /** Persist the durable slice (view/params/preview), flattening sources to disk. */
 export function writePersistedState(fs: ProjectFileSystem, { view, params, preview }: State): void {
   const flatParams = { ...params, sources: params.sources.map(toFragment) };
-  fs.writeFile(STATE_PATH, JSON.stringify({ view, params: flatParams, preview }));
+  fs.writeFile(
+    STATE_PATH,
+    JSON.stringify({ schemaVersion: DURABLE_SCHEMA_VERSION, view, params: flatParams, preview }),
+  );
 }


### PR DESCRIPTION
## #122 — one durable-state validator + schemaVersion

Unifies the two durable-state read paths and adds a forward-compat schema version.

### The divergence fixed
Previously the **URL-fragment** read path validated every field, while the **persisted `/home/state.json`** path trusted the JSON verbatim (only classifying sources). A corrupt or tampered `state.json` could inject object-valued vars, non-finite numbers, an unknown backend/enum, or a malformed camera that then broke the app deeper in.

### What changed
- **New `src/state/durable-state.ts`**: `validateDurableState(raw, { baseUrl })` — the per-field validation extracted from `fragment-state` (now DOM-free; `baseUrl` is a param, not `window`). Both `readStateFromFragment` and `readPersistedState` call it, so the two surfaces **can never validate the same field differently**, and the persisted path now **self-heals** corrupt data to safe defaults.
- **`DURABLE_SCHEMA_VERSION = 1`**, stamped on every write (`state.json` + the URL fragment), read as `0` when absent (legacy — same shape, no migration yet). A newer version logs and reads best-effort. The field is the documented hook for future migrations.
- **Source-URL validation is now non-fatal per source** (adversarial-review fix): an out-of-policy or origin-changed URL drops to a path-only source instead of throwing and discarding **all** durable state along with its valid siblings. The persisted path holds the user's *own* accumulated work, so the fragment path's "one bad URL → reset to defaults" blast radius was too destructive here. A custom-domain move / fork / PR-preview host would otherwise turn every absolute persisted URL cross-origin and wipe saved work.

### Tests
- `durable-state.test.ts`: defaulting, OpenSCAD-value var filtering, tri-state preservation, schemaVersion absent/current/future, throw-on-irrecoverable, and **one-bad-URL-keeps-valid-siblings**.
- `persisted-state-compat.test.ts`: the headline **persisted-path sanitization** of tampered data, a **valid view/camera round-trip** through the now-validating read, and the `schemaVersion` on-disk key.
- The existing **fragment + persisted backward-compat oracles are unchanged and green** (legacy on-disk + legacy-URL shapes, incl. the cross-origin `#url=` rejection).

### Verification
- `npm run verify` green (format, lint, typecheck, unit w/ coverage, assembly, build, budgets, publish-archive). 504 unit tests.
- `durable-state.ts` is DOM-free (not in the engine-`window` lint exemption list); `persisted-state.ts` is now window-free too (baseUrl injected from `index.ts`).

Adversarially reviewed; the one SHOULD-FIX (persisted blast radius on a bad source URL) was fixed with per-source recovery + a test before this PR. Refs #122.