### PR TITLE
fix(off): accept canonical multi-line OFF headers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,13 @@ release (changelog upkeep and tagging had lapsed between `0.1.0` and `0.2.0`).
 
 ## [Unreleased]
 
+### Fixed
+
+- OFF import: canonical multi-line headers (`OFF` on its own line, counts on the
+  next — as emitted by Meshlab and many tools) are no longer rejected with
+  "invalid vertex or face counts". The same-line form (`OFF 8 6 12`, as OpenSCAD
+  exports) is unchanged.
+
 ### Added
 
 - L0 protocol: a fit-aware `setNamedView` inbound message (`VIEWER_NAMED_VIEWS`:

--- a/src/io/__tests__/import_off.test.ts
+++ b/src/io/__tests__/import_off.test.ts
@@ -1,0 +1,51 @@
+import { describe, expect, it } from 'vitest';
+
+import { parseOff } from '../import_off.ts';
+
+// A unit cube: 8 vertices, 6 quad faces (each fan-triangulated to 2 triangles).
+const CUBE_BODY = [
+  '-0.5 -0.5 -0.5',
+  '0.5 -0.5 -0.5',
+  '0.5 0.5 -0.5',
+  '-0.5 0.5 -0.5',
+  '-0.5 -0.5 0.5',
+  '0.5 -0.5 0.5',
+  '0.5 0.5 0.5',
+  '-0.5 0.5 0.5',
+  '4 0 1 2 3',
+  '4 7 6 5 4',
+  '4 0 4 5 1',
+  '4 1 5 6 2',
+  '4 2 6 7 3',
+  '4 3 7 4 0',
+].join('\n');
+
+describe('parseOff', () => {
+  it('parses the same-line header form ("OFF 8 6 12", as OpenSCAD exports)', () => {
+    const poly = parseOff(`OFF 8 6 12\n${CUBE_BODY}\n`);
+    expect(poly.vertices).toHaveLength(8);
+    expect(poly.faces).toHaveLength(12); // 6 quads → 12 triangles
+  });
+
+  it('parses the canonical multi-line header form ("OFF" on its own line) (#188 regression)', () => {
+    // Previously rejected: bare "OFF" matched the same-line branch and read empty
+    // counts, throwing "invalid vertex or face counts".
+    const poly = parseOff(`OFF\n8 6 12\n${CUBE_BODY}\n`);
+    expect(poly.vertices).toHaveLength(8);
+    expect(poly.faces).toHaveLength(12);
+  });
+
+  it('produces identical geometry from both header forms', () => {
+    expect(parseOff(`OFF\n8 6 12\n${CUBE_BODY}\n`)).toEqual(parseOff(`OFF 8 6 12\n${CUBE_BODY}\n`));
+  });
+
+  it('tolerates comments and blank lines between header and counts', () => {
+    const poly = parseOff(`OFF\n# a comment\n\n8 6 12\n${CUBE_BODY}\n`);
+    expect(poly.vertices).toHaveLength(8);
+  });
+
+  it('rejects a missing header and malformed counts', () => {
+    expect(() => parseOff('8 6 12\n0 0 0\n')).toThrow(/missing OFF header/);
+    expect(() => parseOff('OFF\nnot counts\n')).toThrow(/invalid vertex or face counts/);
+  });
+});

--- a/src/io/import_off.ts
+++ b/src/io/import_off.ts
@@ -10,10 +10,12 @@ export function parseOff(content: string): IndexedPolyhedron {
 
   let counts: string;
   let currentLine = 0;
-  if (lines[0].match(/^OFF(\s|$)/)) {
+  if (/^OFF\s+\S/.test(lines[0])) {
+    // Header and counts on the same line: "OFF 8 6 12".
     counts = lines[0].substring(3).trim();
     currentLine = 1;
-  } else if (lines[currentLine] === 'OFF' && lines.length > 1) {
+  } else if (lines[0] === 'OFF' && lines.length > 1) {
+    // Canonical multi-line form: "OFF" alone, counts on the next line.
     counts = lines[1];
     currentLine = 2;
   } else {


### PR DESCRIPTION
## Bug
The OFF importer rejected canonical multi-line OFF — `OFF` on its own line with the counts on the next line (the form Meshlab and most tools emit) — with `Invalid OFF file: invalid vertex or face counts`. Only OpenSCAD's same-line `OFF 8 6 12` form worked.

Root cause (`src/io/import_off.ts`): the same-line branch guard `/^OFF(\s|$)/` matches a **bare** `OFF` line via the `$` alternative, so it took the same-line path, read the counts as the empty string, and `Number('')` → `0`/`NaN` → the thrown error. The intended multi-line branch was never reached.

## Fix
Require non-whitespace content after `OFF` for the same-line branch (`/^OFF\s+\S/`), so a bare `OFF` line falls through to the multi-line branch. Same-line parsing is unchanged.

## Tests
New `src/io/__tests__/import_off.test.ts`: both header forms parse, produce **identical** geometry, tolerate comments/blank lines, and malformed input still throws.

## Why now
Surfaced via the openscad-web-vscode extension: its bundled fixture used canonical multi-line OFF and failed to render ("render-error: invalid vertex or face counts"). This fix also makes the extension's _Preview .off File_ work for real-world multi-line OFF files. `npm run verify` passes.