### PR TITLE
feat(state): session cancel() + terminal-result observability (#123 slice 2)

### DIFF
--- a/src/state/__tests__/model.test.ts
+++ b/src/state/__tests__/model.test.ts
@@ -612,6 +612,19 @@ describe('Model — multi-file project contract (#123)', () => {
     expect(mockRender).not.toHaveBeenCalled();
   });
 
+  it("dispatches an 'operation' event carrying the terminal result", async () => {
+    const seen: { status: string }[] = [];
+    model.addEventListener('operation', (e) => seen.push((e as CustomEvent).detail));
+    model.setVar('x', 1); // triggers a preview render
+    await nextTicks();
+    expect(seen.length).toBeGreaterThanOrEqual(1);
+    expect(seen.every((r) => ['success', 'error', 'cancelled'].includes(r.status))).toBe(true);
+  });
+
+  it('cancel() is safe to call when nothing is in flight', () => {
+    expect(() => model.cancel()).not.toThrow();
+  });
+
   it('removeFile of the active entry re-points deterministically and recompiles', async () => {
     model.setProject(
       [

--- a/src/state/model.ts
+++ b/src/state/model.ts
@@ -81,6 +81,12 @@ export class Model extends EventTarget {
       backend: this.backend,
       sessionId: this.sessionId,
       artifacts: this.artifacts,
+      // Surface each operation's terminal result as an 'operation' event so a host
+      // binding / test can correlate on operationId (ADR 0008 / #123). No-op for
+      // the UI, which has no listener; the commit path is unchanged (the emit is
+      // post-commit and guarded by emitResult).
+      onOperationResult: (result) =>
+        this.dispatchEvent(new CustomEvent('operation', { detail: result })),
     };
   }
 
@@ -437,6 +443,14 @@ export class Model extends EventTarget {
       s.is2D = undefined;
     });
     this.compile.processSource();
+  }
+
+  /** Cancel in-flight compile and export operations on this session (#123).
+   *  Best-effort: each cancelled job surfaces one terminal `cancelled`
+   *  OperationResult (via the 'operation' event) and clears its spinner. */
+  cancel(): void {
+    this.compile.cancel();
+    this.exportService.cancel();
   }
 
   /** Extracts a ZIP archive into /home/ and activates the entry .scad. */

--- a/src/state/services/__tests__/compile-coordinator.test.ts
+++ b/src/state/services/__tests__/compile-coordinator.test.ts
@@ -349,3 +349,56 @@ describe('CompileCoordinator terminal OperationResult (ADR 0008 slice 4)', () =>
     expect(state.rendering).toBe(false);
   });
 });
+
+describe('CompileCoordinator cancel() (#123)', () => {
+  beforeEach(() => {
+    renderImpl.mockReset();
+    checkSyntaxImpl.mockReset();
+  });
+
+  // A never-resolving job whose kill() rejects with the expected-cancellation
+  // message — exactly what the real delayable does when superseded/killed.
+  function hangingJob() {
+    let reject: (e: unknown) => void = () => {};
+    const promise = new Promise((_resolve, rej) => (reject = rej));
+    return Object.assign(promise, { kill: () => reject(new Error('Cancelled')) });
+  }
+
+  it('cancel() kills an in-flight render: one cancelled result, spinner cleared', async () => {
+    const { ctx, state, results } = makeContext(1);
+    renderImpl.mockReturnValueOnce(hangingJob());
+    const coord = new CompileCoordinator(ctx);
+
+    const p = coord.render({ isPreview: true, now: true });
+    await new Promise((r) => setTimeout(r, 0)); // let render() submit + retain the handle
+    coord.cancel();
+    await p;
+
+    expect(results).toHaveLength(1);
+    expect(results[0].status).toBe('cancelled');
+    expect(results[0].kind).toBe('preview');
+    expect(state.previewing).toBe(false); // spinner cleared, no error surfaced
+    expect(state.error).toBeUndefined();
+  });
+
+  it('cancel() kills an in-flight syntax check: one cancelled result', async () => {
+    const { ctx, state, results } = makeContext(1);
+    checkSyntaxImpl.mockReturnValueOnce(hangingJob());
+    const coord = new CompileCoordinator(ctx);
+
+    const p = coord.checkSyntax();
+    await new Promise((r) => setTimeout(r, 0));
+    coord.cancel();
+    await p;
+
+    expect(results).toHaveLength(1);
+    expect(results[0].status).toBe('cancelled');
+    expect(results[0].kind).toBe('syntaxCheck');
+    expect(state.checkingSyntax).toBe(false);
+  });
+
+  it('cancel() is a no-op when nothing is in flight', () => {
+    const { ctx } = makeContext(1);
+    expect(() => new CompileCoordinator(ctx).cancel()).not.toThrow();
+  });
+});

