### PR TITLE
feat(protocol): L1 session wire protocol (session-transport.ts) — #191

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,15 @@ release (changelog upkeep and tagging had lapsed between `0.1.0` and `0.2.0`).
 
 ### Added
 
+- L1 session protocol (`src/protocol/session-transport.ts`, #191): a host-neutral
+  wire protocol for driving an `OpenScadSession`'s `ProjectContract` from a webview
+  — `setProject`/`updateFile`/`removeFile`/`setEntryPoint`/`cancel`/`dispose`
+  inbound, with validation + DoS caps, and a push-stream `operation-result`
+  outbound. Versioned by `SESSION_PROTOCOL_VERSION` (distinct from the result
+  payload's `L1_PROTOCOL_VERSION`). The DOM-free L1 data types (`OperationResult`
+  family, `Diagnostic`, `ArtifactRef`, `ProjectFile`) moved into
+  `src/protocol/session-contract.ts` (re-exported from their prior homes) so the
+  protocol stays self-contained and distributable.
 - L0 protocol: a fit-aware `setNamedView` inbound message (`VIEWER_NAMED_VIEWS`:
   Diagonal/Front/Right/Back/Left/Top/Bottom) that frames the model to its bounds
   viewer-side, so a host (e.g. a VS Code extension) can offer camera presets

--- a/src/diagnostics.ts
+++ b/src/diagnostics.ts
@@ -1,26 +1,14 @@
 // Host-neutral compile diagnostics. Domain and runner code produce and consume
 // these; each host (the Monaco editor today, others later) converts them to its
 // own representation at its boundary, so the core never depends on an editor API.
+//
+// The `Diagnostic` TYPE itself lives in src/protocol/session-contract.ts — it's a
+// wire payload (carried by `OperationResult`) — and is re-exported here so the
+// existing importers and these utilities are unchanged.
 
-export type DiagnosticSeverity = 'error' | 'warning' | 'info';
+import type { Diagnostic, DiagnosticSeverity } from './protocol/session-contract.ts';
 
-export interface Diagnostic {
-  severity: DiagnosticSeverity;
-  message: string;
-  // 1-based line/column range (compatible with common editor marker APIs).
-  startLineNumber: number;
-  startColumn: number;
-  endLineNumber: number;
-  endColumn: number;
-  /** Optional source/tool that produced the diagnostic. */
-  source?: string;
-  /**
-   * File the diagnostic belongs to, as reported by the compiler (e.g.
-   * `/home/playground.scad`). Lets a host route the marker to the right editor
-   * model instead of dumping every file's diagnostics on the active one.
-   */
-  path?: string;
-}
+export type { Diagnostic, DiagnosticSeverity };
 
 const SEVERITY_RANK: Record<DiagnosticSeverity, number> = { info: 0, warning: 1, error: 2 };
 

--- a/src/protocol/__tests__/session-transport.test.ts
+++ b/src/protocol/__tests__/session-transport.test.ts
@@ -1,0 +1,187 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+  SESSION_COMMANDS,
+  SESSION_MAX_FILES,
+  SESSION_MAX_FILE_LENGTH,
+  SESSION_MAX_PATH_LENGTH,
+  SESSION_PROTOCOL_VERSION,
+  sessionError,
+  sessionOperationResult,
+  sessionReady,
+  validateSessionInbound,
+} from '../session-transport.ts';
+import type { OperationResult } from '../session-contract.ts';
+
+const v = SESSION_PROTOCOL_VERSION;
+const ok = (data: unknown) => validateSessionInbound({ protocolVersion: v, ...(data as object) });
+
+describe('validateSessionInbound', () => {
+  it('rejects non-objects, version mismatch, and missing/unknown type', () => {
+    expect(validateSessionInbound(null)).toMatchObject({ ok: false, code: 'malformed' });
+    expect(validateSessionInbound({ type: 'cancel' })).toMatchObject({
+      ok: false,
+      code: 'unsupported-version',
+    });
+    expect(validateSessionInbound({ protocolVersion: 999, type: 'cancel' })).toMatchObject({
+      ok: false,
+      code: 'unsupported-version',
+    });
+    expect(ok({ type: 7 })).toMatchObject({ ok: false, code: 'malformed' });
+    expect(ok({ type: 'nope' })).toMatchObject({ ok: false, code: 'unknown-type' });
+  });
+
+  it('accepts setProject with files + optional entryPoint', () => {
+    const r = ok({
+      type: 'setProject',
+      files: [
+        { path: '/home/main.scad', content: 'cube(1);' },
+        { path: '/home/lib/a.scad', content: '// a' },
+      ],
+      entryPoint: '/home/main.scad',
+    });
+    expect(r).toEqual({
+      ok: true,
+      message: {
+        type: 'setProject',
+        files: [
+          { path: '/home/main.scad', content: 'cube(1);' },
+          { path: '/home/lib/a.scad', content: '// a' },
+        ],
+        entryPoint: '/home/main.scad',
+      },
+    });
+    // entryPoint omitted is fine.
+    expect(ok({ type: 'setProject', files: [] })).toMatchObject({ ok: true });
+  });
+
+  it('rejects malformed setProject payloads', () => {
+    expect(ok({ type: 'setProject', files: 'nope' })).toMatchObject({
+      ok: false,
+      code: 'invalid-payload',
+    });
+    expect(ok({ type: 'setProject', files: [{ path: '/a' }] })).toMatchObject({
+      ok: false,
+      code: 'invalid-payload',
+    });
+    expect(ok({ type: 'setProject', files: [{ path: 1, content: 'x' }] })).toMatchObject({
+      ok: false,
+      code: 'invalid-payload',
+    });
+    expect(
+      ok({ type: 'setProject', files: [{ path: '/a', content: 'x' }], entryPoint: 5 }),
+    ).toMatchObject({ ok: false, code: 'invalid-payload' });
+  });
+
+  it('enforces DoS caps (file count, per-file size, total size, path length)', () => {
+    const tooLarge = { ok: false, code: 'too-large' };
+
+    // file count
+    const many = Array.from({ length: SESSION_MAX_FILES + 1 }, (_, i) => ({
+      path: `/${i}`,
+      content: '',
+    }));
+    expect(ok({ type: 'setProject', files: many })).toMatchObject(tooLarge);
+
+    // per-file content cap — inside setProject AND on updateFile
+    const maxFile = 'x'.repeat(SESSION_MAX_FILE_LENGTH);
+    const overFile = maxFile + 'x';
+    expect(ok({ type: 'setProject', files: [{ path: '/a', content: overFile }] })).toMatchObject(
+      tooLarge,
+    );
+    expect(ok({ type: 'updateFile', path: '/a', content: overFile })).toMatchObject(tooLarge);
+
+    // total project size — two max-size files exceed the total cap
+    expect(
+      ok({
+        type: 'setProject',
+        files: [
+          { path: '/a', content: maxFile },
+          { path: '/b', content: maxFile },
+        ],
+      }),
+    ).toMatchObject(tooLarge);
+
+    // path length — on every path-bearing message
+    const longPath = '/' + 'x'.repeat(SESSION_MAX_PATH_LENGTH);
+    expect(ok({ type: 'setProject', files: [{ path: longPath, content: '' }] })).toMatchObject(
+      tooLarge,
+    );
+    expect(ok({ type: 'updateFile', path: longPath, content: '' })).toMatchObject(tooLarge);
+    expect(ok({ type: 'removeFile', path: longPath })).toMatchObject(tooLarge);
+    expect(ok({ type: 'setEntryPoint', path: longPath })).toMatchObject(tooLarge);
+  });
+
+  it('accepts updateFile / removeFile / setEntryPoint and rejects non-string paths', () => {
+    expect(ok({ type: 'updateFile', path: '/home/m.scad', content: 'x' })).toMatchObject({
+      ok: true,
+      message: { type: 'updateFile', path: '/home/m.scad', content: 'x' },
+    });
+    expect(ok({ type: 'removeFile', path: '/home/m.scad' })).toMatchObject({
+      ok: true,
+      message: { type: 'removeFile', path: '/home/m.scad' },
+    });
+    expect(ok({ type: 'setEntryPoint', path: '/home/m.scad' })).toMatchObject({
+      ok: true,
+      message: { type: 'setEntryPoint', path: '/home/m.scad' },
+    });
+    expect(ok({ type: 'removeFile' })).toMatchObject({ ok: false, code: 'invalid-payload' });
+  });
+
+  it('accepts cancel and dispose', () => {
+    expect(ok({ type: 'cancel' })).toEqual({ ok: true, message: { type: 'cancel' } });
+    expect(ok({ type: 'dispose' })).toEqual({ ok: true, message: { type: 'dispose' } });
+  });
+
+  it('every advertised SESSION_COMMAND is a handled inbound type (capabilities ⟷ dispatch)', () => {
+    const minimal: Record<(typeof SESSION_COMMANDS)[number], object> = {
+      setProject: { files: [] },
+      updateFile: { path: '/a', content: 'x' },
+      removeFile: { path: '/a' },
+      setEntryPoint: { path: '/a' },
+      cancel: {},
+      dispose: {},
+    };
+    for (const cmd of SESSION_COMMANDS) {
+      expect(ok({ type: cmd, ...minimal[cmd] })).toMatchObject({ ok: true });
+    }
+  });
+});
+
+describe('outbound builders', () => {
+  it('sessionReady advertises capabilities, version-stamped', () => {
+    expect(sessionReady(SESSION_COMMANDS)).toEqual({
+      protocolVersion: v,
+      type: 'ready',
+      capabilities: [...SESSION_COMMANDS],
+    });
+  });
+
+  it('sessionOperationResult wraps the result with the session envelope version', () => {
+    const result: OperationResult = {
+      protocolVersion: 1, // the nested L1 version, independent of the wire version
+      sessionId: 's1',
+      operationId: 'op1',
+      sourceRevision: 3,
+      kind: 'preview',
+      elapsedMillis: 12,
+      diagnostics: [],
+      logText: '',
+      status: 'success',
+    };
+    expect(sessionOperationResult(result)).toEqual({
+      protocolVersion: v,
+      type: 'operation-result',
+      result,
+    });
+  });
+
+  it('sessionError carries code + reason', () => {
+    expect(sessionError('invalid-payload', 'bad')).toEqual({
+      protocolVersion: v,
+      type: 'error',
+      code: 'invalid-payload',
+      reason: 'bad',
+    });
+  });
+});

