### PR TITLE
feat(state): project-mutation API (#123 slice 1)

### DIFF
--- a/src/fs/project-path.ts
+++ b/src/fs/project-path.ts
@@ -72,3 +72,18 @@ export function normalizeProjectPath(rawPath: string): string {
 
   return segments.join('/');
 }
+
+/** The project root every source lives under (matches the ZIP-import convention). */
+export const PROJECT_HOME = '/home/';
+
+/**
+ * Canonicalize a host- or project-supplied path to the absolute `/home/<rel>`
+ * form that `State.params.sources` uses. Accepts either a project-relative path
+ * (`main.scad`, `lib/a.scad`) or an already-absolute `/home/...` path, and applies
+ * the same traversal/control-character/absolute-elsewhere rejection as
+ * `normalizeProjectPath`. Throws {@link ProjectPathError} on an unsafe path.
+ */
+export function canonicalProjectHomePath(path: string): string {
+  const rel = path.startsWith(PROJECT_HOME) ? path.slice(PROJECT_HOME.length) : path;
+  return `${PROJECT_HOME}${normalizeProjectPath(rel)}`;
+}

--- a/src/state/__tests__/model.test.ts
+++ b/src/state/__tests__/model.test.ts
@@ -532,3 +532,102 @@ describe('Model — stale-result rejection (#56)', () => {
     expect(model.state.checkingSyntax).toBeFalsy();
   });
 });
+
+// ---------------------------------------------------------------------------
+// describe: multi-file project contract (#123)
+// ---------------------------------------------------------------------------
+
+describe('Model — multi-file project contract (#123)', () => {
+  it('setProject replaces sources + entry and recompiles', async () => {
+    model.setProject(
+      [
+        { path: 'a.scad', content: 'cube(1);' },
+        { path: 'main.scad', content: 'use <a.scad>\nsphere(1);' },
+      ],
+      'main.scad',
+    );
+    await nextTicks();
+
+    expect(model.state.params.sources.map((s) => s.path)).toEqual([
+      '/home/a.scad',
+      '/home/main.scad',
+    ]);
+    expect(model.state.params.activePath).toBe('/home/main.scad');
+    expect(mockRender).toHaveBeenCalled(); // processSource drove a preview
+  });
+
+  it('setProject surfaces an error for an unsafe path (no throw out of the method)', () => {
+    model.setProject([{ path: '../escape.scad', content: 'x' }]);
+    expect(model.state.error).toBeTruthy();
+  });
+
+  it('updateFile replaces a non-active file and recompiles the entry', async () => {
+    model.setProject(
+      [
+        { path: 'main.scad', content: 'use <a.scad>' },
+        { path: 'a.scad', content: 'cube(1);' },
+      ],
+      'main.scad',
+    );
+    await nextTicks();
+    vi.clearAllMocks();
+
+    model.updateFile('a.scad', 'cube(2);');
+    await nextTicks();
+
+    const a = model.state.params.sources.find((s) => s.path === '/home/a.scad');
+    expect(a && 'content' in a ? a.content : undefined).toBe('cube(2);');
+    expect(model.state.params.activePath).toBe('/home/main.scad'); // unchanged
+    expect(mockRender).toHaveBeenCalled(); // entry recompiled (it `use`s a.scad)
+  });
+
+  it('setEntryPoint switches the active file and recompiles', async () => {
+    model.setProject([
+      { path: 'a.scad', content: 'cube(1);' },
+      { path: 'b.scad', content: 'sphere(1);' },
+    ]);
+    await nextTicks();
+    vi.clearAllMocks();
+
+    model.setEntryPoint('b.scad');
+    await nextTicks();
+
+    expect(model.state.params.activePath).toBe('/home/b.scad');
+    expect(mockRender).toHaveBeenCalled();
+  });
+
+  it('setEntryPoint is a no-op for an unknown file', () => {
+    model.setProject([{ path: 'a.scad', content: 'A' }]);
+    const before = model.state.params.activePath;
+    model.setEntryPoint('ghost.scad');
+    expect(model.state.params.activePath).toBe(before);
+  });
+
+  it('setEntryPoint is a no-op (no recompile) when the file is already active', async () => {
+    model.setProject([{ path: 'a.scad', content: 'A' }], 'a.scad');
+    await nextTicks();
+    vi.clearAllMocks();
+    model.setEntryPoint('a.scad'); // already active
+    await nextTicks();
+    expect(mockRender).not.toHaveBeenCalled();
+  });
+
+  it('removeFile of the active entry re-points deterministically and recompiles', async () => {
+    model.setProject(
+      [
+        { path: 'a.scad', content: 'cube(1);' },
+        { path: 'main.scad', content: 'sphere(1);' },
+      ],
+      'a.scad',
+    );
+    await nextTicks();
+    vi.clearAllMocks();
+
+    model.removeFile('a.scad');
+    await nextTicks();
+
+    expect(model.state.params.sources.map((s) => s.path)).toEqual(['/home/main.scad']);
+    expect(model.state.params.activePath).toBe('/home/main.scad');
+    expect(mockRender).toHaveBeenCalled();
+  });
+});

