### PR TITLE
feat(build): distributable viewer-only build + integrity manifest (#175)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,7 @@ node_modules/
 # Build outputs
 dist/
 dist-publish/
+dist-viewer/
 libs/
 openscad-web-publish.zip
 .publish-e2e/

--- a/package.json
+++ b/package.json
@@ -33,6 +33,7 @@
     "start": "npm run start:development",
     "build": "cross-env NODE_ENV=production vite build && node ./scripts/build-sw.mjs && node ./scripts/verify-production-build.mjs && node ./scripts/verify-viewer-bundle.mjs",
     "build:publish": "node ./scripts/build-publish.mjs",
+    "build:viewer": "cross-env NODE_ENV=production vite build --config vite.viewer.config.ts && node ./scripts/verify-viewer-bundle.mjs --dir dist-viewer && node ./scripts/build-viewer-manifest.mjs",
     "build:libs": "cross-env LIBS_BUILD_MODE=all node ./scripts/build-assets/cli.mjs",
     "build:libs:clean": "cross-env LIBS_BUILD_MODE=clean node ./scripts/build-assets/cli.mjs",
     "build:libs:wasm": "cross-env LIBS_BUILD_MODE=wasm node ./scripts/build-assets/cli.mjs",
@@ -53,7 +54,7 @@
     "perf:ci": "npm run perf:capture:series && npm run perf:compare",
     "security:check-install-scripts": "node ./scripts/security/check-install-scripts.mjs",
     "verify:publish-archive": "node ./scripts/verify-publish-archive.mjs",
-    "verify": "npm run format:check && npm run lint && npm run typecheck && npm run test:unit && npm run test:assembly && npm run build && npm run check:budgets && npm run build:publish && npm run verify:publish-archive",
+    "verify": "npm run format:check && npm run lint && npm run typecheck && npm run test:unit && npm run test:assembly && npm run build && npm run check:budgets && npm run build:publish && npm run verify:publish-archive && npm run build:viewer",
     "verify:full": "npm run verify && npm run test:e2e && npm run test:e2e:publish:skip-build",
     "check:budgets": "node ./scripts/check-bundle-budgets.mjs"
   },

--- a/scripts/build-viewer-manifest.mjs
+++ b/scripts/build-viewer-manifest.mjs
@@ -1,0 +1,89 @@
+// Emit dist-viewer/viewer-manifest.json (#143/#175): a versioned, hashed
+// integrity manifest for the distributable viewer artifact, so the consuming VS
+// Code extension can pin and verify exactly what it vendors. The extension, on
+// ingest, asserts: protocolVersion matches what it compiled against, every shipped
+// file is on the allowlist, and every sha256 recomputes.
+
+import { createHash } from 'node:crypto';
+import { execSync } from 'node:child_process';
+import { readFileSync, readdirSync, statSync, writeFileSync } from 'node:fs';
+import path from 'node:path';
+
+const DIST = path.resolve('dist-viewer');
+const MANIFEST_NAME = 'viewer-manifest.json';
+
+function fail(message) {
+  console.error(`[build-viewer-manifest] ${message}`);
+  process.exit(1);
+}
+
+// The single source of truth for the protocol version — read, never hand-copied,
+// so the manifest and the runtime `validateViewerInbound` guard cannot disagree.
+function protocolVersion() {
+  const src = readFileSync('src/protocol/viewer-transport.ts', 'utf8');
+  const m = src.match(/VIEWER_PROTOCOL_VERSION\s*=\s*(\d+)/);
+  if (!m) fail('could not read VIEWER_PROTOCOL_VERSION from src/protocol/viewer-transport.ts');
+  return Number(m[1]);
+}
+
+function viewerVersion() {
+  return JSON.parse(readFileSync('package.json', 'utf8')).version;
+}
+
+function sourceCommit() {
+  try {
+    const commit = execSync('git rev-parse HEAD', { encoding: 'utf8' }).trim();
+    // A build from a dirty tree doesn't correspond to `commit`; mark it so the
+    // manifest's provenance is honest (CI builds from a clean checkout).
+    const dirty = execSync('git status --porcelain', { encoding: 'utf8' }).trim() !== '';
+    return dirty ? `${commit}-dirty` : commit;
+  } catch {
+    return 'unknown';
+  }
+}
+
+// Every file under dist-viewer relative to it, excluding the manifest itself.
+function listFiles(dir, rel = '') {
+  const out = [];
+  for (const name of readdirSync(dir)) {
+    const abs = path.join(dir, name);
+    const relPath = rel ? `${rel}/${name}` : name;
+    if (statSync(abs).isDirectory()) out.push(...listFiles(abs, relPath));
+    else if (relPath !== MANIFEST_NAME) out.push(relPath);
+  }
+  return out;
+}
+
+const sha256 = (abs) => createHash('sha256').update(readFileSync(abs)).digest('hex');
+
+const relFiles = listFiles(DIST).sort();
+if (!relFiles.includes('viewer.html'))
+  fail('dist-viewer/viewer.html missing — run build:viewer first');
+
+const files = {};
+for (const rel of relFiles) {
+  const abs = path.join(DIST, rel);
+  files[rel] = { bytes: statSync(abs).size, sha256: sha256(abs) };
+}
+
+// Top-level entries the extension should expect (dirs with a trailing slash).
+const topLevel = [
+  ...new Set(relFiles.map((f) => (f.includes('/') ? `${f.split('/')[0]}/` : f))),
+].sort();
+const allowlist = [...topLevel, MANIFEST_NAME];
+
+const manifest = {
+  schemaVersion: 1,
+  viewerVersion: viewerVersion(),
+  protocolVersion: protocolVersion(),
+  sourceCommit: sourceCommit(),
+  builtAt: new Date().toISOString(),
+  files,
+  allowlist,
+};
+
+writeFileSync(path.join(DIST, MANIFEST_NAME), `${JSON.stringify(manifest, null, 2)}\n`);
+console.log(
+  `[build-viewer-manifest] wrote dist-viewer/${MANIFEST_NAME} ` +
+    `(${relFiles.length} files, viewer v${manifest.viewerVersion}, protocol v${manifest.protocolVersion})`,
+);