--- a/src/protocol/session-contract.ts
+++ b/src/protocol/session-contract.ts
@@ -1,0 +1,90 @@
+// Layer-1 session contract — the DOM-free data types a host and an OpenScadSession
+// exchange (ADR 0008/0009). They live in the protocol layer because they ARE the
+// wire payloads: a host (a VS Code webview) pushes a project and receives compile
+// operation results. Kept import-free so the protocol stays distributable
+// (lint-fenced). The in-process result CONSTRUCTORS and the scheduler command
+// shapes (OperationCommand/CancelCommand) stay in src/runner/compile-contract.ts,
+// the diagnostic UTILITIES stay in src/diagnostics.ts, and the ProjectStore stays
+// in src/state — each re-exports the types it owned from here.
+
+/**
+ * Layer-1 result-payload version (ADR 0005 axis). Distinct from the session WIRE
+ * version (`SESSION_PROTOCOL_VERSION`, src/protocol/session-transport.ts) and the
+ * embed wire (`EMBED_PROTOCOL_VERSION`): this versions the `OperationResult` shape.
+ */
+export const L1_PROTOCOL_VERSION = 1;
+
+export type DiagnosticSeverity = 'error' | 'warning' | 'info';
+
+export interface Diagnostic {
+  severity: DiagnosticSeverity;
+  message: string;
+  // 1-based line/column range (compatible with common editor marker APIs).
+  startLineNumber: number;
+  startColumn: number;
+  endLineNumber: number;
+  endColumn: number;
+  /** Optional source/tool that produced the diagnostic. */
+  source?: string;
+  /**
+   * File the diagnostic belongs to, as reported by the compiler (e.g.
+   * `/home/playground.scad`), so a host routes the marker to the right editor
+   * model instead of dumping every file's diagnostics on the active one.
+   */
+  path?: string;
+}
+
+/** A text source file in a project (text-first; binary deferred, #121). */
+export interface ProjectFile {
+  path: string;
+  content: string;
+}
+
+export type OperationKind = 'syntaxCheck' | 'preview' | 'render' | 'export';
+
+/**
+ * An immutable handle to a produced artifact's exact bytes. `artifactId` keys a
+ * per-session store so the bytes can be fetched by id (#197) — not a racy
+ * "current output".
+ */
+export interface ArtifactRef {
+  artifactId: string; // v4 UUID; immutable
+  operationId: string;
+  sourceRevision: number;
+  format: string; // 'off' | 'svg' | 'stl' | '3mf' | 'glb' | …
+  mediaType: string;
+  size: number;
+  name: string;
+}
+
+interface OperationResultBase {
+  protocolVersion: number;
+  sessionId: string;
+  operationId: string;
+  /** Echoed from the command; the #56/#99 stale-drop is unchanged. */
+  sourceRevision: number;
+  kind: OperationKind;
+  elapsedMillis: number;
+  /** Host-neutral markers (ADR 0001). */
+  diagnostics: Diagnostic[];
+  logText: string;
+}
+
+export interface OperationSuccess extends OperationResultBase {
+  status: 'success';
+  artifact?: ArtifactRef;
+}
+export interface OperationFailure extends OperationResultBase {
+  status: 'error';
+  code: string;
+  reason: string;
+}
+export interface OperationCancelled extends OperationResultBase {
+  status: 'cancelled';
+}
+
+/** Exactly one terminal result per `operationId`. */
+export type OperationResult = OperationSuccess | OperationFailure | OperationCancelled;
+
+/** The shared, version-independent fields of a terminal result (constructor input). */
+export type OperationBase = Omit<OperationResultBase, 'protocolVersion'>;

