### PR TITLE
chore: remove fork-me ribbon remnant and neutralize default model

### DIFF
--- a/LICENSE.md
+++ b/LICENSE.md
@@ -66,7 +66,6 @@ The WASM build was made possible by https://github.com/DSchroer/openscad-wasm.
   - [Lasercut](#lasercut)
   - [pathbuilder](#pathbuilder)
   - [openscad_attachable_text3d](#openscad_attachable_text3d)
-  - [Fork me on GitHub CSS ribbon](#fork-me-on-github-css-ribbon)
   - [Common licenses](#common-licenses)
     - [MIT](#mit)
     - [BSD 3-Clause](#bsd-3-clause)
@@ -948,14 +947,6 @@ LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 ```
-
-## Fork me on GitHub CSS ribbon
-
-https://github.com/simonwhitaker/github-fork-ribbon-css
-
-Copyright (c) 2013 Simon Whitaker.
-
-Licensed under the [MIT License](#mit).
 
 ## Common licenses
 

--- a/src/state/default-scad.ts
+++ b/src/state/default-scad.ts
@@ -1,20 +1,16 @@
 // Portions of this file are Copyright 2021 Google LLC, and licensed under GPL2+. See COPYING.
 
 export default `/*
-  Hello there!
+  Welcome!
 
-  If you're new to OpenSCAD, please learn the basics here:
-  https://openscad.org/documentation.html
+  This is a starter model — edit the code and the preview
+  updates as you go.
 
-  There are lots of amazing libraries in the OpenSCAD ecosystem
-  (see this list: https://openscad.org/libraries.html).
+  A handful of example libraries are bundled in the file
+  explorer above (search for "demo" or "example"); you can
+  include them directly from your own models.
 
-  Some of these libraries are bundled with this playground
-  (search for "demo" or "example" in the file explorer above)
-  and can be included directly from your models.
-
-  Any bugs (this is an Alpha!) or ideas of features?
-  https://github.com/openscad/openscad-playground/issues/new
+  Happy modeling!
 */
 
 title = "OpenSCAD";


### PR DESCRIPTION
Two small, related cleanups (reviewed locally before commit).

## 1. Fork-me ribbon — final remnant removed
The "Fork me on GitHub" ribbon's **usage and dependency were already removed** during the webpack→vite migration (`db1b258`, `0095883`) — it's absent from `src`, `public`, `index.html`, `package.json`, and `package-lock.json`, and the live site has no banner. The only surviving trace was a stale attribution in `LICENSE.md`, now removed (TOC entry + section). A full re-scan finds zero `fork-me`/`ribbon`/`simonwhitaker` references remaining.

## 2. Default model welcome comment — neutralized
Rewrote only the top comment block of `src/state/default-scad.ts`: dropped the OpenSCAD-specific doc/library links and the upstream `openscad-playground` issues link; kept it light/generic; added no project-specific attribution. The example's own lower comments (CSG-modules description, Marius Kintel / CC0 dedication) are left intact.

Gate: `npm run verify` passed locally.