--- a/src/protocol/__tests__/version-source.test.ts
+++ b/src/protocol/__tests__/version-source.test.ts
@@ -1,0 +1,18 @@
+import { readFileSync } from 'node:fs';
+
+import { describe, expect, it } from 'vitest';
+
+import { VIEWER_PROTOCOL_VERSION } from '../viewer-transport.ts';
+
+// The viewer-manifest build script reads VIEWER_PROTOCOL_VERSION from the source
+// (never hand-copies it) so the artifact manifest and the runtime
+// `validateViewerInbound` guard can never disagree. This pins the exact regex the
+// script uses (scripts/build-viewer-manifest.mjs) to the real exported constant.
+describe('VIEWER_PROTOCOL_VERSION manifest pin (#175)', () => {
+  it('is extractable by the build-viewer-manifest regex and matches the export', () => {
+    const src = readFileSync('src/protocol/viewer-transport.ts', 'utf8');
+    const m = src.match(/VIEWER_PROTOCOL_VERSION\s*=\s*(\d+)/);
+    expect(m).not.toBeNull();
+    expect(Number(m![1])).toBe(VIEWER_PROTOCOL_VERSION);
+  });
+});

--- a/vite.shared.ts
+++ b/vite.shared.ts
@@ -24,32 +24,45 @@ export function getPackageHomepagePath(): string {
 export function createAppViteConfig({
   base,
   outDir,
+  entries = ['index.html', 'viewer.html'],
+  publicDir = 'public',
 }: {
   base: string;
   outDir: string;
+  /**
+   * The HTML entry files to build. Defaults to the full app (`index.html`) + the
+   * standalone viewer (`viewer.html`). The distributable viewer-only build
+   * (`vite.viewer.config.ts`) passes just `['viewer.html']`. Each entry's chunk is
+   * keyed by its base name, so `index.html` keeps the `index-*` chunk name the
+   * bundle budgets / tooling rely on.
+   */
+  entries?: string[];
+  /**
+   * The static-assets dir copied verbatim into the build. Defaults to `public`
+   * (favicon, the OpenSCAD `libraries/` zips, fonts, …). The distributable viewer
+   * passes `false`: the standalone viewer fetches none of those at runtime, so the
+   * artifact stays small (just `viewer.html` + its chunks).
+   */
+  publicDir?: string | false;
 }): UserConfig {
+  const input = Object.fromEntries(
+    entries.map((name) => [name.replace(/\.html$/, ''), htmlInput(name)]),
+  );
   return {
     base,
-    publicDir: 'public',
+    publicDir,
     optimizeDeps: {
-      entries: ['index.html', 'viewer.html'],
+      entries,
     },
     build: {
       outDir,
       target: 'es2022',
       emptyOutDir: true,
       rollupOptions: {
-        // Two HTML entries: the full app (index.html) and a standalone, read-only
-        // geometry viewer (viewer.html) for host/webview embedding. The viewer
-        // entry pulls in only Lit + Three + the OFF viewer — no Monaco, BrowserFS,
-        // OpenSCAD WASM, Model, or service worker (asserted by
-        // scripts/verify-viewer-bundle.mjs).
-        // The `index` key keeps the app entry chunk named `index-*` (the bundle
-        // budgets and the existing tooling key off that).
-        input: {
-          index: htmlInput('index.html'),
-          viewer: htmlInput('viewer.html'),
-        },
+        // The HTML entries (see `entries` above). The viewer entry pulls in only
+        // Lit + Three + the OFF viewer — no Monaco, BrowserFS, OpenSCAD WASM,
+        // Model, or service worker (asserted by scripts/verify-viewer-bundle.mjs).
+        input,
         output: {
           // Split the two heavy vendor libraries into their own named chunks so
           // they can be budgeted separately and are only fetched by the surfaces

--- a/vite.viewer.config.ts
+++ b/vite.viewer.config.ts
@@ -1,0 +1,20 @@
+import { defineConfig } from 'vite';
+import { createAppViteConfig } from './vite.shared.ts';
+
+// The DISTRIBUTABLE viewer-only build (#143/#175): just viewer.html + its chunk
+// graph, with RELATIVE asset URLs so it loads under an opaque VS Code webview
+// origin (the Pages build's absolute /openscad-web/ URLs would not). A separate
+// config + outDir keeps it entirely out of the main `dist` graph, so the service
+// worker, bundle budgets, and publish archive are untouched. The output is gated
+// by `verify-viewer-bundle --dir dist-viewer` and pinned by a viewer-manifest.json.
+export default defineConfig(
+  createAppViteConfig({
+    base: './',
+    outDir: 'dist-viewer',
+    entries: ['viewer.html'],
+    // No public/ copy: the standalone viewer fetches none of the app's static
+    // assets (libraries zips, fonts, chime, fixtures) at runtime, so the
+    // distributable stays minimal — viewer.html + its chunks + the manifest.
+    publicDir: false,
+  }),
+);


### PR DESCRIPTION
## #143 Phase 0, slice 5 of 5 — the distributable viewer artifact

A separate, distributable build a VS Code extension can vendor — **cleanly isolated from the main app**.

### What changed
- **`vite.viewer.config.ts`** — a viewer-only build: `base: './'` (relative asset URLs that load under an opaque webview origin — the Pages build's absolute `/openscad-web/` URLs would not), `outDir: dist-viewer`, **`publicDir: false`** so the app's static assets (the OpenSCAD `libraries/` zips — BOSL2 alone is 1.1 MB! — fonts, chime, fixtures) are **not** copied. The artifact is just `viewer.html` + its chunks (~576 KB, mostly Three; the viewer fetches no public asset at runtime).
- **`createAppViteConfig`** gained `entries` + `publicDir` params, **both defaulting to the previous values**, so the `dist` + `dist-publish` builds are byte-for-byte unchanged (same `{index, viewer}` input, same `index-*` chunk naming that budgets + the SW precache key off).
- **`scripts/build-viewer-manifest.mjs`** — emits `dist-viewer/viewer-manifest.json`: a hashed integrity manifest (`schemaVersion`, `viewerVersion`, `protocolVersion` read from the single source, `sourceCommit` (+`-dirty` when the tree is dirty), per-asset **SHA-256**, allowlist) so the extension pins + verifies exactly what it vendors and never floats against `main`.
- **`npm run build:viewer`** = build + `verify-viewer-bundle --dir dist-viewer` (the no-Monaco/WASM/BrowserFS/SW gate) + the manifest; **wired into `npm run verify`**. `dist-viewer/` gitignored.

### Isolation (the point)
Separate config + `outDir` keeps the distributable **entirely out of the main `dist` graph** — the service worker (`build-sw.mjs` globs `dist`), bundle budgets (key off `dist`), and `verify-publish-archive` (`dist-publish`) are all untouched. `npm run verify` green confirms the app build/budgets/archive are unchanged.

### Tests / verification
- `version-source.test.ts` pins the manifest's protocol-version regex to the exported `VIEWER_PROTOCOL_VERSION` (guards "read, never hand-copied").
- `npm run verify` green (incl. the new `build:viewer` step + the unchanged `dist`/budgets/`dist-publish`/archive).

Adversarially reviewed (deploy-pipeline-touching): no BLOCKER/SHOULD-FIX — **app-build parity proved by construction**; the dirty-tree provenance NOTE was fixed before this PR. Refs #143.