--- a/src/protocol/session-transport.ts
+++ b/src/protocol/session-transport.ts
@@ -1,0 +1,164 @@
+// Layer-1 session transport (ADR 0005/0009): the message set a host (a VS Code
+// webview) speaks to drive an `OpenScadSession`'s `ProjectContract` — push a
+// project, edit/remove files, change the entry point, cancel, dispose — and
+// receive the session's compile operation results. Built on the shared envelope
+// core, DOM-free, so validation is unit-testable in isolation. The session host
+// (the controller in the viewer-host tier, #192) binds these messages to the
+// in-process `ProjectContract` + the Model's `'operation'` event.
+//
+// Render is internal to the session webview (it embeds the viewer, #179), so this
+// protocol carries NO geometry/artifact bytes for display. Fetching an artifact's
+// bytes to export/save is a separate, later message (#197).
+
+import { isRecord, stampOutbound, type ProtocolErrorCode } from './envelope.ts';
+import type { OperationResult, ProjectFile } from './session-contract.ts';
+
+/**
+ * Bump on any breaking change to the session INBOUND/OUTBOUND message shapes. This
+ * is the session WIRE version — distinct from `L1_PROTOCOL_VERSION`, which versions
+ * the nested `OperationResult` payload (ADR 0005: each binding owns its version).
+ */
+export const SESSION_PROTOCOL_VERSION = 1;
+
+// DoS pre-filter caps (the host channel is trusted, but a runaway extension must
+// not OOM the worker). These mirror the engine's own caps in src/fs/project-path.ts
+// (MAX_PROJECT_FILE_COUNT = 2000, MAX_PROJECT_TOTAL_BYTES = 64 MiB) — the protocol
+// need not match exactly; `ProjectStore` re-validates and is the real enforcer.
+// Lengths are UTF-16 code units (as MAX_OFF_LENGTH in viewer-transport.ts).
+export const SESSION_MAX_FILE_LENGTH = 32 * 1024 * 1024;
+export const SESSION_MAX_FILES = 2048;
+export const SESSION_MAX_TOTAL_LENGTH = 64 * 1024 * 1024;
+export const SESSION_MAX_PATH_LENGTH = 4096;
+
+/** The inbound command types, advertised in `ready` so a host can feature-detect. */
+export const SESSION_COMMANDS = [
+  'setProject',
+  'updateFile',
+  'removeFile',
+  'setEntryPoint',
+  'cancel',
+  'dispose',
+] as const;
+
+/** Host → session. Mirrors `ProjectContract` (src/state/project-contract.ts) 1:1,
+ *  plus `dispose` for worker teardown. */
+export type SessionInbound =
+  | { type: 'setProject'; files: ProjectFile[]; entryPoint?: string }
+  | { type: 'updateFile'; path: string; content: string }
+  | { type: 'removeFile'; path: string }
+  | { type: 'setEntryPoint'; path: string }
+  | { type: 'cancel' }
+  | { type: 'dispose' };
+
+export type SessionValidation =
+  | { ok: true; message: SessionInbound }
+  | { ok: false; code: ProtocolErrorCode; reason: string };
+
+function readString(v: unknown): string | undefined {
+  return typeof v === 'string' ? v : undefined;
+}
+
+function err(code: ProtocolErrorCode, reason: string): SessionValidation {
+  return { ok: false, code, reason };
+}
+
+/** Validate a `ProjectFile[]` payload: shape + the DoS caps. */
+function readProjectFiles(value: unknown): SessionValidation | { files: ProjectFile[] } {
+  if (!Array.isArray(value)) return err('invalid-payload', 'files must be an array');
+  if (value.length > SESSION_MAX_FILES) return err('too-large', 'too many files');
+  const files: ProjectFile[] = [];
+  let total = 0;
+  for (const entry of value) {
+    if (!isRecord(entry)) return err('invalid-payload', 'each file must be an object');
+    const path = readString(entry.path);
+    const content = readString(entry.content);
+    if (path === undefined || content === undefined) {
+      return err('invalid-payload', 'file path and content must be strings');
+    }
+    if (path.length > SESSION_MAX_PATH_LENGTH) return err('too-large', 'a file path is too long');
+    if (content.length > SESSION_MAX_FILE_LENGTH) return err('too-large', 'a file is too large');
+    total += content.length + path.length;
+    if (total > SESSION_MAX_TOTAL_LENGTH) return err('too-large', 'project exceeds the size limit');
+    files.push({ path, content });
+  }
+  return { files };
+}
+
+/**
+ * Validate an untrusted inbound session message against the L1 protocol. Returns
+ * the narrowed message or a structured rejection the host can be told about. Shape
+ * + size only — path safety / canonicalization is the in-process `ProjectStore`'s
+ * job (and lives behind the protocol's import fence).
+ */
+export function validateSessionInbound(data: unknown): SessionValidation {
+  if (!isRecord(data)) return err('malformed', 'message is not an object');
+  if (data.protocolVersion !== SESSION_PROTOCOL_VERSION) {
+    return err('unsupported-version', `expected protocolVersion ${SESSION_PROTOCOL_VERSION}`);
+  }
+  if (typeof data.type !== 'string') return err('malformed', 'missing message type');
+
+  switch (data.type) {
+    case 'setProject': {
+      const result = readProjectFiles(data.files);
+      if ('ok' in result) return result; // a rejection
+      const entryPoint = data.entryPoint === undefined ? undefined : readString(data.entryPoint);
+      if (data.entryPoint !== undefined && entryPoint === undefined) {
+        return err('invalid-payload', 'entryPoint must be a string');
+      }
+      return {
+        ok: true,
+        message: {
+          type: 'setProject',
+          files: result.files,
+          ...(entryPoint !== undefined ? { entryPoint } : {}),
+        },
+      };
+    }
+    case 'updateFile': {
+      const path = readString(data.path);
+      const content = readString(data.content);
+      if (path === undefined || content === undefined) {
+        return err('invalid-payload', 'path and content must be strings');
+      }
+      if (path.length > SESSION_MAX_PATH_LENGTH) return err('too-large', 'path is too long');
+      if (content.length > SESSION_MAX_FILE_LENGTH) return err('too-large', 'file is too large');
+      return { ok: true, message: { type: 'updateFile', path, content } };
+    }
+    case 'removeFile':
+    case 'setEntryPoint': {
+      const path = readString(data.path);
+      if (path === undefined) return err('invalid-payload', 'path must be a string');
+      if (path.length > SESSION_MAX_PATH_LENGTH) return err('too-large', 'path is too long');
+      return { ok: true, message: { type: data.type, path } };
+    }
+    case 'cancel':
+      return { ok: true, message: { type: 'cancel' } };
+    case 'dispose':
+      return { ok: true, message: { type: 'dispose' } };
+    default:
+      return err('unknown-type', `unknown type "${data.type}"`);
+  }
+}
+
+// Outbound builders (session → host), version-stamped with the session WIRE version.
+
+/** Announce readiness + the supported inbound commands (host feature-detection). */
+export function sessionReady(capabilities: readonly string[]) {
+  return stampOutbound(SESSION_PROTOCOL_VERSION, 'ready', { capabilities: [...capabilities] });
+}
+
+/**
+ * Forward a terminal compile result. These are a PUSH STREAM, NOT 1:1 with
+ * commands: one edit fans out to multiple results (syntaxCheck + preview render +
+ * …), each a distinct `operationId`. The host correlates by `sourceRevision` +
+ * `kind` (e.g. render the highest-revision `preview`/`render`), never by command.
+ * The nested `result` keeps its own `L1_PROTOCOL_VERSION`.
+ */
+export function sessionOperationResult(result: OperationResult) {
+  return stampOutbound(SESSION_PROTOCOL_VERSION, 'operation-result', { result });
+}
+
+/** A protocol-level rejection of an inbound message (validation failure). */
+export function sessionError(code: ProtocolErrorCode | string, reason: string) {
+  return stampOutbound(SESSION_PROTOCOL_VERSION, 'error', { code, reason });
+}