--- a/src/state/services/__tests__/export-service.test.ts
+++ b/src/state/services/__tests__/export-service.test.ts
@@ -381,4 +381,30 @@ describe('ExportService', () => {
     expect(results[0].status).toBe('error');
     expect(results[0].kind).toBe('export');
   });
+
+  it('cancel() of an in-flight conversion clears the spinner and emits one cancelled result (#123)', async () => {
+    const { ctx, getState, results } = makeCtx({
+      is2D: false,
+      exportFormat3D: 'stl',
+      output: fileOutput('m.off'),
+    });
+    const conversion = hangingRender();
+    mockRenderExport.mockReturnValueOnce(conversion.inner);
+    const svc = new ExportService(ctx);
+
+    const p = svc.export(); // worker-conversion branch; sets _activeRender, awaits
+    await Promise.resolve();
+    expect(getState().exporting).toBe(true);
+
+    svc.cancel();
+    expect(conversion.kill).toHaveBeenCalled();
+    conversion.reject(new Error('Cancelled')); // the kill rejects the job
+    await p;
+
+    // The still-current export was cancelled (not superseded), so it must clear
+    // its own spinner — the BLOCKER this test guards.
+    expect(getState().exporting).toBe(false);
+    expect(getState().error).toBeUndefined();
+    expect(results.filter((r) => r.status === 'cancelled')).toHaveLength(1);
+  });
 });

--- a/src/state/services/compile-coordinator.ts
+++ b/src/state/services/compile-coordinator.ts
@@ -20,7 +20,7 @@ import {
   normalizeOperationFailure,
   UserFacingOperationError,
 } from '../../user-facing-errors.ts';
-import { fetchSource, formatBytes, formatMillis } from '../../utils.ts';
+import { fetchSource, formatBytes, formatMillis, type AbortablePromise } from '../../utils.ts';
 import { applyUserFacingError } from '../apply-user-facing-error.ts';
 import type { State } from '../app-state.ts';
 import { is2DFormatExtension } from '../formats.ts';
