### PR TITLE
refactor(viewer): extract ViewerController + pluggable Transport (#173)

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -121,6 +121,76 @@ export default tseslint.config(
     },
   },
 
+  // The Layer-0 protocol is the DISTRIBUTABLE, DOM-free wire contract (#143/#176):
+  // it must import nothing outside src/protocol/ so it stays portable to a
+  // separate consumer (a VS Code extension) and publishable as-is.
+  {
+    files: ['src/protocol/**/*.ts'],
+    ignores: ['src/protocol/__tests__/**'],
+    rules: {
+      'no-restricted-imports': [
+        'error',
+        {
+          patterns: [
+            {
+              group: ['../*', '../**'],
+              message:
+                'src/protocol is the distributable wire contract: no imports outside src/protocol.',
+            },
+          ],
+        },
+      ],
+    },
+  },
+
+  // The viewer-host (controller + transports) is the host-binding tier (#143/#173):
+  // it may use the protocol and the reusable viewer, but NOT the app shell, state,
+  // language, Monaco, or the editor — so the VS Code work stays isolated from the
+  // main app.
+  {
+    files: ['src/viewer-host/**/*.ts'],
+    rules: {
+      'no-restricted-imports': [
+        'error',
+        {
+          patterns: [
+            {
+              group: [
+                '**/state/**',
+                '**/language/**',
+                'monaco-editor',
+                'monaco-editor/**',
+                '**/osc-editor-panel*',
+                '**/osc-app-shell*',
+                '**/model*',
+              ],
+              message: 'The viewer host must not import the app shell, state, or editor.',
+            },
+          ],
+        },
+      ],
+    },
+  },
+
+  // The app must not reach into the viewer-host transports (reverse direction):
+  // host-binding code is consumed only by the viewer entry composition root.
+  {
+    files: ['src/components/**/*.ts', 'src/state/**/*.ts'],
+    rules: {
+      'no-restricted-imports': [
+        'error',
+        {
+          patterns: [
+            {
+              group: ['**/viewer-host/**'],
+              message: 'App code must not import the viewer-host transports.',
+            },
+          ],
+        },
+      ],
+    },
+  },
+
   // JavaScript/ESM rules applied to Node scripts and root JS config files
   {
     files: ['scripts/**/*.mjs', '*.js'],

--- a/src/viewer-entry/index.ts
+++ b/src/viewer-entry/index.ts
@@ -3,52 +3,13 @@
 // NOTHING from the app shell — no Model, BrowserFS, OpenSCAD WASM, Monaco, or
 // service worker — so it can run inside a VS Code webview or any iframe host.
 // scripts/verify-viewer-bundle.mjs enforces that exclusion at build time.
+//
+// This is just the composition root: create the viewer element, pick a transport
+// for the host environment, and let the ViewerController wire them together.
 
 import '../components/elements/osc-geometry-viewer.ts';
-import { isTrustedOrigin } from '../protocol/envelope.ts';
-import {
-  validateViewerInbound,
-  viewerCameraChange,
-  viewerCameraSet,
-  viewerDisposed,
-  viewerError,
-  viewerGeometryLoaded,
-  viewerGeometrySet,
-  viewerReady,
-  viewerSettingsSet,
-} from '../protocol/viewer-transport.ts';
-import type { CameraState } from '../components/viewer/ThreeScene.ts';
-
-type GeometryViewer = HTMLElement & {
-  offText: string | null;
-  color: string;
-  showAxes: boolean;
-  active: boolean;
-  generateThumbnails: boolean;
-  setCamera(camera: CameraState): void;
-};
-
-const selfOrigin = window.location.origin;
-// A trusted parent origin may be injected via ?parentOrigin=…; parse it as a URL
-// and keep only the origin, rejecting malformed values and unsupported schemes
-// (and never the wildcard). A bad value falls back to same-origin-only trust.
-function canonicalOrigin(raw: string | null): string | null {
-  if (raw == null) return null;
-  try {
-    const url = new URL(raw);
-    return url.protocol === 'https:' || url.protocol === 'http:' ? url.origin : null;
-  } catch {
-    return null;
-  }
-}
-const parentOrigin = canonicalOrigin(
-  new URLSearchParams(window.location.search).get('parentOrigin'),
-);
-const targetOrigin = parentOrigin ?? selfOrigin;
-// The viewer is meant to be embedded (iframe / webview): the host is the parent
-// frame. When opened top-level there is no host — don't post to ourselves (that
-// would re-enter our own inbound handler).
-const host: Window | null = window.parent !== window ? window.parent : null;
+import { ViewerController, type GeometryViewer } from '../viewer-host/controller.ts';
+import { BrowserParentTransport } from '../viewer-host/transports/browser-parent.ts';
 
 const root = document.getElementById('viewer-root')!;
 const viewer = document.createElement('osc-geometry-viewer') as GeometryViewer;
@@ -56,67 +17,4 @@ const viewer = document.createElement('osc-geometry-viewer') as GeometryViewer;
 viewer.generateThumbnails = false;
 root.appendChild(viewer);
 
-function post(message: object): void {
-  host?.postMessage(message, targetOrigin);
-}
-
-// The opId of the in-flight setGeometry, so the (async) render outcome it
-// produces — geometry-loaded or a render error — can be correlated back to it.
-// Only setGeometry sets viewer.offText, so every load maps to one setGeometry.
-let geometryOpId: string | undefined;
-
-// Forward viewer events to the host.
-viewer.addEventListener('camera-change', (e) => {
-  post(viewerCameraChange((e as CustomEvent<CameraState>).detail));
-});
-viewer.addEventListener('geometry-loaded', (e) => {
-  post(
-    viewerGeometryLoaded((e as CustomEvent<{ thumbhash?: string }>).detail.thumbhash, geometryOpId),
-  );
-});
-viewer.addEventListener('viewer-error', (e) => {
-  // A render/parse failure of host-supplied geometry — distinct from a protocol
-  // validation rejection — correlated to the setGeometry that triggered it.
-  post(viewerError('render-error', String((e as CustomEvent).detail), geometryOpId));
-});
-
-const onMessage = (event: MessageEvent): void => {
-  // Trust both the origin AND the sender window: a same-origin sibling frame
-  // must not be able to drive the viewer. When embedded, only the host frame.
-  if (host !== null && event.source !== host) return;
-  if (!isTrustedOrigin(event.origin, parentOrigin, selfOrigin)) return;
-  const result = validateViewerInbound(event.data);
-  if (!result.ok) {
-    post(viewerError(result.code, result.reason, result.opId));
-    return;
-  }
-  const msg = result.message;
-  switch (msg.type) {
-    case 'setGeometry':
-      geometryOpId = msg.opId; // correlate the eventual geometry-loaded / error
-      viewer.offText = msg.offText;
-      post(viewerGeometrySet(msg.opId)); // accepted; render outcome follows
-      break;
-    case 'setViewerSettings':
-      if (msg.color !== undefined) viewer.color = msg.color;
-      if (msg.showAxes !== undefined) viewer.showAxes = msg.showAxes;
-      if (msg.active !== undefined) viewer.active = msg.active;
-      post(viewerSettingsSet(msg.opId));
-      break;
-    case 'setCamera':
-      viewer.setCamera(msg.camera);
-      post(viewerCameraSet(msg.opId));
-      break;
-    case 'dispose':
-      // Tear down fully: remove the element (disposes the GL scene) and stop
-      // listening, so no further messages are silently swallowed.
-      viewer.remove();
-      window.removeEventListener('message', onMessage);
-      post(viewerDisposed(msg.opId));
-      break;
-  }
-};
-window.addEventListener('message', onMessage);
-
-// Announce readiness and the supported inbound commands.
-post(viewerReady(['setGeometry', 'setViewerSettings', 'setCamera', 'dispose']));
+new ViewerController(viewer, new BrowserParentTransport());

--- a/src/viewer-host/__tests__/controller.test.ts
+++ b/src/viewer-host/__tests__/controller.test.ts
@@ -1,0 +1,122 @@
+import { describe, expect, it } from 'vitest';
+
+import { ViewerController, type GeometryViewer } from '../controller.ts';
+import { InProcessTestTransport } from '../transports/in-process.ts';
+import { VIEWER_PROTOCOL_VERSION } from '../../protocol/viewer-transport.ts';
+
+const V = VIEWER_PROTOCOL_VERSION;
+
+// A minimal stand-in for <osc-geometry-viewer>: EventTarget gives the
+// add/removeEventListener + dispatchEvent surface the controller uses.
+class FakeViewer extends EventTarget {
+  offText: string | null = null;
+  color = '';
+  showAxes = true;
+  active = true;
+  generateThumbnails = false;
+  camera: unknown;
+  removed = false;
+  setCamera(camera: unknown): void {
+    this.camera = camera;
+  }
+  remove(): void {
+    this.removed = true;
+  }
+}
+
+function setup() {
+  const viewer = new FakeViewer();
+  const transport = new InProcessTestTransport();
+  const controller = new ViewerController(viewer as unknown as GeometryViewer, transport);
+  return { viewer, transport, controller };
+}
+
+const sentTypes = (t: InProcessTestTransport) => t.sent.map((m) => (m as { type: string }).type);
+
+describe('ViewerController', () => {
+  it('announces ready (after subscribing) with the supported commands', () => {
+    const { transport } = setup();
+    expect(transport.sent).toHaveLength(1);
+    expect(transport.sent[0]).toMatchObject({
+      type: 'ready',
+      capabilities: ['setGeometry', 'setViewerSettings', 'setCamera', 'dispose'],
+    });
+  });
+
+  it('applies setGeometry and acks with geometry-set, correlating opId', () => {
+    const { viewer, transport } = setup();
+    transport.receive({
+      protocolVersion: V,
+      type: 'setGeometry',
+      offText: 'OFF\n0 0 0\n',
+      opId: 'g1',
+    });
+    expect(viewer.offText).toBe('OFF\n0 0 0\n');
+    expect(transport.sent.at(-1)).toMatchObject({ type: 'geometry-set', opId: 'g1' });
+  });
+
+  it('forwards geometry-loaded to the host, correlated to the setGeometry opId', () => {
+    const { viewer, transport } = setup();
+    transport.receive({ protocolVersion: V, type: 'setGeometry', offText: 'x', opId: 'g1' });
+    viewer.dispatchEvent(new CustomEvent('geometry-loaded', { detail: { thumbhash: 'h' } }));
+    expect(transport.sent.at(-1)).toMatchObject({
+      type: 'geometry-loaded',
+      thumbhash: 'h',
+      opId: 'g1',
+    });
+  });
+
+  it('forwards a render failure as a correlated render-error', () => {
+    const { viewer, transport } = setup();
+    transport.receive({ protocolVersion: V, type: 'setGeometry', offText: 'x', opId: 'g2' });
+    viewer.dispatchEvent(new CustomEvent('viewer-error', { detail: 'boom' }));
+    expect(transport.sent.at(-1)).toMatchObject({
+      type: 'error',
+      code: 'render-error',
+      opId: 'g2',
+    });
+  });
+
+  it('applies setViewerSettings (only provided fields) and acks', () => {
+    const { viewer, transport } = setup();
+    transport.receive({ protocolVersion: V, type: 'setViewerSettings', color: '#abc', opId: 's1' });
+    expect(viewer.color).toBe('#abc');
+    expect(viewer.showAxes).toBe(true); // untouched
+    expect(transport.sent.at(-1)).toMatchObject({ type: 'viewer-settings-set', opId: 's1' });
+  });
+
+  it('applies setCamera and acks; forwards camera-change from the viewer', () => {
+    const { viewer, transport } = setup();
+    const camera = { position: [1, 2, 3], target: [0, 0, 0], zoom: 1.5 };
+    transport.receive({ protocolVersion: V, type: 'setCamera', camera, opId: 'c1' });
+    expect(viewer.camera).toEqual(camera);
+    expect(transport.sent.at(-1)).toMatchObject({ type: 'camera-set', opId: 'c1' });
+
+    viewer.dispatchEvent(new CustomEvent('camera-change', { detail: camera }));
+    expect(transport.sent.at(-1)).toMatchObject({ type: 'camera-change', camera });
+  });
+
+  it('rejects an invalid inbound payload with a protocol error', () => {
+    const { transport } = setup();
+    transport.receive({ protocolVersion: V + 99, type: 'setGeometry', offText: 'x' });
+    expect(transport.sent.at(-1)).toMatchObject({ type: 'error', code: 'unsupported-version' });
+  });
+
+  it('dispose acks, removes the viewer, and ignores subsequent commands', () => {
+    const { viewer, transport } = setup();
+    transport.receive({ protocolVersion: V, type: 'dispose', opId: 'd1' });
+    expect(transport.sent.at(-1)).toMatchObject({ type: 'disposed', opId: 'd1' });
+    expect(viewer.removed).toBe(true);
+
+    const before = transport.sent.length;
+    transport.receive({ protocolVersion: V, type: 'setGeometry', offText: 'y', opId: 'g9' });
+    expect(transport.sent.length).toBe(before); // detached — no further output
+    expect(viewer.offText).toBeNull(); // not applied
+  });
+
+  it('does not emit acks/events for non-setGeometry before any geometry op', () => {
+    const { transport } = setup();
+    // ready only so far
+    expect(sentTypes(transport)).toEqual(['ready']);
+  });
+});

--- a/src/viewer-host/controller.ts
+++ b/src/viewer-host/controller.ts
@@ -1,0 +1,114 @@
+// Transport-agnostic Layer-0 viewer controller (ADR 0005 / #143). It wires a
+// `<osc-geometry-viewer>` element to a `Transport`: validates inbound commands,
+// applies them to the viewer, posts the correlated acks/events, forwards the
+// viewer's own events to the host, and tears everything down on `dispose`.
+//
+// It imports ONLY the protocol (DOM-free wire contract) — never the app shell,
+// state, Monaco, or the editor — so the viewer host stays cleanly isolated.
+
+import {
+  validateViewerInbound,
+  viewerCameraChange,
+  viewerCameraSet,
+  viewerDisposed,
+  viewerError,
+  viewerGeometryLoaded,
+  viewerGeometrySet,
+  viewerReady,
+  viewerSettingsSet,
+  type CameraPose,
+} from '../protocol/viewer-transport.ts';
+import type { Transport } from './transport.ts';
+
+/**
+ * The structural surface the controller drives on `<osc-geometry-viewer>`. Typed
+ * with the protocol's `CameraPose` (structurally identical to the component's
+ * camera state) so the controller needs no import from the viewer component.
+ */
+export type GeometryViewer = HTMLElement & {
+  offText: string | null;
+  color: string;
+  showAxes: boolean;
+  active: boolean;
+  generateThumbnails: boolean;
+  setCamera(camera: CameraPose): void;
+};
+
+export class ViewerController {
+  // The opId of the in-flight setGeometry, so its (async) render outcome —
+  // geometry-loaded or a render error — correlates back. Only setGeometry sets
+  // offText, so every load maps to one setGeometry.
+  private geometryOpId: string | undefined;
+  private disposed = false;
+
+  constructor(
+    private readonly viewer: GeometryViewer,
+    private readonly transport: Transport,
+  ) {
+    viewer.addEventListener('camera-change', this.onCameraChange);
+    viewer.addEventListener('geometry-loaded', this.onGeometryLoaded);
+    viewer.addEventListener('viewer-error', this.onViewerError);
+    // Attach the inbound handler BEFORE announcing readiness, so a host that
+    // sends a command the instant it sees `ready` is never racing our listener.
+    transport.subscribe(this.onInbound);
+    transport.send(viewerReady(['setGeometry', 'setViewerSettings', 'setCamera', 'dispose']));
+  }
+
+  private onCameraChange = (e: Event): void => {
+    this.transport.send(viewerCameraChange((e as CustomEvent<CameraPose>).detail));
+  };
+  private onGeometryLoaded = (e: Event): void => {
+    const { thumbhash } = (e as CustomEvent<{ thumbhash?: string }>).detail;
+    this.transport.send(viewerGeometryLoaded(thumbhash, this.geometryOpId));
+  };
+  private onViewerError = (e: Event): void => {
+    // A render/parse failure of host-supplied geometry — distinct from a protocol
+    // validation rejection — correlated to the setGeometry that triggered it.
+    this.transport.send(
+      viewerError('render-error', String((e as CustomEvent).detail), this.geometryOpId),
+    );
+  };
+
+  private onInbound = (payload: unknown): void => {
+    if (this.disposed) return; // commands after disposal are ignored, not queued
+    const result = validateViewerInbound(payload);
+    if (!result.ok) {
+      this.transport.send(viewerError(result.code, result.reason, result.opId));
+      return;
+    }
+    const msg = result.message;
+    switch (msg.type) {
+      case 'setGeometry':
+        this.geometryOpId = msg.opId; // correlate the eventual geometry-loaded / error
+        this.viewer.offText = msg.offText;
+        this.transport.send(viewerGeometrySet(msg.opId)); // accepted; render outcome follows
+        break;
+      case 'setViewerSettings':
+        if (msg.color !== undefined) this.viewer.color = msg.color;
+        if (msg.showAxes !== undefined) this.viewer.showAxes = msg.showAxes;
+        if (msg.active !== undefined) this.viewer.active = msg.active;
+        this.transport.send(viewerSettingsSet(msg.opId));
+        break;
+      case 'setCamera':
+        this.viewer.setCamera(msg.camera);
+        this.transport.send(viewerCameraSet(msg.opId));
+        break;
+      case 'dispose':
+        this.transport.send(viewerDisposed(msg.opId)); // ack before tearing down
+        this.dispose();
+        break;
+    }
+  };
+
+  /** Tear down fully: stop forwarding, remove the element (disposes the GL
+   *  scene), and detach the transport. Idempotent. */
+  dispose(): void {
+    if (this.disposed) return;
+    this.disposed = true;
+    this.viewer.removeEventListener('camera-change', this.onCameraChange);
+    this.viewer.removeEventListener('geometry-loaded', this.onGeometryLoaded);
+    this.viewer.removeEventListener('viewer-error', this.onViewerError);
+    this.viewer.remove();
+    this.transport.dispose();
+  }
+}

--- a/src/viewer-host/transport.ts
+++ b/src/viewer-host/transport.ts
@@ -1,0 +1,24 @@
+// The host-binding abstraction for the Layer-0 viewer (ADR 0005 / #143). A
+// `ViewerController` drives an `<osc-geometry-viewer>` over a `Transport`, so the
+// same viewer runs in an iframe (BrowserParentTransport), a VS Code webview
+// (VsCodeWebviewTransport), or a test (InProcessTestTransport) with no change to
+// the controller or the protocol.
+//
+// Trust is the transport's responsibility, not the controller's: each
+// implementation decides which inbound messages it accepts (origin + sender-frame
+// for an iframe; the channel itself for a webview) and only hands accepted
+// payloads to the controller, which then validates them against the protocol.
+
+export interface Transport {
+  /** Send one outbound message to the host. */
+  send(message: object): void;
+  /**
+   * Register the single handler for TRUSTED inbound payloads. The transport
+   * applies its own trust filtering first, so `handler` only sees messages the
+   * transport accepts; the controller still validates each payload against the
+   * protocol. Calling again replaces the handler.
+   */
+  subscribe(handler: (payload: unknown) => void): void;
+  /** Detach the inbound handler and release the transport's resources. */
+  dispose(): void;
+}

--- a/src/viewer-host/transports/__tests__/browser-parent.test.ts
+++ b/src/viewer-host/transports/__tests__/browser-parent.test.ts
@@ -1,0 +1,90 @@
+import { afterEach, describe, expect, it } from 'vitest';
+
+import { BrowserParentTransport, canonicalOrigin } from '../browser-parent.ts';
+
+describe('canonicalOrigin', () => {
+  it('keeps the origin of a valid http(s) URL', () => {
+    expect(canonicalOrigin('https://host.example.com/path?x=1')).toBe('https://host.example.com');
+    expect(canonicalOrigin('http://localhost:3000')).toBe('http://localhost:3000');
+  });
+
+  it('rejects null, malformed, the wildcard, and unsupported schemes', () => {
+    expect(canonicalOrigin(null)).toBeNull();
+    expect(canonicalOrigin('not a url')).toBeNull();
+    expect(canonicalOrigin('*')).toBeNull();
+    expect(canonicalOrigin('javascript:alert(1)')).toBeNull();
+    expect(canonicalOrigin('file:///etc/passwd')).toBeNull();
+  });
+});
+
+describe('BrowserParentTransport trust filtering', () => {
+  const realParent = window.parent;
+  const restoreParent = () =>
+    Object.defineProperty(window, 'parent', { configurable: true, value: realParent });
+  const setParent = (parent: unknown) =>
+    Object.defineProperty(window, 'parent', { configurable: true, value: parent });
+
+  afterEach(restoreParent);
+
+  function collect(t: BrowserParentTransport) {
+    const seen: unknown[] = [];
+    t.subscribe((p) => seen.push(p));
+    return seen;
+  }
+
+  it('rejects a message from a wrong origin', () => {
+    const t = new BrowserParentTransport();
+    const seen = collect(t);
+    window.dispatchEvent(
+      new MessageEvent('message', { data: { a: 1 }, origin: 'https://evil.example' }),
+    );
+    expect(seen).toHaveLength(0);
+    t.dispose();
+  });
+
+  it('accepts a message from the trusted (self) origin when top-level', () => {
+    const t = new BrowserParentTransport();
+    const seen = collect(t);
+    window.dispatchEvent(
+      new MessageEvent('message', { data: { a: 1 }, origin: window.location.origin }),
+    );
+    expect(seen).toEqual([{ a: 1 }]);
+    t.dispose();
+  });
+
+  it('rejects a message whose source is not the host frame (sibling-frame defense)', () => {
+    const fakeParent = {} as Window;
+    setParent(fakeParent);
+    const t = new BrowserParentTransport();
+    const seen = collect(t);
+    // Correct origin but WRONG source (a sibling, not the host) -> rejected.
+    window.dispatchEvent(
+      new MessageEvent('message', {
+        data: { a: 1 },
+        origin: window.location.origin,
+        source: window as unknown as MessageEventSource,
+      }),
+    );
+    expect(seen).toHaveLength(0);
+    // Correct source (the host frame) AND origin -> accepted.
+    window.dispatchEvent(
+      new MessageEvent('message', {
+        data: { b: 2 },
+        origin: window.location.origin,
+        source: fakeParent as unknown as MessageEventSource,
+      }),
+    );
+    expect(seen).toEqual([{ b: 2 }]);
+    t.dispose();
+  });
+
+  it('dispose detaches the listener', () => {
+    const t = new BrowserParentTransport();
+    const seen = collect(t);
+    t.dispose();
+    window.dispatchEvent(
+      new MessageEvent('message', { data: { a: 1 }, origin: window.location.origin }),
+    );
+    expect(seen).toHaveLength(0);
+  });
+});

--- a/src/viewer-host/transports/browser-parent.ts
+++ b/src/viewer-host/transports/browser-parent.ts
@@ -1,0 +1,59 @@
+// The iframe/embedded `Transport`: outbound goes to the parent frame, inbound is
+// trusted only from that frame AND the configured origin. This is the original
+// viewer-entry behaviour, extracted verbatim (ADR 0005 / #143).
+
+import { isTrustedOrigin } from '../../protocol/envelope.ts';
+import type { Transport } from '../transport.ts';
+
+/** Parse `?parentOrigin=…` to a bare origin, rejecting malformed values and
+ *  unsupported schemes (never the wildcard); a bad value falls back to
+ *  same-origin-only trust. Exported for unit testing. */
+export function canonicalOrigin(raw: string | null): string | null {
+  if (raw == null) return null;
+  try {
+    const url = new URL(raw);
+    return url.protocol === 'https:' || url.protocol === 'http:' ? url.origin : null;
+  } catch {
+    return null;
+  }
+}
+
+export class BrowserParentTransport implements Transport {
+  private readonly selfOrigin = window.location.origin;
+  private readonly parentOrigin = canonicalOrigin(
+    new URLSearchParams(window.location.search).get('parentOrigin'),
+  );
+  private readonly targetOrigin = this.parentOrigin ?? this.selfOrigin;
+  // Embedded (iframe / webview): the host is the parent frame. Opened top-level
+  // there is no host — don't post to ourselves and re-enter our own handler.
+  private readonly host: Window | null = window.parent !== window ? window.parent : null;
+  private listener: ((e: MessageEvent) => void) | null = null;
+
+  send(message: object): void {
+    this.host?.postMessage(message, this.targetOrigin);
+  }
+
+  subscribe(handler: (payload: unknown) => void): void {
+    this.detach();
+    const listener = (event: MessageEvent): void => {
+      // Trust both the origin AND the sender window: a same-origin sibling frame
+      // must not drive the viewer; when embedded, only the host frame.
+      if (this.host !== null && event.source !== this.host) return;
+      if (!isTrustedOrigin(event.origin, this.parentOrigin, this.selfOrigin)) return;
+      handler(event.data);
+    };
+    this.listener = listener;
+    window.addEventListener('message', listener);
+  }
+
+  dispose(): void {
+    this.detach();
+  }
+
+  private detach(): void {
+    if (this.listener) {
+      window.removeEventListener('message', this.listener);
+      this.listener = null;
+    }
+  }
+}

--- a/src/viewer-host/transports/in-process.ts
+++ b/src/viewer-host/transports/in-process.ts
@@ -1,0 +1,29 @@
+// A direct, trust-free `Transport` for unit-testing `ViewerController` without a
+// DOM message channel: `receive()` injects an inbound payload as if from the
+// host; `sent` records outbound messages for assertions.
+
+import type { Transport } from '../transport.ts';
+
+export class InProcessTestTransport implements Transport {
+  /** Outbound messages the controller has sent, in order. */
+  readonly sent: object[] = [];
+  private handler: ((payload: unknown) => void) | null = null;
+
+  send(message: object): void {
+    this.sent.push(message);
+  }
+
+  subscribe(handler: (payload: unknown) => void): void {
+    this.handler = handler;
+  }
+
+  dispose(): void {
+    this.handler = null;
+  }
+
+  /** Deliver an inbound payload to the controller as if from the host. No-op once
+   *  disposed (mirrors a real transport whose channel is detached). */
+  receive(payload: unknown): void {
+    this.handler?.(payload);
+  }
+}


### PR DESCRIPTION
## #143 Phase 0, slice 1 of 5 — the host-neutral viewer seam

Behavior-preserving extraction of the host-binding logic out of `viewer-entry` into an isolated **`src/viewer-host/`** tier, so the same viewer runs in an iframe today and a VS Code webview next — **cleanly separated from the main app**.

### What changed
- **`src/viewer-host/transport.ts`** — the `Transport` interface (`send`/`subscribe`/`dispose`). Trust is the transport's job; the controller only validates + applies.
- **`src/viewer-host/controller.ts`** — `ViewerController`, transport-agnostic, **imports only the protocol**. `GeometryViewer.setCamera` is typed with the protocol's `CameraPose` (structurally identical to the component's `CameraState`) so it needs no viewer-component import. Dispose now also removes the viewer event listeners (the old code leaked them — a correctness improvement).
- **`src/viewer-host/transports/browser-parent.ts`** — the iframe transport: the dual trust check (`event.source === host` **and** `isTrustedOrigin`) + `?parentOrigin` canonicalization + self-loop guard, extracted verbatim.
- **`src/viewer-host/transports/in-process.ts`** — a trust-free transport for tests.
- **`viewer-entry/index.ts`** is now a thin composition root.