--- a/src/runner/compile-contract.ts
+++ b/src/runner/compile-contract.ts
@@ -1,11 +1,30 @@
-// Layer-1 compile contract (ADR 0008): a host-side, DOM-free description of a
-// compile operation and its result, sitting ABOVE the CompileBackend boundary.
-// The worker protocol is unchanged; these types are derived host-side and are the
-// unit the host / embed / (future) MCP correlate on.
+// Layer-1 compile contract (ADR 0008): the in-process scheduler COMMAND shapes and
+// the result CONSTRUCTORS, sitting ABOVE the CompileBackend boundary. The DOM-free
+// result/payload TYPES (`OperationResult` family, `Diagnostic`, `ArtifactRef`,
+// `OperationKind`, `L1_PROTOCOL_VERSION`) now live in src/protocol/session-contract.ts
+// so the protocol stays distributable; they are re-exported here for existing
+// importers, who are unaffected.
 
-import type { Diagnostic } from '../diagnostics.ts';
+import {
+  L1_PROTOCOL_VERSION,
+  type ArtifactRef,
+  type OperationBase,
+  type OperationCancelled,
+  type OperationFailure,
+  type OperationKind,
+  type OperationSuccess,
+} from '../protocol/session-contract.ts';
 
-export type OperationKind = 'syntaxCheck' | 'preview' | 'render' | 'export';
+export {
+  L1_PROTOCOL_VERSION,
+  type ArtifactRef,
+  type OperationBase,
+  type OperationCancelled,
+  type OperationFailure,
+  type OperationKind,
+  type OperationResult,
+  type OperationSuccess,
+} from '../protocol/session-contract.ts';
 
 export interface OperationCommand {
   /** Shared envelope version (ADR 0005). */
@@ -27,47 +46,9 @@ export interface CancelCommand {
   operationId: string;
 }
 
-interface OperationResultBase {
-  protocolVersion: number;
-  sessionId: string;
-  operationId: string;
-  /** Echoed from the command; the #56/#99 stale-drop is unchanged. */
-  sourceRevision: number;
-  kind: OperationKind;
-  elapsedMillis: number;
-  /** Host-neutral markers (ADR 0001). */
-  diagnostics: Diagnostic[];
-  logText: string;
-}
-
-export interface OperationSuccess extends OperationResultBase {
-  status: 'success';
-  artifact?: ArtifactRef;
-}
-export interface OperationFailure extends OperationResultBase {
-  status: 'error';
-  code: string;
-  reason: string;
-}
-export interface OperationCancelled extends OperationResultBase {
-  status: 'cancelled';
-}
-
-/** Exactly one terminal result per `operationId`. */
-export type OperationResult = OperationSuccess | OperationFailure | OperationCancelled;
-
-/**
- * Layer-1 envelope version (ADR 0005 axis). Distinct from `EMBED_PROTOCOL_VERSION`
- * — that versions the embed *wire*; this versions the host-side operation result.
- */
-export const L1_PROTOCOL_VERSION = 1;
-
 /** Coarse failure code pending a real taxonomy when the MCP binding needs to
  *  branch on it; `reason` carries the user-facing message today. */
 export const OPERATION_FAILED = 'operation_failed';
-
-/** The shared, status-independent fields of a terminal result. */
-export type OperationBase = Omit<OperationResultBase, 'protocolVersion'>;
 
 export function operationSuccess(base: OperationBase, artifact?: ArtifactRef): OperationSuccess {
   // Omit the key entirely when artifact-less (e.g. a syntax check), so `'artifact'
@@ -90,21 +71,6 @@ export function operationFailure(
 
 export function operationCancelled(base: OperationBase): OperationCancelled {
   return { protocolVersion: L1_PROTOCOL_VERSION, status: 'cancelled', ...base };
-}
-
-/**
- * An immutable handle to a produced artifact's exact bytes. `artifactId` keys a
- * per-session store so `getArtifact(artifactId)` returns those exact bytes — not a
- * racy "current output".
- */
-export interface ArtifactRef {
-  artifactId: string; // v4 UUID; immutable
-  operationId: string;
-  sourceRevision: number;
-  format: string; // 'off' | 'svg' | 'stl' | '3mf' | 'glb' | …
-  mediaType: string;
-  size: number;
-  name: string;
 }
 
 /**

--- a/src/state/project-store.ts
+++ b/src/state/project-store.ts
@@ -18,12 +18,11 @@ export interface ProjectSnapshot {
   activePath: string;
 }
 
-/** One text file in a host-supplied project (the multi-file contract, #123). A
- *  binary variant is a future widening (see #121) and does not change this shape. */
-export interface ProjectFile {
-  path: string;
-  content: string;
-}
+// `ProjectFile` (one text file in a host-supplied project, the multi-file contract
+// #123; binary variant deferred, #121) is a wire payload, so its type lives in
+// src/protocol/session-contract.ts and is re-exported here for existing importers.
+import type { ProjectFile } from '../protocol/session-contract.ts';
+export type { ProjectFile };
 
 /**
  * Pick the entry point for a set of absolute source paths: a top-level


### PR DESCRIPTION
Closes #191 — the core net-new piece of the live-`.scad` session epic (#179). A host-neutral postMessage protocol for driving an `OpenScadSession`'s `ProjectContract` from a webview, mirroring the read-only viewer's L0 transport.

## What
- **`src/protocol/session-transport.ts`** — the wire:
  - Inbound `SessionInbound` = `setProject` / `updateFile` / `removeFile` / `setEntryPoint` / `cancel` / `dispose` (mirrors `ProjectContract` 1:1 + worker teardown).
  - `validateSessionInbound` — shape + DoS caps (file count, per-file/total length, **path length**); path safety stays downstream in `ProjectStore`.
  - Outbound builders: `sessionReady(capabilities)`, `sessionOperationResult(result)` (a **push stream** — results are *not* 1:1 with commands; correlate by `operationId`/`kind`/`sourceRevision`), `sessionError`.
  - `SESSION_PROTOCOL_VERSION`, distinct from the result payload's `L1_PROTOCOL_VERSION` (each binding owns its version).
  - **No artifact bytes** — render is internal to the session webview (#179); fetching bytes to export is #197.
- **`src/protocol/session-contract.ts`** — per the design review, the DOM-free L1 data types (`OperationResult` family, `Diagnostic`, `ArtifactRef`, `ProjectFile`, `L1_PROTOCOL_VERSION`) **moved** here and re-exported from `compile-contract.ts` / `diagnostics.ts` / `project-store.ts`. Single source of truth, **zero importer churn** (all `import type`), no mirror/drift-guard — keeps the protocol self-contained behind its import fence.

## Review
Two adversarial passes (design + implementation), no BLOCKERs. The implementation review confirmed the move is exact (prior public surface preserved) and the validator matches the viewer template; I added the **path-length cap** and the **total-size / in-`setProject` per-file** cap tests it flagged.

## Scope
Just the protocol module + the type move + tests. The `SessionController` binding to `OpenScadSession` + the `'operation'` event (and catching `ProjectPathError`→`sessionError`) is #192; the distributable session emit/manifest is #194.

`npm run verify` green (typecheck across all ~13 importers, lint incl. the protocol fence, build, protocol emit, viewer-bundle gate, 10 new tests).