--- a/src/state/__tests__/project-store.test.ts
+++ b/src/state/__tests__/project-store.test.ts
@@ -128,3 +128,146 @@ describe('ProjectStore (#57)', () => {
   // type-check rejects jsdom's Uint8Array, so a buildZip round-trip isn't unit-
   // testable here without a real browser.
 });
+
+describe('ProjectStore — multi-file project contract (#123)', () => {
+  it('setProject canonicalizes relative paths, writes text, and picks main.scad', () => {
+    const { fs, written } = makeFs();
+    const store = new ProjectStore(fs);
+
+    const next = store.setProject([
+      { path: 'a.scad', content: 'cube(1);' },
+      { path: 'main.scad', content: 'use <a.scad>' },
+    ]);
+
+    expect(next.sources).toEqual([
+      { kind: 'text', path: '/home/a.scad', content: 'cube(1);' },
+      { kind: 'text', path: '/home/main.scad', content: 'use <a.scad>' },
+    ]);
+    expect(next.activePath).toBe('/home/main.scad'); // main.scad wins the entry rule
+    expect(written['/home/a.scad']).toBe('cube(1);');
+    expect(written['/home/main.scad']).toBe('use <a.scad>');
+  });
+
+  it('setProject honors an explicit entryPoint and falls back when it is unknown', () => {
+    const store = new ProjectStore(makeFs().fs);
+    const files = [
+      { path: 'a.scad', content: 'A' },
+      { path: 'b.scad', content: 'B' },
+    ];
+    expect(store.setProject(files, 'b.scad').activePath).toBe('/home/b.scad');
+    // Unknown entryPoint → the rule (first .scad, since no main.scad).
+    expect(store.setProject(files, 'nope.scad').activePath).toBe('/home/a.scad');
+  });
+
+  it('setProject rejects an unsafe path before writing anything (atomic)', () => {
+    const { fs, written } = makeFs();
+    const store = new ProjectStore(fs);
+    expect(() =>
+      store.setProject([
+        { path: 'ok.scad', content: 'A' },
+        { path: '../escape.scad', content: 'B' },
+      ]),
+    ).toThrow();
+    expect(written['/home/ok.scad']).toBeUndefined(); // nothing written
+  });
+
+  it('setProject rejects an unsafe entryPoint before writing anything (atomic)', () => {
+    const { fs, written } = makeFs();
+    const store = new ProjectStore(fs);
+    expect(() => store.setProject([{ path: 'ok.scad', content: 'A' }], '../escape.scad')).toThrow();
+    expect(written['/home/ok.scad']).toBeUndefined(); // entryPoint validated before writes
+  });
+
+  it('setProject accepts an already-/home/-prefixed entryPoint (idempotent canonicalization)', () => {
+    const store = new ProjectStore(makeFs().fs);
+    const next = store.setProject(
+      [
+        { path: '/home/a.scad', content: 'A' },
+        { path: 'b.scad', content: 'B' },
+      ],
+      '/home/b.scad',
+    );
+    expect(next.sources.map((s) => s.path)).toEqual(['/home/a.scad', '/home/b.scad']);
+    expect(next.activePath).toBe('/home/b.scad');
+  });
+
+  it('setProject with no files yields one fresh empty file (always-an-active-file)', () => {
+    const next = new ProjectStore(makeFs().fs).setProject([]);
+    expect(next.sources).toHaveLength(1);
+    expect(next.activePath).toBe('/home/untitled.scad');
+    expect(contentOf(next.sources[0])).toBe('');
+  });
+
+  it('updateFile replaces an existing file and appends a new one, active unchanged', () => {
+    const store = new ProjectStore(makeFs().fs);
+    const sources: SerializableSource[] = [
+      { kind: 'text', path: '/home/main.scad', content: 'M' },
+      { kind: 'text', path: '/home/a.scad', content: 'A' },
+    ];
+    const replaced = store.updateFile(sources, 'a.scad', 'A2');
+    expect(contentOf(replaced.find((s) => s.path === '/home/a.scad')!)).toBe('A2');
+    expect(replaced).toHaveLength(2);
+
+    const appended = store.updateFile(sources, 'b.scad', 'B');
+    expect(appended).toHaveLength(3);
+    expect(appended.find((s) => s.path === '/home/b.scad')).toEqual({
+      kind: 'text',
+      path: '/home/b.scad',
+      content: 'B',
+    });
+  });
+
+  it('removeFile re-points the entry deterministically when the active file goes', () => {
+    const store = new ProjectStore(makeFs().fs);
+    const sources: SerializableSource[] = [
+      { kind: 'text', path: '/home/a.scad', content: 'A' },
+      { kind: 'text', path: '/home/main.scad', content: 'M' },
+    ];
+    // Removing the active a.scad re-points to main.scad (the rule).
+    const next = store.removeFile(sources, '/home/a.scad', 'a.scad');
+    expect(next.sources.map((s) => s.path)).toEqual(['/home/main.scad']);
+    expect(next.activePath).toBe('/home/main.scad');
+
+    // Removing a non-active file keeps the active path.
+    const keep = store.removeFile(sources, '/home/main.scad', 'a.scad');
+    expect(keep.activePath).toBe('/home/main.scad');
+  });
+
+  it('updateFile refuses to overwrite a binary local asset with text', () => {
+    const { fs, written } = makeFs();
+    const store = new ProjectStore(fs);
+    const sources: SerializableSource[] = [
+      { kind: 'text', path: '/home/main.scad', content: 'M' },
+      { kind: 'local', path: '/home/logo.png' },
+    ];
+    expect(() => store.updateFile(sources, 'logo.png', 'oops')).toThrow();
+    expect(written['/home/logo.png']).toBeUndefined(); // bytes not clobbered
+  });
+
+  it('removeFile re-points to the first remaining file when no .scad survives', () => {
+    const store = new ProjectStore(makeFs().fs);
+    const sources: SerializableSource[] = [
+      { kind: 'text', path: '/home/a.scad', content: 'A' },
+      { kind: 'text', path: '/home/notes.txt', content: 'N' },
+    ];
+    const next = store.removeFile(sources, '/home/a.scad', 'a.scad');
+    expect(next.sources.map((s) => s.path)).toEqual(['/home/notes.txt']);
+    expect(next.activePath).toBe('/home/notes.txt'); // fell through to paths[0]
+  });
+
+  it('removeFile of the last file yields a fresh empty file', () => {
+    const store = new ProjectStore(makeFs().fs);
+    const sources: SerializableSource[] = [{ kind: 'text', path: '/home/only.scad', content: 'X' }];
+    const next = store.removeFile(sources, '/home/only.scad', 'only.scad');
+    expect(next.sources).toHaveLength(1);
+    expect(next.activePath).toBe('/home/untitled.scad');
+    expect(contentOf(next.sources[0])).toBe('');
+  });
+
+  it('removeFile of an absent path is a no-op (same array reference)', () => {
+    const store = new ProjectStore(makeFs().fs);
+    const sources: SerializableSource[] = [{ kind: 'text', path: '/home/a.scad', content: 'A' }];
+    const next = store.removeFile(sources, '/home/a.scad', 'ghost.scad');
+    expect(next.sources).toBe(sources); // unchanged reference → caller no-ops
+  });
+});