@@ -77,6 +77,24 @@ export class CompileCoordinator {
   // syntax has its own. See ADR 0007.
   private readonly _render: ReturnType<typeof createRenderDelayable>;
   private readonly _checkSyntax: ReturnType<typeof createSyntaxDelayable>;
+
+  // The in-flight render / syntax jobs, retained so cancel() can kill them
+  // (mirrors ExportService._activeRender). Each is cleared when its job settles.
+  private _activeRender: AbortablePromise<unknown> | null = null;
+  private _activeSyntax: AbortablePromise<unknown> | null = null;
+
+  /**
+   * Cancel any in-flight syntax check / render on this session (best-effort, the
+   * `cancel` of the Layer-1 command set — ADR 0008/#123). A killed job rejects
+   * with an expected cancellation, so the existing catch emits exactly one
+   * terminal `cancelled` OperationResult and clears the spinner. A job already
+   * executing `callMain` in the worker finishes there; its result is discarded by
+   * id (same as supersession).
+   */
+  cancel(): void {
+    this._activeSyntax?.kill();
+    this._activeRender?.kill();
+  }
 
   /**
    * Convert the typed sources to the flat wire shape, reading each project-local
@@ -206,7 +224,7 @@ export class CompileCoordinator {
     });
     this.ctx.mutate((s) => (s.checkingSyntax = true));
     try {
-      const checkerRun = await this._checkSyntax({
+      const syntaxJob = this._checkSyntax({
         activePath: this.ctx.getState().params.activePath,
         // The param/syntax pass never resolves `import()` (it's lazy, evaluated
         // only at geometry time), so a binary `local` asset is not needed here —
@@ -217,6 +235,11 @@ export class CompileCoordinator {
           .params.sources.filter((s) => !(s.kind === 'local' && !isProbablyTextPath(s.path))),
         revision: this.ctx.getSourceRevision(),
       })({ now: false });
+      // Retain the handle so cancel() can kill it; clear it once it settles.
+      this._activeSyntax = syntaxJob;
+      const checkerRun = await syntaxJob.finally(() => {
+        if (this._activeSyntax === syntaxJob) this._activeSyntax = null;
+      });
       if (!isCurrent()) {
         this.emitResult(operationCancelled(base())); // superseded
         return; // a newer syntax check superseded this one
@@ -369,7 +392,12 @@ export class CompileCoordinator {
         backend: this.ctx.getState().params.backend,
         revision: this.ctx.getSourceRevision(),
       };
-      const output = await this._render(renderArgs)({ now });
+      const renderJob = this._render(renderArgs)({ now });
+      // Retain the handle so cancel() can kill it; clear it once it settles.
+      this._activeRender = renderJob;
+      const output = await renderJob.finally(() => {
+        if (this._activeRender === renderJob) this._activeRender = null;
+      });
       if (!isCurrent()) {
         this.emitResult(operationCancelled(base())); // superseded
         return; // a newer render/preview superseded this one

--- a/src/state/services/export-service.ts
+++ b/src/state/services/export-service.ts
@@ -67,6 +67,13 @@ export class ExportService {
     });
   }
 
+  /** Cancel an in-flight format-conversion render (best-effort, #123). The killed
+   *  job rejects with an expected cancellation, so the existing catch emits one
+   *  terminal `cancelled` result and clears the exporting spinner. */
+  cancel(): void {
+    this._activeRender?.kill();
+  }
+
   /** Route a terminal result to the optional sink, guarding the commit path: a
    *  throwing sink must never corrupt committed state or double-emit (ADR 0008).
    *  No-op when no sink is wired. */
@@ -275,9 +282,12 @@ export class ExportService {
       });
       this.emitResult(operationSuccess(base({ elapsedMillis: output.elapsedMillis }), artifactRef));
     } catch (err) {
-      // A superseded export rejects with the delayable's cancellation; that is
-      // expected supersession, not a failure — the newer export owns the spinner.
+      // An expected cancellation is either supersession (a newer export, which
+      // owns the spinner — leave it) or an explicit cancel() of THIS still-current
+      // export (nothing newer owns the spinner, so we must clear it ourselves or
+      // it stays stuck). Distinguish by ownership, then emit one cancelled result.
       if (isExpectedJobCancellation(err)) {
+        if (isCurrent()) mutate((s) => (s.exporting = false));
         this.emitResult(operationCancelled(base()));
         return;
       }

--- a/src/state/session.ts
+++ b/src/state/session.ts
@@ -45,6 +45,11 @@ export class OpenScadSession {
     this.model.init();
   }
 
+  /** Cancel this session's in-flight compile/export operations (#123). */
+  cancel(): void {
+    this.model.cancel();
+  }
+
   /** Tear the session down: stop persistence timers and terminate the worker.
    *  Fixes the page-lifetime worker leak the singleton had. */
   dispose(): void {


### PR DESCRIPTION
## #123 Gate B — multi-file project contract, slice 2 of 3

`cancel()` + observability, the foundation the headless capstone test (slice 3) needs.

### What changed
- **`CompileCoordinator`** retains its in-flight render/syntax jobs (`_activeRender`/`_activeSyntax`, cleared via `.finally()` on settle — mirrors `ExportService._activeRender`) and gains **`cancel()`**, which kills them. A killed job rejects with the expected cancellation, so the existing catch emits exactly one terminal `cancelled` `OperationResult` and clears the spinner.
- **`ExportService.cancel()`** kills its in-flight conversion render. **Fix (adversarial-review BLOCKER):** an expected cancellation now clears the `exporting` spinner when the export is still current (an explicit `cancel()`, not superseded) — previously the catch returned before clearing, leaving the spinner stuck forever. Supersession behavior is unchanged (a newer export still owns the flag).
- **`Model.cancel()` / `OpenScadSession.cancel()`** fan out to both services.
- **Observability:** wire `ServiceContext.onOperationResult` to dispatch an `'operation'` `CustomEvent` on the `Model`, so a host binding / test can correlate terminal results (incl. `cancelled`) on `operationId`. This flips on emission that ADR 0008 slice 4 built but left unwired — now with a concrete consumer.

### Deploy safety
The UI has no `'operation'` listener; the emit is post-commit and routed through `emitResult`'s try/catch, and `dispatchEvent` runs inside it — so a throwing listener can't corrupt committed state and the commit path (mutations, object-URL revoke, chime, export token, revision stale-drop) stays byte-identical. Per-op cost is one `CustomEvent` + a no-listener dispatch.

### Tests
- Coordinator cancel: render **and** syntax → one `cancelled` result + spinner cleared; no-op when idle.
- Export cancel: clears the spinner + one `cancelled` result — **guards the stuck-spinner regression** the review caught.
- The Model `'operation'` event dispatch; `cancel()` safe when idle.
- Existing coordinator / export / two-session-isolation suites unchanged and green.

### Verification
- `npm run verify` green (format, lint, typecheck, unit w/ coverage, assembly, build, budgets, publish-archive).

Adversarially reviewed: the one BLOCKER (export cancel left `exporting` stuck) was fixed + tested before this PR; the `.finally()` handle-clearing race and the always-on dispatch were confirmed correct.

**Next:** slice 3 — `ProjectContract` interface on `OpenScadSession` + the headless complete-project-operation test (FakeBackend) + the transport-seam doc.