### PR TITLE
feat(viewer): VsCodeWebviewTransport + transport auto-select (#174)

### DIFF
--- a/src/viewer-entry/index.ts
+++ b/src/viewer-entry/index.ts
@@ -9,7 +9,7 @@
 
 import '../components/elements/osc-geometry-viewer.ts';
 import { ViewerController, type GeometryViewer } from '../viewer-host/controller.ts';
-import { BrowserParentTransport } from '../viewer-host/transports/browser-parent.ts';
+import { selectViewerTransport } from '../viewer-host/transports/select.ts';
 
 const root = document.getElementById('viewer-root')!;
 const viewer = document.createElement('osc-geometry-viewer') as GeometryViewer;
@@ -17,4 +17,5 @@ const viewer = document.createElement('osc-geometry-viewer') as GeometryViewer;
 viewer.generateThumbnails = false;
 root.appendChild(viewer);
 
-new ViewerController(viewer, new BrowserParentTransport());
+// Auto-select the transport for the host (VS Code webview vs iframe parent).
+new ViewerController(viewer, selectViewerTransport());

--- a/src/viewer-host/transports/__tests__/vscode-webview.test.ts
+++ b/src/viewer-host/transports/__tests__/vscode-webview.test.ts
@@ -1,0 +1,83 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+import { VsCodeWebviewTransport } from '../vscode-webview.ts';
+import { selectViewerTransport } from '../select.ts';
+import { BrowserParentTransport } from '../browser-parent.ts';
+
+// A loose handle to the ambient global, detached from its strict declared type.
+const g = globalThis as unknown as { acquireVsCodeApi?: unknown };
+
+/** Install a stub `acquireVsCodeApi` returning a spyable api; returns the spies. */
+function stubVsCodeApi() {
+  const postMessage = vi.fn();
+  const acquire = vi.fn(() => ({
+    postMessage,
+    getState: () => undefined,
+    setState: (s: unknown) => s,
+  }));
+  g.acquireVsCodeApi = acquire;
+  return { postMessage, acquire };
+}
+
+afterEach(() => {
+  delete g.acquireVsCodeApi;
+});
+
+describe('VsCodeWebviewTransport', () => {
+  it('acquires the vscode api exactly once and routes send to postMessage', () => {
+    const { postMessage, acquire } = stubVsCodeApi();
+    const t = new VsCodeWebviewTransport();
+    expect(acquire).toHaveBeenCalledTimes(1);
+    t.send({ type: 'ready' });
+    expect(postMessage).toHaveBeenCalledWith({ type: 'ready' });
+  });
+
+  it('delivers inbound messages WITHOUT any origin/source filtering (trusted channel)', () => {
+    stubVsCodeApi();
+    const t = new VsCodeWebviewTransport();
+    const seen: unknown[] = [];
+    t.subscribe((p) => seen.push(p));
+    // A message with an "evil" origin and no source is still delivered — the
+    // webview channel itself is the trust boundary, unlike the iframe transport.
+    window.dispatchEvent(
+      new MessageEvent('message', { data: { a: 1 }, origin: 'https://evil.example' }),
+    );
+    expect(seen).toEqual([{ a: 1 }]);
+    t.dispose();
+  });
+
+  it('dispose detaches the listener', () => {
+    stubVsCodeApi();
+    const t = new VsCodeWebviewTransport();
+    const seen: unknown[] = [];
+    t.subscribe((p) => seen.push(p));
+    t.dispose();
+    window.dispatchEvent(new MessageEvent('message', { data: { a: 1 }, origin: 'x' }));
+    expect(seen).toHaveLength(0);
+  });
+
+  it('re-subscribe replaces the prior handler (no double delivery)', () => {
+    stubVsCodeApi();
+    const t = new VsCodeWebviewTransport();
+    const first: unknown[] = [];
+    const second: unknown[] = [];
+    t.subscribe((p) => first.push(p));
+    t.subscribe((p) => second.push(p)); // detaches the first
+    window.dispatchEvent(new MessageEvent('message', { data: { a: 1 }, origin: 'x' }));
+    expect(first).toHaveLength(0);
+    expect(second).toEqual([{ a: 1 }]);
+    t.dispose();
+  });
+});
+
+describe('selectViewerTransport', () => {
+  it('picks the VS Code transport when acquireVsCodeApi is present', () => {
+    stubVsCodeApi();
+    expect(selectViewerTransport()).toBeInstanceOf(VsCodeWebviewTransport);
+  });
+
+  it('falls back to the parent-frame transport when it is absent', () => {
+    // No stub installed (afterEach cleared any) -> typeof acquireVsCodeApi === 'undefined'.
+    expect(selectViewerTransport()).toBeInstanceOf(BrowserParentTransport);
+  });
+});

--- a/src/viewer-host/transports/select.ts
+++ b/src/viewer-host/transports/select.ts
@@ -1,0 +1,15 @@
+import type { Transport } from '../transport.ts';
+import { BrowserParentTransport } from './browser-parent.ts';
+import { VsCodeWebviewTransport } from './vscode-webview.ts';
+
+/**
+ * Pick the transport for the current host environment: the VS Code webview bridge
+ * when `acquireVsCodeApi` is present (injected only inside a VS Code webview),
+ * otherwise the iframe/parent-frame transport. `typeof` is safe even when the
+ * global is undeclared (it yields `'undefined'`, not a ReferenceError).
+ */
+export function selectViewerTransport(): Transport {
+  return typeof acquireVsCodeApi === 'function'
+    ? new VsCodeWebviewTransport()
+    : new BrowserParentTransport();
+}

--- a/src/viewer-host/transports/vscode-api.d.ts
+++ b/src/viewer-host/transports/vscode-api.d.ts
@@ -1,0 +1,16 @@
+// Minimal LOCAL typing of the VS Code webview bridge — the `acquireVsCodeApi`
+// global, injected only inside a VS Code webview. Reproduces the public surface
+// of @types/vscode-webview's WebviewApi so the VS Code transport adds ZERO VS
+// Code build/dependency to openscad-web (keeps the viewer host cleanly isolated).
+//
+// This is an ambient script declaration (no import/export) so the global is typed
+// project-wide. The function is callable exactly once per webview session; hold
+// onto the returned instance and never leak it to global scope.
+
+interface VsCodeApi<State = unknown> {
+  postMessage(message: unknown): void;
+  getState(): State | undefined;
+  setState<T extends State>(state: T): T;
+}
+
+declare function acquireVsCodeApi<State = unknown>(): VsCodeApi<State>;

--- a/src/viewer-host/transports/vscode-webview.ts
+++ b/src/viewer-host/transports/vscode-webview.ts
@@ -1,0 +1,35 @@
+// The VS Code webview `Transport`: outbound via the once-acquired vscode API,
+// inbound from the extension over the webview channel. Unlike the iframe
+// transport there is NO origin or sender-window check — the webview channel
+// itself is the trust boundary (the only sender is the extension host). Payloads
+// are still validated by the controller (DoS/format hygiene on a trusted channel).
+
+import type { Transport } from '../transport.ts';
+
+export class VsCodeWebviewTransport implements Transport {
+  // Acquired exactly once, at construction; the handle is held for the session.
+  private readonly api = acquireVsCodeApi();
+  private listener: ((e: MessageEvent) => void) | null = null;
+
+  send(message: object): void {
+    this.api.postMessage(message);
+  }
+
+  subscribe(handler: (payload: unknown) => void): void {
+    this.detach();
+    const listener = (event: MessageEvent): void => handler(event.data);
+    this.listener = listener;
+    window.addEventListener('message', listener);
+  }
+
+  dispose(): void {
+    this.detach();
+  }
+
+  private detach(): void {
+    if (this.listener) {
+      window.removeEventListener('message', this.listener);
+      this.listener = null;
+    }
+  }
+}


### PR DESCRIPTION
## #143 Phase 0, slice 3 of 5 — the VS Code webview binding

The same `viewer.html` now runs in a VS Code webview as well as an iframe, with **zero VS Code build/dependency** added to openscad-web.

### What changed
- **`vscode-api.d.ts`** — a LOCAL ambient declaration of the `acquireVsCodeApi` global + the minimal `VsCodeApi` interface. No `@types/vscode` / `@types/vscode-webview` dependency (confirmed: `package.json` has no vscode dep).
- **`vscode-webview.ts`** — `VsCodeWebviewTransport`: outbound via the once-acquired vscode api; inbound over the webview channel with **no origin/`event.source` check** — the channel itself is the trust boundary (the extension host is the only sender; `event.origin` is a non-checkable `vscode-webview://` value). The controller still validates every payload.
- **`select.ts`** — `selectViewerTransport()`: the VS Code transport when `acquireVsCodeApi` is present, else `BrowserParentTransport`. `typeof` is ReferenceError-safe when the global is undeclared.
- **`viewer-entry`** uses the auto-select.

### Safety
`acquireVsCodeApi()` runs in the **constructor** (not at module import), so importing the class in a plain browser never throws; the class is only constructed when selected. `acquireVsCodeApi` is **acquired once** (it throws on a second call in a real webview).

### Tests
acquire-once + send-routing; the **no-filtering inbound** (the key trust delta — an evil-origin/no-source event is still delivered); dispose + re-subscribe detach; **both auto-select branches**. The iframe e2e passes unchanged (browser path still picks `BrowserParentTransport`); `verify-viewer-bundle` stays green.

### Verification
`npm run verify` green (format, lint, typecheck, **559** unit w/ coverage, assembly, build, budgets, publish-archive) + the iframe e2e.

Adversarially reviewed: no BLOCKER/SHOULD-FIX — the zero-vscode-dep ambient typing, module-load safety, the trust model (matches official VS Code guidance), and acquire-once all confirmed. Refs #143.