--- a/src/state/model.ts
+++ b/src/state/model.ts
@@ -12,7 +12,8 @@ import { bubbleUpDeepMutations } from './deep-mutate.ts';
 import { openLocalFile, saveViaHandle } from '../fs/filesystem.ts';
 import { ProjectFileSystem } from '../fs/project-filesystem.ts';
 import { contentOf, isProbablyTextPath } from './project-source.ts';
-import { ProjectStore } from './project-store.ts';
+import { ProjectStore, type ProjectFile } from './project-store.ts';
+import { canonicalProjectHomePath } from '../fs/project-path.ts';
 import { HostAdapter, WebHostAdapter } from './web-host-adapter.ts';
 import { WasmWorkerBackend, type CompileBackend } from '../runner/openscad-runner.ts';
 import { newId } from '../runner/compile-contract.ts';
@@ -335,6 +336,107 @@ export class Model extends EventTarget {
       s.error = undefined;
       s.errorDetails = undefined;
     });
+  }
+
+  // --- Multi-file project contract (#123) -----------------------------------
+  // Typed, host-drivable project mutations over the same `sources`/`activePath`
+  // state the editor uses. Each funnels through one `mutate` (one revision bump,
+  // one 'state' event) then drives `processSource`, so the existing supersession
+  // + revision-stale-drop machinery keeps a superseded in-flight compile from
+  // clobbering the result. Text files only for now (binary is deferred — #121).
+
+  /** Replace the whole project with `files`, selecting `entryPoint` (or the
+   *  main.scad→first-.scad→first rule) as the active file. */
+  setProject(files: ProjectFile[], entryPoint?: string): void {
+    try {
+      const next = this.projectStore.setProject(files, entryPoint);
+      // None of these sources were FSAPI-opened; drop retained handles so a
+      // colliding path can't write back to a user's original on-disk file.
+      this.fsapiHandles.clear();
+      this.mutate((s) => {
+        s.params.sources = next.sources;
+        s.params.activePath = next.activePath;
+        s.lastCheckerRun = undefined;
+        s.output = undefined;
+        s.export = undefined;
+        s.preview = undefined;
+        s.currentRunLogs = undefined;
+        s.error = undefined;
+        s.errorDetails = undefined;
+        s.is2D = undefined;
+      });
+      this.compile.processSource();
+    } catch (err) {
+      this.mutate((s) => applyUserFacingError(s, err, 'model'));
+    }
+  }
+
+  /** Add or replace one text file's content (active file unchanged). */
+  updateFile(path: string, content: string): void {
+    try {
+      const sources = this.projectStore.updateFile(this.state.params.sources, path, content);
+      if (this.mutate((s) => (s.params.sources = sources))) {
+        this.compile.processSource();
+      }
+    } catch (err) {
+      this.mutate((s) => applyUserFacingError(s, err, 'model'));
+    }
+  }
+
+  /** Remove one source; re-point the entry deterministically if it was active. */
+  removeFile(path: string): void {
+    try {
+      const next = this.projectStore.removeFile(
+        this.state.params.sources,
+        this.state.params.activePath,
+        path,
+      );
+      if (next.sources === this.state.params.sources) return; // path not present — no-op
+      this.fsapiHandles.delete(canonicalProjectHomePath(path));
+      const entryChanged = next.activePath !== this.state.params.activePath;
+      this.mutate((s) => {
+        s.params.sources = next.sources;
+        s.params.activePath = next.activePath;
+        if (entryChanged) {
+          s.lastCheckerRun = undefined;
+          s.output = undefined;
+          s.export = undefined;
+          s.preview = undefined;
+          s.currentRunLogs = undefined;
+          s.error = undefined;
+          s.errorDetails = undefined;
+          s.is2D = undefined;
+        }
+      });
+      this.compile.processSource();
+    } catch (err) {
+      this.mutate((s) => applyUserFacingError(s, err, 'model'));
+    }
+  }
+
+  /** Change which file compiles (the entry point). No-op if unknown/already active. */
+  setEntryPoint(path: string): void {
+    let target: string;
+    try {
+      target = canonicalProjectHomePath(path);
+    } catch (err) {
+      this.mutate((s) => applyUserFacingError(s, err, 'model'));
+      return;
+    }
+    if (!this.state.params.sources.some((s) => s.path === target)) return; // unknown
+    if (target === this.state.params.activePath) return; // already active
+    this.mutate((s) => {
+      s.params.activePath = target;
+      s.lastCheckerRun = undefined;
+      s.output = undefined;
+      s.export = undefined;
+      s.preview = undefined;
+      s.currentRunLogs = undefined;
+      s.error = undefined;
+      s.errorDetails = undefined;
+      s.is2D = undefined;
+    });
+    this.compile.processSource();
   }
 
   /** Extracts a ZIP archive into /home/ and activates the entry .scad. */