### Isolation (the point)
Edit-time lint fences (extend `no-restricted-imports`):
- `src/protocol/**` imports **nothing outward** → keeps it distributable (#176).
- `src/viewer-host/**` must not import the app shell / `state` / Monaco / editor.
- app code must not import `src/viewer-host/**` (reverse direction).

### Tests
- `controller.test.ts` via `InProcessTestTransport` — every command + ack + forwarded event + validation error + dispose/ignore-after-dispose (9).
- `browser-parent.test.ts` — the **security-critical trust filtering** (wrong-origin reject, self-origin accept, **sibling-frame-source reject**, dispose detach) + `canonicalOrigin` (6). *(Added in response to the adversarial review, which flagged this had zero direct coverage.)*
- The iframe e2e (`tests/viewer.spec.ts`) passes **unchanged** (ready handshake, geometry load, correlated render error, the setCamera-on-ready race, malformed-message error).

### Verification
- `npm run verify` green (format, lint, typecheck, **554** unit w/ coverage, assembly, build, budgets, build:publish, publish-archive). `verify-viewer-bundle` confirms the new `viewer-host` code leaked no Monaco/BrowserFS/WASM/SW into the viewer bundle.

Adversarially reviewed: no BLOCKERs; behavior parity verified message-by-message; the one SHOULD-FIX (untested trust boundary) is now covered. Refs #143.