### PR TITLE
feat(viewer): background + showControls on setViewerSettings (#177)

### DIFF
--- a/src/protocol/__tests__/viewer-transport.test.ts
+++ b/src/protocol/__tests__/viewer-transport.test.ts
@@ -85,6 +85,28 @@ describe('validateViewerInbound', () => {
     ).toMatchObject({ ok: false, code: 'invalid-payload' });
   });
 
+  it('accepts optional background + showControls on setViewerSettings (#177)', () => {
+    const r = validateViewerInbound({
+      protocolVersion: v,
+      type: 'setViewerSettings',
+      background: '#101010',
+      showControls: false,
+    });
+    expect(r).toEqual({
+      ok: true,
+      message: { type: 'setViewerSettings', background: '#101010', showControls: false },
+    });
+  });
+
+  it('rejects wrong types for background + showControls', () => {
+    expect(
+      validateViewerInbound({ protocolVersion: v, type: 'setViewerSettings', background: 7 }),
+    ).toMatchObject({ ok: false, code: 'invalid-payload' });
+    expect(
+      validateViewerInbound({ protocolVersion: v, type: 'setViewerSettings', showControls: 'no' }),
+    ).toMatchObject({ ok: false, code: 'invalid-payload' });
+  });
+
   it('accepts a valid camera pose and rejects malformed ones', () => {
     expect(validateViewerInbound({ protocolVersion: v, type: 'setCamera', camera: pose })).toEqual({
       ok: true,

--- a/src/protocol/viewer-transport.ts
+++ b/src/protocol/viewer-transport.ts
@@ -30,6 +30,8 @@ export type ViewerInbound =
       color?: string;
       showAxes?: boolean;
       active?: boolean;
+      background?: string;
+      showControls?: boolean;
     } & Correlated)
   | ({ type: 'setCamera'; camera: CameraPose } & Correlated)
   | ({ type: 'dispose' } & Correlated);
@@ -109,6 +111,18 @@ export function validateViewerInbound(data: unknown): ViewerValidation {
       if (data.active !== undefined && typeof data.active !== 'boolean') {
         return { ok: false, code: 'invalid-payload', reason: 'active must be a boolean', opId };
       }
+      const background = data.background === undefined ? undefined : readString(data.background);
+      if (data.background !== undefined && background === undefined) {
+        return { ok: false, code: 'invalid-payload', reason: 'background must be a string', opId };
+      }
+      if (data.showControls !== undefined && typeof data.showControls !== 'boolean') {
+        return {
+          ok: false,
+          code: 'invalid-payload',
+          reason: 'showControls must be a boolean',
+          opId,
+        };
+      }
       return {
         ok: true,
         message: {
@@ -116,6 +130,10 @@ export function validateViewerInbound(data: unknown): ViewerValidation {
           ...(color !== undefined ? { color } : {}),
           ...(data.showAxes !== undefined ? { showAxes: data.showAxes as boolean } : {}),
           ...(data.active !== undefined ? { active: data.active as boolean } : {}),
+          ...(background !== undefined ? { background } : {}),
+          ...(data.showControls !== undefined
+            ? { showControls: data.showControls as boolean }
+            : {}),
           ...corr,
         },
       };

--- a/src/viewer-host/__tests__/controller.test.ts
+++ b/src/viewer-host/__tests__/controller.test.ts
@@ -13,6 +13,8 @@ class FakeViewer extends EventTarget {
   color = '';
   showAxes = true;
   active = true;
+  background: string | undefined;
+  showControls = true;
   generateThumbnails = false;
   camera: unknown;
   removed = false;
@@ -83,6 +85,21 @@ describe('ViewerController', () => {
     expect(viewer.color).toBe('#abc');
     expect(viewer.showAxes).toBe(true); // untouched
     expect(transport.sent.at(-1)).toMatchObject({ type: 'viewer-settings-set', opId: 's1' });
+  });
+
+  it('applies background + showControls from setViewerSettings (#177)', () => {
+    const { viewer, transport } = setup();
+    transport.receive({
+      protocolVersion: V,
+      type: 'setViewerSettings',
+      background: '#101010',
+      showControls: false,
+      opId: 's2',
+    });
+    expect(viewer.background).toBe('#101010');
+    expect(viewer.showControls).toBe(false);
+    expect(viewer.color).toBe(''); // untouched
+    expect(transport.sent.at(-1)).toMatchObject({ type: 'viewer-settings-set', opId: 's2' });
   });
 
   it('applies setCamera and acks; forwards camera-change from the viewer', () => {

--- a/src/viewer-host/controller.ts
+++ b/src/viewer-host/controller.ts
@@ -30,6 +30,8 @@ export type GeometryViewer = HTMLElement & {
   color: string;
   showAxes: boolean;
   active: boolean;
+  background?: string;
+  showControls: boolean;
   generateThumbnails: boolean;
   setCamera(camera: CameraPose): void;
 };
@@ -87,6 +89,8 @@ export class ViewerController {
         if (msg.color !== undefined) this.viewer.color = msg.color;
         if (msg.showAxes !== undefined) this.viewer.showAxes = msg.showAxes;
         if (msg.active !== undefined) this.viewer.active = msg.active;
+        if (msg.background !== undefined) this.viewer.background = msg.background;
+        if (msg.showControls !== undefined) this.viewer.showControls = msg.showControls;
         this.transport.send(viewerSettingsSet(msg.opId));
         break;
       case 'setCamera':


### PR DESCRIPTION
## #143 Phase 0, slice 2 of 5 — additive L0 settings

Lets a host (VS Code theme integration) set the scene `background` and toggle the in-viewer `showControls` over the wire. The `osc-geometry-viewer` component already has both props; this plumbs them through the L0 protocol. Done now, while the `ViewerController` plumbing from #173 is fresh, so the post-Gate-B theme work isn't later blocked on a protocol round-trip.

### What changed
- `setViewerSettings` inbound type + `validateViewerInbound` gain optional `background?: string` and `showControls?: boolean` — validated **exactly** like the existing `color`/`showAxes`/`active` (string / boolean; included only when present; wrong types → `invalid-payload`).
- `ViewerController` applies them to the viewer element; `GeometryViewer` type gains the two props.

### Additive — no version bump
Optional fields; `VIEWER_PROTOCOL_VERSION` stays **1**. A host that never sends them is unaffected; the validator's unknown-field handling is unchanged.

### Tests
`validateViewerInbound` accepts the two fields + rejects wrong types; `ViewerController` applies them. `npm run verify` green (554 unit + build + bundle gate + publish-archive).

This is a small, pattern-identical additive change — the full gate is the proportionate check; substantive subagent review is reserved for #174/#175. Refs #143.