### PR TITLE
feat(state): ProjectContract on OpenScadSession + headless capstone (#123 slice 3)

### DIFF
--- a/src/state/__tests__/project-contract.test.ts
+++ b/src/state/__tests__/project-contract.test.ts
@@ -1,0 +1,180 @@
+// #123 Gate B capstone: one headless, end-to-end run of the multi-file project
+// contract over the REAL Model + CompileCoordinator + actions pipeline, with a
+// fake CompileBackend standing in for the WASM worker. Proves the contract's
+// operations mutate the project, drive deterministic compiles, surface terminal
+// OperationResults (success-with-artifact and cancelled) on the 'operation'
+// event, and that an artifact's exact bytes are retrievable by id.
+
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { Model } from '../model.ts';
+import { ArtifactStore } from '../artifact-store.ts';
+import type { State } from '../app-state.ts';
+import type { HostAdapter } from '../web-host-adapter.ts';
+import type { ProjectFileSystem } from '../../fs/project-filesystem.ts';
+import type { OperationResult } from '../../runner/compile-contract.ts';
+import {
+  type CompileBackend,
+  type OpenSCADInvocation,
+  type OpenSCADInvocationResults,
+} from '../../runner/openscad-runner.ts';
+import { AbortablePromise } from '../../utils.ts';
+
+// A backend that resolves immediately with canned outputs (one per requested
+// output path: valid JSON for the syntax `out.json`, OFF bytes otherwise), or —
+// in 'hang' mode — never resolves and rejects on kill() like the real delayable.
+class FakeBackend implements CompileBackend {
+  mode: 'ok' | 'hang' = 'ok';
+
+  spawn(invocation: OpenSCADInvocation): AbortablePromise<OpenSCADInvocationResults> {
+    if (this.mode === 'hang') {
+      return AbortablePromise<OpenSCADInvocationResults>(
+        (_res, rej) => () => rej(new Error('Cancelled')),
+      );
+    }
+    const outputs = (invocation.outputPaths ?? ['out']).map((p): [string, Uint8Array] => [
+      p,
+      new TextEncoder().encode(p.endsWith('.json') ? '{}' : 'OFF\n0 0 0\n'),
+    ]);
+    return AbortablePromise<OpenSCADInvocationResults>((res) => {
+      res({ outputs, mergedOutputs: [], elapsedMillis: 1, revision: invocation.revision });
+      return () => {};
+    });
+  }
+  cancel(): void {}
+  dispose(): void {}
+}
+
+let urlN = 0;
+const host = {
+  createObjectURL: () => `blob:fake-${urlN++}`,
+  revokeObjectURL: () => {},
+  download: () => {},
+  downloadBlob: () => {},
+  playCompletionChime: () => {},
+  baseUrl: () => 'http://localhost/',
+} as unknown as HostAdapter;
+
+const fakeFs = {
+  readFileSync: () => new Uint8Array(),
+  writeFile: () => {},
+} as unknown as ProjectFileSystem;
+
+function baseState(): State {
+  return {
+    params: {
+      activePath: '/home/seed.scad',
+      sources: [{ kind: 'text', path: '/home/seed.scad', content: 'cube(0);' }],
+      features: [],
+      exportFormat2D: 'svg',
+      exportFormat3D: 'stl',
+    },
+    view: {
+      layout: { mode: 'multi', editor: true, viewer: true, customizer: false },
+      color: '#000',
+    },
+  } as State;
+}
+
+function makeModel(backend: FakeBackend) {
+  const model = new Model(
+    fakeFs,
+    baseState(),
+    undefined,
+    undefined,
+    host,
+    backend,
+    'sess',
+    new ArtifactStore(),
+  );
+  const ops: OperationResult[] = [];
+  model.addEventListener('operation', (e) => ops.push((e as CustomEvent<OperationResult>).detail));
+  return { model, ops };
+}
+
+// Flush the syntax (300ms) + render (1000ms) debounces and the resolved jobs.
+const settle = () => vi.advanceTimersByTimeAsync(1200);
+
+describe('#123 multi-file project contract — headless end to end', () => {
+  beforeEach(() => vi.useFakeTimers());
+  afterEach(() => vi.useRealTimers());
+
+  it('setProject → render commits a retrievable artifact and a success result', async () => {
+    const { model, ops } = makeModel(new FakeBackend());
+
+    model.setProject(
+      [
+        { path: 'a.scad', content: 'cube(1);' },
+        { path: 'main.scad', content: 'use <a.scad>\nsphere(1);' },
+      ],
+      'main.scad',
+    );
+    await settle();
+
+    expect(model.state.params.sources.map((s) => s.path)).toEqual([
+      '/home/a.scad',
+      '/home/main.scad',
+    ]);
+    expect(model.state.params.activePath).toBe('/home/main.scad');
+
+    const success = ops.find((o) => o.status === 'success' && o.artifact);
+    expect(success).toBeDefined();
+    if (success?.status === 'success' && success.artifact) {
+      expect(success.sessionId).toBe('sess');
+      expect(success.artifact.format).toBe('off');
+      // The exact bytes are retrievable by the immutable artifactId.
+      const stored = model.getStoredArtifact(success.artifact.artifactId);
+      expect(stored).toBeDefined();
+      expect(stored!.bytes).toBe(model.state.output!.outFile);
+    }
+  });
+
+  it('updateFile → setEntryPoint → removeFile drive deterministic recompiles', async () => {
+    const { model, ops } = makeModel(new FakeBackend());
+    model.setProject(
+      [
+        { path: 'a.scad', content: 'cube(1);' },
+        { path: 'main.scad', content: 'use <a.scad>\nsphere(1);' },
+      ],
+      'main.scad',
+    );
+    await settle();
+
+    // Update a non-active file — the entry (which `use`s it) recompiles.
+    ops.length = 0;
+    model.updateFile('a.scad', 'cube(2);');
+    await settle();
+    const aSrc = model.state.params.sources.find((s) => s.path === '/home/a.scad');
+    expect(aSrc && 'content' in aSrc ? aSrc.content : undefined).toBe('cube(2);');
+    expect(ops.some((o) => o.status === 'success')).toBe(true);
+
+    // Switch the entry point.
+    model.setEntryPoint('a.scad');
+    await settle();
+    expect(model.state.params.activePath).toBe('/home/a.scad');
+
+    // Remove the active entry → deterministic re-point to main.scad.
+    model.removeFile('a.scad');
+    await settle();
+    expect(model.state.params.sources.map((s) => s.path)).toEqual(['/home/main.scad']);
+    expect(model.state.params.activePath).toBe('/home/main.scad');
+  });
+
+  it('cancel() surfaces a terminal cancelled result for the in-flight compile', async () => {
+    const backend = new FakeBackend();
+    const { model, ops } = makeModel(backend);
+
+    backend.mode = 'hang'; // the next compile never resolves
+    model.setProject([{ path: 'main.scad', content: 'sphere(1);' }], 'main.scad');
+    await settle(); // the debounced syntax + render jobs start and hang
+
+    model.cancel();
+    await vi.advanceTimersByTimeAsync(0);
+
+    expect(ops.some((o) => o.status === 'cancelled')).toBe(true);
+    // The cancelled compile cleared its spinners.
+    expect(model.state.rendering).toBeFalsy();
+    expect(model.state.previewing).toBeFalsy();
+    expect(model.state.checkingSyntax).toBeFalsy();
+  });
+});

--- a/src/state/project-contract.ts
+++ b/src/state/project-contract.ts
@@ -1,0 +1,32 @@
+import type { ProjectFile } from './project-store.ts';
+
+export type { ProjectFile };
+
+/**
+ * The host-drivable project + lifecycle operations a session exposes (#123, Gate
+ * B). Typed methods over the same `params.sources` / `activePath` state the
+ * editor uses — text files first (#121). Each mutation funnels through one
+ * `mutate` then drives a recompile; terminal results are observed via the Model's
+ * `'operation'` event (correlated on `operationId`), not return values, matching
+ * the fire-and-recompile shape of every compile-triggering method.
+ *
+ * **Transport seam.** This is the in-process binding. A future
+ * `src/protocol/session-transport.ts` maps the ADR-0005 envelope onto these
+ * methods 1:1 — `{type:'setProject', …}` → `setProject(…)`, the envelope's `opId`
+ * ↔ the `OperationResult.operationId`, and a terminal `OperationResult` → a
+ * response message — so the postMessage binding and this interface share one set
+ * of handlers. No wire protocol ships until a host (VS Code webview, embed)
+ * actually consumes it; building it now would be a consumer-less protocol.
+ */
+export interface ProjectContract {
+  /** Replace the whole project; select `entryPoint` (or the rule) as active. */
+  setProject(files: ProjectFile[], entryPoint?: string): void;
+  /** Add or replace one text file's content (active file unchanged). */
+  updateFile(path: string, content: string): void;
+  /** Remove one source; re-point the entry deterministically if it was active. */
+  removeFile(path: string): void;
+  /** Change which file compiles (the entry point). */
+  setEntryPoint(path: string): void;
+  /** Cancel in-flight compile/export operations on this session. */
+  cancel(): void;
+}

--- a/src/state/session.ts
+++ b/src/state/session.ts
@@ -2,6 +2,7 @@ import { Model } from './model.ts';
 import { WasmWorkerBackend, type CompileBackend } from '../runner/openscad-runner.ts';
 import { newId } from '../runner/compile-contract.ts';
 import { ArtifactStore } from './artifact-store.ts';
+import type { ProjectFile, ProjectContract } from './project-contract.ts';
 import type { ProjectFileSystem } from '../fs/project-filesystem.ts';
 import type { State, StatePersister } from './app-state.ts';
 import type { HostAdapter } from './web-host-adapter.ts';
@@ -12,8 +13,11 @@ import type { HostAdapter } from './web-host-adapter.ts';
  * on one page share nothing — no worker, id space, pending jobs, or schedulers —
  * and can be torn down independently. The app constructs exactly one; future
  * multi-document hosts construct N.
+ *
+ * It implements the host-drivable {@link ProjectContract} (#123) by delegating to
+ * its Model — the in-process binding a future transport maps onto (ADR 0005).
  */
-export class OpenScadSession {
+export class OpenScadSession implements ProjectContract {
   /** Stable session id, for routing/debug correlation of operations/artifacts. */
   readonly id = newId();
   readonly backend: CompileBackend;
@@ -43,6 +47,20 @@ export class OpenScadSession {
   /** Kick off the initial compile (delegates to the model). */
   init(): void {
     this.model.init();
+  }
+
+  // --- ProjectContract (#123): host-drivable project ops, delegated to Model ---
+  setProject(files: ProjectFile[], entryPoint?: string): void {
+    this.model.setProject(files, entryPoint);
+  }
+  updateFile(path: string, content: string): void {
+    this.model.updateFile(path, content);
+  }
+  removeFile(path: string): void {
+    this.model.removeFile(path);
+  }
+  setEntryPoint(path: string): void {
+    this.model.setEntryPoint(path);
   }
 
   /** Cancel this session's in-flight compile/export operations (#123). */


### PR DESCRIPTION
## #123 Gate B — multi-file project contract, slice 3 of 3 (final)

The session-level contract surface + the headless complete-project-operation test.

### What changed
- **New `src/state/project-contract.ts`**: the `ProjectContract` interface (`setProject` / `updateFile` / `removeFile` / `setEntryPoint` / `cancel`) — the **in-process binding**, documented with the **transport seam**: a future `session-transport.ts` maps the ADR-0005 envelope onto these methods 1:1 (`opId` ↔ `operationId`, terminal `OperationResult` → response). No wire protocol ships until a host (VS Code webview, embed) consumes it.
- **`OpenScadSession implements ProjectContract`** — four delegating methods (`cancel` existed); the `implements` clause gives compile-time coverage that the surface is complete.
- **New headless capstone test** (#123's "one complete project operation") — drives the **real** `Model` + `CompileCoordinator` + `actions` pipeline with a `FakeBackend implements CompileBackend` (canned results / a hang+kill mode) and fake timers, proving end to end:
  - `setProject` → a preview render **commits an artifact whose exact bytes are retrievable by `artifactId`**, surfaced as a terminal **success** `OperationResult` on the `'operation'` event (with the correlated `sessionId`);
  - `updateFile` / `setEntryPoint` / `removeFile` drive deterministic recompiles and the deterministic entry re-point;
  - `cancel()` surfaces a terminal **cancelled** result and clears the spinners.

### Verification
- `npm run verify` green (format, lint, typecheck, unit w/ coverage, assembly, build, budgets, publish-archive).

Adversarially reviewed for **test faithfulness**: the revision echo, the cancel kill→`'Cancelled'`→`isExpectedJobCancellation` path, and the commit/store File-identity are all genuinely exercised — the suite goes red if cancel or commit break. No false-pass holes; no BLOCKER/SHOULD-FIX. (Happy-path capstone; failure/diagnostics/stale-drop/dimension-retry remain covered by the coordinator suites.)

With this, Gate B's required tests are both in place (headless complete-project-operation + two-session isolation). Remaining #123: the optional State-container split and the binary-assets MVP decision doc (#121, text-first).