### PR TITLE
feat(session): SessionController — bind OpenScadSession to a Transport (#192)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,13 @@ release (changelog upkeep and tagging had lapsed between `0.1.0` and `0.2.0`).
 
 ### Added
 
+- L1 `SessionController` (`src/session-host/`, #192): the compile counterpart of
+  `ViewerController` — binds a compiling `OpenScadSession` to a `Transport`,
+  validates inbound session commands and drives the session's `ProjectContract`,
+  streams the session's operation results to the host, and (embedded-viewer model)
+  renders a successful OFF result in-process into the session's viewer. State-free
+  behind a minimal `SessionHost` seam (with an `OpenScadSession` adapter), in a new
+  lint-fenced `session-host` tier.
 - L1 session protocol (`src/protocol/session-transport.ts`, #191): a host-neutral
   wire protocol for driving an `OpenScadSession`'s `ProjectContract` from a webview
   — `setProject`/`updateFile`/`removeFile`/`setEntryPoint`/`cancel`/`dispose`

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -174,6 +174,34 @@ export default tseslint.config(
     },
   },
 
+  // The session-host tier (the compile counterpart of viewer-host, #192/#179) MAY
+  // import the engine (state/runner) and the protocol + the reusable transports —
+  // it drives an OpenScadSession — but NOT the editor, Monaco, the language tooling,
+  // or the app shell, so the compile-capable session bundle stays lean.
+  {
+    files: ['src/session-host/**/*.ts'],
+    rules: {
+      'no-restricted-imports': [
+        'error',
+        {
+          patterns: [
+            {
+              group: [
+                '**/language/**',
+                'monaco-editor',
+                'monaco-editor/**',
+                '**/osc-editor-panel*',
+                '**/osc-app-shell*',
+              ],
+              message:
+                'The session host must not import the editor, Monaco, language, or app shell.',
+            },
+          ],
+        },
+      ],
+    },
+  },
+
   // The app must not reach into the viewer-host transports (reverse direction):
   // host-binding code is consumed only by the viewer entry composition root.
   {

--- a/src/session-host/__tests__/controller.test.ts
+++ b/src/session-host/__tests__/controller.test.ts
@@ -1,0 +1,252 @@
+import { describe, expect, it } from 'vitest';
+
+import { SessionController, type SessionHost } from '../controller.ts';
+import { InProcessTestTransport } from '../../viewer-host/transports/in-process.ts';
+import { SESSION_PROTOCOL_VERSION } from '../../protocol/session-transport.ts';
+import type { OperationResult } from '../../protocol/session-contract.ts';
+
+const V = SESSION_PROTOCOL_VERSION;
+const flush = () => new Promise((r) => setTimeout(r));
+
+class FakeSession implements SessionHost {
+  calls: string[] = [];
+  disposed = false;
+  throwOnUpdate = false;
+  throwOnRead = false;
+  useDeferredReads = false;
+  readonly artifacts = new Map<string, string>(); // artifactId → OFF text
+  private op: ((r: OperationResult) => void) | null = null;
+  private readDeferreds = new Map<string, (text: string | undefined) => void>();
+
+  setProject(files: { path: string }[], entryPoint?: string) {
+    this.calls.push(`setProject:${files.length}:${entryPoint ?? ''}`);
+  }
+  updateFile(path: string) {
+    if (this.throwOnUpdate) throw new Error('ProjectPathError: unsafe path');
+    this.calls.push(`updateFile:${path}`);
+  }
+  removeFile(path: string) {
+    this.calls.push(`removeFile:${path}`);
+  }
+  setEntryPoint(path: string) {
+    this.calls.push(`setEntryPoint:${path}`);
+  }
+  cancel() {
+    this.calls.push('cancel');
+  }
+  dispose() {
+    this.disposed = true;
+    this.calls.push('dispose');
+  }
+  onOperation(handler: (r: OperationResult) => void) {
+    this.op = handler;
+    return () => {
+      this.op = null;
+    };
+  }
+  async readArtifactText(id: string) {
+    if (this.throwOnRead) throw new Error('blob read failed');
+    if (this.useDeferredReads)
+      return new Promise<string | undefined>((res) => this.readDeferreds.set(id, res));
+    return this.artifacts.get(id);
+  }
+  /** Resolve a pending deferred read (for out-of-order completion tests). */
+  resolveRead(id: string, text: string | undefined) {
+    const res = this.readDeferreds.get(id);
+    this.readDeferreds.delete(id);
+    res?.(text);
+  }
+  emit(r: OperationResult) {
+    this.op?.(r);
+  }
+  get subscribed() {
+    return this.op !== null;
+  }
+}
+
+function result(over: Partial<OperationResult> & { artifactId?: string }): OperationResult {
+  const { artifactId, ...rest } = over;
+  return {
+    protocolVersion: 1,
+    sessionId: 's',
+    operationId: 'op',
+    sourceRevision: 1,
+    kind: 'preview',
+    elapsedMillis: 1,
+    diagnostics: [],
+    logText: '',
+    status: 'success',
+    ...(artifactId
+      ? {
+          artifact: {
+            artifactId,
+            operationId: 'op',
+            sourceRevision: (rest.sourceRevision as number) ?? 1,
+            format: 'off',
+            mediaType: 'text/plain',
+            size: 1,
+            name: 'out.off',
+          },
+        }
+      : {}),
+    ...rest,
+  } as OperationResult;
+}
+
+function setup() {
+  const session = new FakeSession();
+  const viewer = { offText: null as string | null };
+  const transport = new InProcessTestTransport();
+  const controller = new SessionController(session, viewer, transport);
+  return { session, viewer, transport, controller };
+}
+
+const sentTypes = (t: InProcessTestTransport) => t.sent.map((m) => (m as { type: string }).type);
+
+describe('SessionController', () => {
+  it('announces ready (after subscribing) with the supported commands', () => {
+    const { transport, session } = setup();
+    expect(session.subscribed).toBe(true);
+    expect(transport.sent[0]).toMatchObject({
+      protocolVersion: V,
+      type: 'ready',
+      capabilities: [
+        'setProject',
+        'updateFile',
+        'removeFile',
+        'setEntryPoint',
+        'cancel',
+        'dispose',
+      ],
+    });
+  });
+
+  it('dispatches each inbound command to the session', () => {
+    const { session, transport } = setup();
+    transport.receive({
+      protocolVersion: V,
+      type: 'setProject',
+      files: [{ path: '/a', content: 'x' }],
+    });
+    transport.receive({ protocolVersion: V, type: 'updateFile', path: '/a', content: 'y' });
+    transport.receive({ protocolVersion: V, type: 'removeFile', path: '/a' });
+    transport.receive({ protocolVersion: V, type: 'setEntryPoint', path: '/a' });
+    transport.receive({ protocolVersion: V, type: 'cancel' });
+    expect(session.calls).toEqual([
+      'setProject:1:',
+      'updateFile:/a',
+      'removeFile:/a',
+      'setEntryPoint:/a',
+      'cancel',
+    ]);
+  });
+
+  it('rejects an invalid inbound payload with a protocol error and no dispatch', () => {
+    const { session, transport } = setup();
+    transport.receive({ protocolVersion: V, type: 'updateFile', path: 5 });
+    expect(session.calls).toEqual([]);
+    expect(transport.sent.at(-1)).toMatchObject({ type: 'error', code: 'invalid-payload' });
+  });
+
+  it('catches a thrown ProjectPathError and surfaces it as a session error', () => {
+    const { session, transport } = setup();
+    session.throwOnUpdate = true;
+    transport.receive({ protocolVersion: V, type: 'updateFile', path: '/a', content: 'x' });
+    expect(transport.sent.at(-1)).toMatchObject({ type: 'error', code: 'invalid-payload' });
+  });
+
+  it('forwards operation results as a push stream', () => {
+    const { session, transport } = setup();
+    session.emit(result({ kind: 'syntaxCheck', artifactId: undefined }));
+    expect(sentTypes(transport)).toEqual(['ready', 'operation-result']);
+    expect(transport.sent.at(-1)).toMatchObject({
+      type: 'operation-result',
+      result: { kind: 'syntaxCheck', status: 'success' },
+    });
+  });
+
+  it('render bridge: pushes a successful OFF result into the embedded viewer', async () => {
+    const { session, viewer } = setup();
+    session.artifacts.set('a1', 'OFF 8 6 12\n...');
+    session.emit(result({ kind: 'render', sourceRevision: 5, artifactId: 'a1' }));
+    await flush();
+    expect(viewer.offText).toBe('OFF 8 6 12\n...');
+  });
+
+  it('render bridge: ignores non-OFF and non-success results', async () => {
+    const { session, viewer } = setup();
+    session.artifacts.set('a1', 'OFF');
+    // an error result + a 2D (no artifact) result
+    session.emit(
+      result({ status: 'error', code: 'render-error', reason: 'bad' } as Partial<OperationResult>),
+    );
+    session.emit(result({ kind: 'preview', artifactId: undefined }));
+    await flush();
+    expect(viewer.offText).toBeNull();
+  });
+
+  it('render bridge: a stale (older-revision) result does not overwrite a newer one', async () => {
+    const { session, viewer } = setup();
+    session.artifacts.set('new', 'NEW');
+    session.artifacts.set('old', 'OLD');
+    session.emit(result({ sourceRevision: 9, artifactId: 'new' }));
+    await flush();
+    session.emit(result({ sourceRevision: 4, artifactId: 'old' }));
+    await flush();
+    expect(viewer.offText).toBe('NEW');
+  });
+
+  it('render bridge: a full render supersedes a same-revision preview (either order)', async () => {
+    const { session, viewer } = setup();
+    session.artifacts.set('p', 'PREVIEW');
+    session.artifacts.set('r', 'RENDER');
+    session.emit(result({ kind: 'preview', sourceRevision: 5, artifactId: 'p' }));
+    await flush();
+    session.emit(result({ kind: 'render', sourceRevision: 5, artifactId: 'r' }));
+    await flush();
+    expect(viewer.offText).toBe('RENDER');
+    // a late preview at the same revision must NOT overwrite the render
+    session.emit(result({ kind: 'preview', sourceRevision: 5, artifactId: 'p' }));
+    await flush();
+    expect(viewer.offText).toBe('RENDER');
+  });
+
+  it('render bridge: out-of-order artifact reads can not clobber a higher-quality render', async () => {
+    const { session, viewer } = setup();
+    session.useDeferredReads = true;
+    session.emit(result({ kind: 'preview', sourceRevision: 7, artifactId: 'p' }));
+    session.emit(result({ kind: 'render', sourceRevision: 7, artifactId: 'r' }));
+    // the render's read resolves first; the preview's lands late and must be dropped
+    session.resolveRead('r', 'RENDER');
+    await flush();
+    session.resolveRead('p', 'PREVIEW');
+    await flush();
+    expect(viewer.offText).toBe('RENDER');
+  });
+
+  it('render bridge: a failed artifact read is swallowed (no crash, no render)', async () => {
+    const { session, viewer } = setup();
+    session.throwOnRead = true;
+    session.emit(result({ kind: 'render', sourceRevision: 3, artifactId: 'a1' }));
+    await flush();
+    expect(viewer.offText).toBeNull();
+  });
+
+  it('dispose: tears down the session, transport, and operation subscription; idempotent', () => {
+    const { session, transport, controller } = setup();
+    controller.dispose();
+    expect(session.disposed).toBe(true);
+    expect(session.subscribed).toBe(false);
+    // transport detached: further inbound is ignored.
+    transport.receive({ protocolVersion: V, type: 'cancel' });
+    expect(session.calls).toEqual(['dispose']);
+    controller.dispose(); // idempotent
+    expect(session.calls).toEqual(['dispose']);
+  });
+
+  it('a `dispose` inbound message tears the session down', () => {
+    const { session, transport } = setup();
+    transport.receive({ protocolVersion: V, type: 'dispose' });
+    expect(session.disposed).toBe(true);
+  });
+});

--- a/src/session-host/controller.ts
+++ b/src/session-host/controller.ts
@@ -1,0 +1,153 @@
+// Transport-agnostic Layer-1 session controller (ADR 0009 / #192). The compile
+// counterpart to the read-only `ViewerController`: it binds a compiling session to
+// a `Transport`, validates inbound commands, drives the session's `ProjectContract`,
+// streams the session's operation results back to the host, and — under the
+// embedded-viewer model (#179) — renders the produced geometry IN-PROCESS into the
+// session webview's own viewer (no geometry crosses the wire).
+//
+// It depends only on the protocol, the payload-agnostic `Transport`, and a minimal
+// `SessionHost` seam (so it's unit-testable without a real OpenSCAD worker); the
+// `OpenScadSession` adapter lives in ./session-host.ts.
+
+import {
+  SESSION_COMMANDS,
+  sessionError,
+  sessionOperationResult,
+  sessionReady,
+  validateSessionInbound,
+} from '../protocol/session-transport.ts';
+import type { OperationResult, ProjectFile } from '../protocol/session-contract.ts';
+import type { Transport } from '../viewer-host/transport.ts';
+
+/** The minimal session surface the controller drives (adapted from `OpenScadSession`). */
+export interface SessionHost {
+  setProject(files: ProjectFile[], entryPoint?: string): void;
+  updateFile(path: string, content: string): void;
+  removeFile(path: string): void;
+  setEntryPoint(path: string): void;
+  cancel(): void;
+  dispose(): void;
+  /** Subscribe to terminal operation results (the Model's `'operation'` stream);
+   *  returns an unsubscribe. */
+  onOperation(handler: (result: OperationResult) => void): () => void;
+  /** The exact OFF text of a produced artifact (race-free, by id), or undefined. */
+  readArtifactText(artifactId: string): Promise<string | undefined>;
+}
+
+/** The minimal viewer surface the render bridge sets (the embedded geometry viewer). */
+export interface SessionViewer {
+  offText: string | null;
+}
+
+export class SessionController {
+  private disposed = false;
+  private readonly unsubscribeOperations: () => void;
+  /** The (revision, quality-rank) of the geometry currently shown, so a stale or
+   *  lower-quality result can't overwrite it even if its async read finishes late. */
+  private renderedRevision = -1;
+  private renderedRank = -1;
+
+  constructor(
+    private readonly session: SessionHost,
+    private readonly viewer: SessionViewer,
+    private readonly transport: Transport,
+  ) {
+    this.unsubscribeOperations = session.onOperation(this.onOperation);
+    // Subscribe BEFORE announcing readiness, so a host that sends a command the
+    // instant it sees `ready` is never racing our inbound handler.
+    transport.subscribe(this.onInbound);
+    transport.send(sessionReady(SESSION_COMMANDS));
+  }
+
+  private onInbound = (payload: unknown): void => {
+    if (this.disposed) return;
+    const result = validateSessionInbound(payload);
+    if (!result.ok) {
+      this.transport.send(sessionError(result.code, result.reason));
+      return;
+    }
+    const msg = result.message;
+    try {
+      switch (msg.type) {
+        case 'setProject':
+          this.session.setProject(msg.files, msg.entryPoint);
+          break;
+        case 'updateFile':
+          this.session.updateFile(msg.path, msg.content);
+          break;
+        case 'removeFile':
+          this.session.removeFile(msg.path);
+          break;
+        case 'setEntryPoint':
+          this.session.setEntryPoint(msg.path);
+          break;
+        case 'cancel':
+          this.session.cancel();
+          break;
+        case 'dispose':
+          this.dispose();
+          break;
+      }
+    } catch (e) {
+      // ProjectStore throws synchronously on an unsafe / binary-overwrite path
+      // (ProjectPathError); surface it as a protocol error rather than letting it
+      // escape the transport's message pump. Skip if a `dispose` command's teardown
+      // threw — the transport is already gone.
+      if (this.disposed) return;
+      this.transport.send(sessionError('invalid-payload', String((e as Error)?.message ?? e)));
+    }
+  };
+
+  private onOperation = (result: OperationResult): void => {
+    if (this.disposed) return;
+    this.transport.send(sessionOperationResult(result));
+    void this.render(result);
+  };
+
+  /** Render bridge: push a successful 3D (OFF) result's bytes into the embedded
+   *  viewer. Supersession is by (revision, quality): a newer revision always wins,
+   *  and at the same revision a full `render` beats a fast `preview` — checked both
+   *  before and after the async read so out-of-order completions can't clobber it. */
+  private async render(result: OperationResult): Promise<void> {
+    if (result.status !== 'success' || result.artifact?.format !== 'off') return;
+    const rank = renderRank(result.kind);
+    if (!this.supersedesRender(result.sourceRevision, rank)) return;
+    let text: string | undefined;
+    try {
+      text = await this.session.readArtifactText(result.artifact.artifactId);
+    } catch {
+      return; // artifact read failed (evicted / blob error) — leave the current render.
+    }
+    if (text === undefined || this.disposed) return;
+    if (!this.supersedesRender(result.sourceRevision, rank)) return; // a newer/better render landed
+    this.renderedRevision = result.sourceRevision;
+    this.renderedRank = rank;
+    this.viewer.offText = text;
+  }
+
+  private supersedesRender(revision: number, rank: number): boolean {
+    return (
+      revision > this.renderedRevision ||
+      (revision === this.renderedRevision && rank > this.renderedRank)
+    );
+  }
+
+  /** Tear down: stop forwarding, dispose the session (terminating its worker), and
+   *  detach the transport last (via finally, so a throwing session teardown still
+   *  releases the transport). Idempotent. */
+  dispose(): void {
+    if (this.disposed) return;
+    this.disposed = true;
+    this.unsubscribeOperations();
+    try {
+      this.session.dispose();
+    } finally {
+      this.transport.dispose();
+    }
+  }
+}
+
+/** Render quality rank: a full `render` supersedes a fast `preview` at the same revision. */
+function renderRank(kind: OperationResult['kind']): number {
+  return kind === 'render' ? 1 : kind === 'preview' ? 0 : -1;
+}

--- a/src/session-host/session-host.ts
+++ b/src/session-host/session-host.ts
@@ -1,0 +1,27 @@
+// Adapts a concrete `OpenScadSession` to the `SessionHost` seam the
+// `SessionController` drives. This is the only state-coupled file in the tier; the
+// controller itself stays state-free (and unit-testable) behind `SessionHost`.
+
+import type { OperationResult } from '../protocol/session-contract.ts';
+import type { OpenScadSession } from '../state/session.ts';
+import type { SessionHost } from './controller.ts';
+
+export function sessionHostOf(session: OpenScadSession): SessionHost {
+  return {
+    setProject: (files, entryPoint) => session.setProject(files, entryPoint),
+    updateFile: (path, content) => session.updateFile(path, content),
+    removeFile: (path) => session.removeFile(path),
+    setEntryPoint: (path) => session.setEntryPoint(path),
+    cancel: () => session.cancel(),
+    dispose: () => session.dispose(),
+    onOperation: (handler) => {
+      const listener = (e: Event) => handler((e as CustomEvent<OperationResult>).detail);
+      session.model.addEventListener('operation', listener);
+      return () => session.model.removeEventListener('operation', listener);
+    },
+    readArtifactText: async (artifactId) => {
+      const stored = session.artifacts.get(artifactId);
+      return stored ? stored.bytes.text() : undefined;
+    },
+  };
+}


### PR DESCRIPTION
Closes #192. The compile counterpart of `ViewerController` — binds a compiling `OpenScadSession` to a `Transport`, completing the host-binding half of the live-`.scad` session (#179).

## What
- **`src/session-host/controller.ts`** — `SessionController(session, viewer, transport)`:
  - validates inbound session commands (#191) → drives the session's `ProjectContract`;
  - streams the session's `'operation'` results back to the host (a **push stream**, version-stamped);
  - **render bridge**: pushes a successful OFF result's bytes into the embedded viewer **in-process** (no geometry over the wire, #179);
  - `dispose` inbound → teardown; subscribe-before-`ready`; idempotent dispose.
  - **State-free** behind a minimal `SessionHost` seam → fully unit-testable.
- **`src/session-host/session-host.ts`** — `sessionHostOf(OpenScadSession)` adapter (the only state-coupled file).
- **eslint** — a new `session-host` fence: may import `state`/`runner`/`protocol`/the reusable transports (it drives the engine), but **not** the editor/Monaco/language/app-shell, so the compile-capable session bundle stays lean.

## Review
Adversarially reviewed (no BLOCKERs; lifecycle/adapter/fence confirmed correct). Fixed the two timing defects it found: **kind-aware render supersession** (a full `render` beats a same-revision `preview` regardless of async-read ordering — checked before *and* after the await), and **dispose** now uses `try/finally` + a disposed-guard so a throwing session teardown can't `send` on a torn-down transport. Also swallow a failed artifact read. 13 unit tests, including **out-of-order artifact reads**.

## Scope
The `SessionController` + adapter + tests. The composition root (`session.html`/`session-entry`) + the distributable bundle/manifest is #193/#194; the webview blob-worker bootstrap is #196.

`npm run verify` green.