--- a/src/state/project-store.ts
+++ b/src/state/project-store.ts
@@ -4,6 +4,7 @@ import { ProjectFileSystem } from '../fs/project-filesystem.ts';
 import { contentOf, isProbablyTextPath, type SerializableSource } from './project-source.ts';
 import { fetchSource } from '../utils.ts';
 import {
+  canonicalProjectHomePath,
   MAX_COMPRESSED_ZIP_BYTES,
   MAX_PROJECT_FILE_COUNT,
   MAX_PROJECT_TOTAL_BYTES,
@@ -15,6 +16,24 @@ import {
 export interface ProjectSnapshot {
   sources: SerializableSource[];
   activePath: string;
+}
+
+/** One text file in a host-supplied project (the multi-file contract, #123). A
+ *  binary variant is a future widening (see #121) and does not change this shape. */
+export interface ProjectFile {
+  path: string;
+  content: string;
+}
+
+/**
+ * Pick the entry point for a set of absolute source paths: a top-level
+ * `/home/main.scad`, else the first `.scad`, else the first path. The ZIP-import
+ * convention, applied to the absolute paths the contract operates on.
+ */
+function selectEntryPath(paths: string[]): string {
+  return (
+    paths.find((p) => p === '/home/main.scad') ?? paths.find((p) => p.endsWith('.scad')) ?? paths[0]
+  );
 }
 
 /**
@@ -95,6 +114,96 @@ export class ProjectStore {
     }
     const withoutExisting = sources.filter((src) => src.path !== path);
     return { sources: [...withoutExisting, { kind: 'text', path, content }], activePath: path };
+  }
+
+  /** Write a text file, creating its parent dirs first (mkdir -p). Best-effort:
+   *  the in-memory sources drive compilation, so an FS failure must not abort. */
+  private writeTextFile(path: string, content: string): void {
+    try {
+      if (this.fs.mkdirSync) {
+        for (const dir of ancestorDirsOf(path)) {
+          try {
+            this.fs.mkdirSync(dir);
+          } catch {
+            /* already exists */
+          }
+        }
+      }
+      this.fs.writeFile(path, content);
+    } catch {
+      /* best-effort */
+    }
+  }
+
+  /**
+   * Replace the whole project with `files` (text only — #121), selecting
+   * `entryPoint` as the active file (or the {@link selectEntryPath} rule when it
+   * is absent/unknown). All paths are validated and canonicalized up front, so a
+   * single unsafe path rejects the whole call before any file is written (atomic,
+   * like ZIP import). An empty file list yields one fresh empty file so the
+   * "there is always an active file" invariant holds.
+   */
+  setProject(files: ProjectFile[], entryPoint?: string): ProjectSnapshot {
+    const canon = files.map((f) => ({
+      path: canonicalProjectHomePath(f.path),
+      content: f.content,
+    }));
+    const seen = new Set<string>();
+    for (const f of canon) {
+      if (seen.has(f.path)) throw new ProjectPathError(`Duplicate path in project: ${f.path}`);
+      seen.add(f.path);
+    }
+    // Canonicalize the entry point up front too, so an unsafe entryPoint rejects
+    // the whole call BEFORE any file is written (truly atomic, like ZIP import).
+    const requested = entryPoint !== undefined ? canonicalProjectHomePath(entryPoint) : undefined;
+    if (canon.length === 0) return this.newFile([]);
+    for (const f of canon) this.writeTextFile(f.path, f.content);
+    const sources: SerializableSource[] = canon.map((f) => ({
+      kind: 'text',
+      path: f.path,
+      content: f.content,
+    }));
+    const activePath =
+      requested && sources.some((s) => s.path === requested)
+        ? requested
+        : selectEntryPath(sources.map((s) => s.path));
+    return { sources, activePath };
+  }
+
+  /**
+   * Add or replace one text file's content, leaving the active file unchanged.
+   * Returns the new sources array (caller applies it + recompiles — even for a
+   * non-active file, since the entry may `include`/`use` it).
+   */
+  updateFile(sources: SerializableSource[], path: string, content: string): SerializableSource[] {
+    const target = canonicalProjectHomePath(path);
+    const existing = sources.find((s) => s.path === target);
+    // Refuse to overwrite a binary asset with text — the same protection
+    // `set source` gives the editor, so a text update can't silently destroy the
+    // bytes of a `{kind:'local'}` asset (#153 / ADR 0006).
+    if (existing?.kind === 'local' && !isProbablyTextPath(target)) {
+      throw new ProjectPathError(`Cannot replace the binary asset ${target} with text content.`);
+    }
+    this.writeTextFile(target, content);
+    if (existing) {
+      return sources.map((s) => (s.path === target ? { kind: 'text', path: target, content } : s));
+    }
+    return [...sources, { kind: 'text', path: target, content }];
+  }
+
+  /**
+   * Remove one source. If it was the active file, re-point the entry
+   * deterministically via {@link selectEntryPath} over the survivors; if it was
+   * the last file, create a fresh empty one so an active file always exists.
+   * Returns the original snapshot unchanged when `path` isn't present.
+   */
+  removeFile(sources: SerializableSource[], activePath: string, path: string): ProjectSnapshot {
+    const target = canonicalProjectHomePath(path);
+    const next = sources.filter((s) => s.path !== target);
+    if (next.length === sources.length) return { sources, activePath }; // not present
+    if (next.length === 0) return this.newFile([]);
+    const newActive = target === activePath ? selectEntryPath(next.map((s) => s.path)) : activePath;
+    return { sources: next, activePath: newActive };
   }
 
   /** Add a binary asset: write its bytes to the FS and record a content-less


### PR DESCRIPTION
## #123 Gate B — multi-file project contract, slice 1 of 3

The project-mutation API: typed, host-drivable operations over the same `params.sources` / `activePath` state the editor uses. **Additive** — the existing editor / `newFile` / `importZip` / `openFile` paths are unchanged.

### What changed
- **`canonicalProjectHomePath(path)`** (`project-path.ts`) — canonicalize a relative or `/home/`-prefixed path to absolute `/home/<rel>`, reusing `normalizeProjectPath`'s traversal / control-char / absolute-elsewhere rejection.
- **`ProjectStore`**:
  - `setProject(files, entryPoint?)` — **atomic** whole-project replace (validates every file path **and** the `entryPoint` before writing anything; text-only). Entry selection: explicit `entryPoint` → `/home/main.scad` → first `.scad` → first file.
  - `updateFile(sources, path, content)` — add-or-replace one text file; **refuses to clobber a binary `local` asset** (mirrors the `set source` guard, #153 / ADR 0006).
  - `removeFile(sources, activePath, path)` — deterministic entry **re-point** when the active file goes; a fresh empty file when the last one goes (`activePath` never dangles).
- **`Model.setProject` / `updateFile` / `removeFile` / `setEntryPoint`** — each funnels through one `mutate` (one revision bump, one `'state'` event) then `processSource`, so the existing **supersession + revision-stale-drop** machinery drops a superseded in-flight compile. `setEntryPoint` changes only `activePath`, so it relies on preview-seq supersession and always recompiles. Bad host paths surface as a model error (caught, like `importProjectZip`).

### Determinism
Reuses the existing seq/revision guards — no new locking. `removeFile`/`setProject` mid-render → revision bump → stale-drop; `setEntryPoint` mid-preview → seq supersession. Entry re-point is fully deterministic for the headless test (slice 3).

### Tests
- `ProjectStore`: atomic rejection of an unsafe file **and** entryPoint path, deterministic re-point (incl. the no-`.scad`-remains fallthrough), the binary-local guard, `/home/`-prefix idempotence, and the empty-project edges.
- `Model`: replace / update / remove / switch-entry trigger a recompile; unknown / already-active `setEntryPoint` no-ops; bad-path error surfacing.

### Verification
- `npm run verify` green (format, lint, typecheck, unit w/ coverage, assembly, build, budgets, publish-archive).

Adversarially reviewed; the two SHOULD-FIX items (entryPoint validated after writes → atomicity hole; `updateFile` clobbering a binary local) were fixed + tested before this PR.

**Next:** slice 2 (`cancel()` + wire `onOperationResult` to a Model event for observability), slice 3 (`ProjectContract` on `OpenScadSession` + the headless complete-project-operation test). Text files first; binary deferred (#121) — `ProjectFile` widens later without breaking these signatures.