### PR TITLE
feat(runner): host-configurable worker for webview blob workers (#196)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,18 @@ release (changelog upkeep and tagging had lapsed between `0.1.0` and `0.2.0`).
   "invalid vertex or face counts". The same-line form (`OFF 8 6 12`, as OpenSCAD
   exports) is unchanged.
 
+### Changed
+
+- The compile worker is now host-configurable (#196), so it can run from a
+  same-origin `blob:` URL inside a VS Code webview (where `new Worker` of a
+  cross-origin asset URL is blocked, and a blob worker's `import.meta.url` /
+  `self.location` — `blob:` — can't resolve assets). The host now resolves the
+  WASM URL + asset base on the main thread and injects them via a one-time
+  `configure` message (`worker-bootstrap.ts` `configureWorkerBootstrap` /
+  `workerConfigPayload`, `runtime/asset-urls.ts` `setRuntimeAssetBase`); the
+  worker no longer derives its base from `import.meta.url`. Behavior-equivalent
+  for the normal page (verified by the e2e compile suite).
+
 ### Added
 
 - L1 `SessionController` (`src/session-host/`, #192): the compile counterpart of

--- a/src/runner/__tests__/worker-bootstrap.test.ts
+++ b/src/runner/__tests__/worker-bootstrap.test.ts
@@ -1,0 +1,59 @@
+// #196: the worker bootstrap picks a same-origin blob worker for a cross-origin
+// (webview) host and injects a host-resolved asset base + wasm URL. Module state
+// is per-file in vitest, so this file owns the bootstrap's one-shot config.
+
+import { afterAll, beforeAll, describe, expect, it, vi } from 'vitest';
+
+import {
+  configureWorkerBootstrap,
+  createOpenSCADWorker,
+  workerConfigPayload,
+} from '../worker-bootstrap.ts';
+
+const workerArgs: { url: unknown; opts: unknown }[] = [];
+const origCreateObjectURL = URL.createObjectURL;
+
+beforeAll(() => {
+  vi.stubGlobal(
+    'Worker',
+    class {
+      constructor(url: unknown, opts?: unknown) {
+        workerArgs.push({ url, opts });
+      }
+    },
+  );
+  vi.stubGlobal(
+    'fetch',
+    vi.fn(async () => ({ text: async () => '/* worker iife */' })),
+  );
+  URL.createObjectURL = vi.fn(() => 'blob:fake-uuid') as typeof URL.createObjectURL;
+});
+
+afterAll(() => {
+  vi.unstubAllGlobals();
+  URL.createObjectURL = origCreateObjectURL;
+});
+
+describe('worker bootstrap (#196)', () => {
+  it('default → a module worker from the asset URL; the config payload host-resolves base + wasm', () => {
+    const payload = workerConfigPayload();
+    expect(payload.type).toBe('configure');
+    expect(typeof payload.assetBase).toBe('string');
+    expect(payload.assetBase.length).toBeGreaterThan(0);
+    expect(typeof payload.wasmUrl).toBe('string');
+
+    createOpenSCADWorker();
+    expect(workerArgs.at(-1)).toMatchObject({ opts: { type: 'module' } });
+    expect(String(workerArgs.at(-1)!.url)).not.toMatch(/^blob:/);
+  });
+
+  it('after configure → a classic blob worker, and the payload carries the injected base', async () => {
+    await configureWorkerBootstrap({ assetBase: 'https://abc.vscode-cdn.net/mount/' });
+
+    createOpenSCADWorker();
+    // classic worker: a blob: URL and no `{ type: 'module' }`.
+    expect(workerArgs.at(-1)).toEqual({ url: 'blob:fake-uuid', opts: undefined });
+
+    expect(workerConfigPayload().assetBase).toBe('https://abc.vscode-cdn.net/mount/');
+  });
+});

--- a/src/runner/openscad-runner.ts
+++ b/src/runner/openscad-runner.ts
@@ -3,7 +3,7 @@
 import { AbortablePromise } from '../utils.ts';
 import type { WireSource } from '../state/project-source.ts';
 import { markPerf, measurePerf, recordPerfDuration } from '../perf/runtime-performance.ts';
-import { createOpenSCADWorker } from './worker-bootstrap.ts';
+import { createOpenSCADWorker, workerConfigPayload } from './worker-bootstrap.ts';
 import {
   CompileRequest,
   CancelRequest,
@@ -173,6 +173,8 @@ export class WasmWorkerBackend implements CompileBackend {
       this.worker.onmessage = (e: MessageEvent<WorkerResponse>) =>
         this.handleWorkerMessage(e, generation);
       this.worker.onerror = (e: ErrorEvent) => this.handleWorkerError(e);
+      // Inject the host-resolved asset base + wasm URL before any compile (#196).
+      this.worker.postMessage(workerConfigPayload());
     }
     return this.worker;
   }

--- a/src/runner/openscad-runtime.ts
+++ b/src/runner/openscad-runtime.ts
@@ -3,9 +3,15 @@
 // eslint-disable-next-line @typescript-eslint/ban-ts-comment
 // @ts-ignore — no type declarations for the WASM module
 import OpenSCAD from '../wasm/openscad.js';
-import { openSCADWasmUrl } from './openscad-asset-urls.ts';
 
 export type RuntimeOptions = {
+  /**
+   * Host-resolved URL of `openscad.wasm` for Emscripten's `locateFile`. Injected
+   * (via the worker's `configure` handshake, #196) rather than imported here,
+   * because the worker may run from a `blob:` URL where the build's
+   * `import.meta.url`-relative `?url` literal would throw at module-eval time.
+   */
+  wasmUrl: string;
   print: (text: string) => void;
   printErr: (text: string) => void;
 };
@@ -32,7 +38,7 @@ export async function createRuntime(opts: RuntimeOptions): Promise<OpenSCADRunti
     noInitialRun: true,
     print: opts.print,
     printErr: opts.printErr,
-    locateFile: (path: string) => (path === 'openscad.wasm' ? openSCADWasmUrl : path),
+    locateFile: (path: string) => (path === 'openscad.wasm' ? opts.wasmUrl : path),
   });
 
   return {

--- a/src/runner/openscad-worker.ts
+++ b/src/runner/openscad-worker.ts
@@ -11,6 +11,7 @@ import {
 import { markPerf, measurePerf } from '../perf/runtime-performance.ts';
 import { createSerialQueue } from './serial-queue.ts';
 import { ensureWorkerBrowserFSLoaded } from '../runtime/browserfs-runtime.ts';
+import { setRuntimeAssetBase } from '../runtime/asset-urls.ts';
 import { createRuntime, OpenSCADRuntime } from './openscad-runtime.ts';
 import {
   CompileRequest,
@@ -26,10 +27,12 @@ import {
 import { fetchSource } from '../utils.ts';
 
 declare const self: DedicatedWorkerGlobalScope;
-// The worker bundle always lives under <mount>/assets/, so one parent hop from
-// import.meta.url recovers the app mount regardless of whether the build is
-// fixed-base (/openscad-web/) or relocatable (./).
-const appBaseUrl = new URL('../', import.meta.url).href;
+// Asset base + WASM URL are injected by the host's `configure` message (#196),
+// set before any compile. They are NOT derived from `import.meta.url` /
+// `self.location` — those are `blob:` (and throw when used to resolve a relative
+// asset) when this worker runs from a blob URL inside a VS Code webview.
+let appBaseUrl = '';
+let wasmUrl = '';
 
 // NOTE: runtimePromise is NOT a singleton — Emscripten's callMain calls exit() internally,
 // setting Module.ABORT=true. A second callMain on the same instance throws
@@ -43,6 +46,7 @@ const appBaseUrl = new URL('../', import.meta.url).href;
 // and compile jobs are serialized by the queue below regardless.
 function createJobRuntime(jobId: string, mergedOutputs: MergedOutput[]): Promise<OpenSCADRuntime> {
   return createRuntime({
+    wasmUrl,
     print: (text: string) => {
       self.postMessage({ type: 'stdout', id: jobId, text } satisfies CompileStdout);
       mergedOutputs.push({ stdout: text });
@@ -99,6 +103,12 @@ const compileQueue = createSerialQueue<CompileRequest>((request) => runCompile(r
 
 self.addEventListener('message', (e: MessageEvent<WorkerRequest>) => {
   const msg = e.data;
+  if (msg.type === 'configure') {
+    appBaseUrl = msg.assetBase;
+    wasmUrl = msg.wasmUrl;
+    setRuntimeAssetBase(msg.assetBase); // libraries/fonts/sources resolve here
+    return;
+  }
   if (msg.type === 'cancel') {
     compileQueue.cancel((request) => request.id === msg.id);
     return;

--- a/src/runner/worker-bootstrap.ts
+++ b/src/runner/worker-bootstrap.ts
@@ -1,7 +1,61 @@
+// How the OpenSCAD compile worker is created and configured (#196).
+//
+// Two host environments:
+//   - Normal page: `new Worker(url, { type: 'module' })` — the worker URL is
+//     same-origin, and `import.meta.url` here (the main thread) resolves the wasm.
+//   - VS Code webview: worker resources are cross-origin (`*.vscode-cdn.net` ≠
+//     `vscode-webview://`), so `new Worker(crossOriginUrl)` is SOP-blocked. The
+//     session-entry calls `configureWorkerBootstrap()` once to instantiate the
+//     worker from a same-origin `blob:` URL instead.
+//
+// EITHER WAY, the worker bundle no longer derives its own asset base from
+// `import.meta.url`/`self.location` (which is `blob:` and unusable in a webview).
+// The host resolves the asset base + the wasm URL — where `import.meta.url` is a
+// real URL — and injects them via the `configure` message (see `getWorker`).
+
 import openSCADWorkerUrl from './openscad-worker.ts?worker&url';
+import { openSCADWasmUrl } from './openscad-asset-urls.ts';
+import { resolveDefaultRuntimeBaseUrl } from '../runtime/asset-urls.ts';
+import type { ConfigureRequest } from './worker-protocol.ts';
+
+let blobWorkerUrl: string | null = null;
+let assetBaseOverride: string | undefined;
+
+/**
+ * Configure the bootstrap for a host whose worker/asset URLs are cross-origin to
+ * the document (a VS Code webview): pre-fetch the worker script (a `fetch` of the
+ * cross-origin URL is permitted — only `new Worker` of it is blocked) and cache a
+ * same-origin `blob:` URL to instantiate from, and pin the base the worker resolves
+ * assets against. Call once, before constructing the session. Idempotent-ish: the
+ * blob URL is created once and reused across worker recycles.
+ */
+export async function configureWorkerBootstrap(opts: { assetBase: string }): Promise<void> {
+  if (!blobWorkerUrl) {
+    const source = await fetch(openSCADWorkerUrl).then((r) => r.text());
+    blobWorkerUrl = URL.createObjectURL(new Blob([source], { type: 'text/javascript' }));
+  }
+  assetBaseOverride = opts.assetBase;
+}
 
 export function createOpenSCADWorker(): Worker {
-  return new Worker(openSCADWorkerUrl, { type: 'module' });
+  // A blob worker must be classic — the worker bundle is built as a single IIFE
+  // (vite.shared.ts `worker.format: 'iife'`), so there are no ESM imports to load.
+  return blobWorkerUrl
+    ? new Worker(blobWorkerUrl)
+    : new Worker(openSCADWorkerUrl, { type: 'module' });
+}
+
+/**
+ * The `configure` message the host posts to a freshly-created worker, before any
+ * compile. `wasmUrl` and `assetBase` are resolved HERE (main thread), where
+ * `import.meta.url` is a real URL, then handed to the worker verbatim (#196).
+ */
+export function workerConfigPayload(): ConfigureRequest {
+  return {
+    type: 'configure',
+    assetBase: assetBaseOverride ?? resolveDefaultRuntimeBaseUrl(import.meta.env.BASE_URL),
+    wasmUrl: openSCADWasmUrl,
+  };
 }
 
 export { openSCADWorkerUrl };

--- a/src/runner/worker-protocol.ts
+++ b/src/runner/worker-protocol.ts
@@ -20,7 +20,21 @@ export type CancelRequest = {
   id: string;
 };
 
-export type WorkerRequest = CompileRequest | CancelRequest;
+/**
+ * Sent once, before any compile, so the worker resolves the WASM + runtime assets
+ * against a HOST-resolved base. The worker's own `import.meta.url`/`self.location`
+ * is unusable when it runs from a `blob:` URL (a VS Code webview, #196), so the
+ * asset base and the wasm URL are computed on the main thread and injected here.
+ */
+export type ConfigureRequest = {
+  type: 'configure';
+  /** Absolute base for resolving library/font/source assets. */
+  assetBase: string;
+  /** Host-resolved URL of the OpenSCAD WASM binary (Emscripten `locateFile`). */
+  wasmUrl: string;
+};
+
+export type WorkerRequest = CompileRequest | CancelRequest | ConfigureRequest;
 
 // Worker response types (worker → host)
 export type CompileStarted = { type: 'started'; id: string };

--- a/src/runtime/__tests__/asset-urls.test.ts
+++ b/src/runtime/__tests__/asset-urls.test.ts
@@ -1,6 +1,10 @@
-import { describe, expect, it } from 'vitest';
+import { afterEach, describe, expect, it } from 'vitest';
 
-import { resolveDefaultRuntimeBaseUrl, resolveRuntimeAssetUrl } from '../asset-urls.ts';
+import {
+  resolveDefaultRuntimeBaseUrl,
+  resolveRuntimeAssetUrl,
+  setRuntimeAssetBase,
+} from '../asset-urls.ts';
 
 describe('resolveRuntimeAssetUrl', () => {
   it('resolves dot-slash asset specifiers against a base URL', () => {
@@ -49,5 +53,26 @@ describe('resolveDefaultRuntimeBaseUrl', () => {
         workerHref: 'https://example.com/assets/openscad-worker-D3It6O_Y.js',
       }),
     ).toBe('https://example.com/');
+  });
+});
+
+describe('setRuntimeAssetBase (#196)', () => {
+  afterEach(() => setRuntimeAssetBase(null)); // restore default derivation
+
+  it('pins the base used to resolve library/font/source assets', () => {
+    setRuntimeAssetBase('https://abc.vscode-cdn.net/mount/');
+    expect(resolveRuntimeAssetUrl('libraries/fonts.zip')).toBe(
+      'https://abc.vscode-cdn.net/mount/libraries/fonts.zip',
+    );
+    expect(resolveRuntimeAssetUrl('./assets/runtime-worker.js')).toBe(
+      'https://abc.vscode-cdn.net/mount/assets/runtime-worker.js',
+    );
+  });
+
+  it('an explicit base argument still overrides the pinned default', () => {
+    setRuntimeAssetBase('https://abc.vscode-cdn.net/mount/');
+    expect(resolveRuntimeAssetUrl('x.zip', 'https://other.example/d/')).toBe(
+      'https://other.example/d/x.zip',
+    );
   });
 });

--- a/src/runtime/asset-urls.ts
+++ b/src/runtime/asset-urls.ts
@@ -54,8 +54,20 @@ export function resolveDefaultRuntimeBaseUrl(
   ).toString();
 }
 
+let overrideBase: string | null = null;
+
+/**
+ * Pin the base used to resolve runtime assets (libraries/fonts/sources). A blob
+ * worker — a VS Code webview's compile worker (#196) — can't derive its base from
+ * `self.location` (it's `blob:`), so the worker sets this from its `configure`
+ * handshake. `null` (the default, and the main thread) restores normal derivation.
+ */
+export function setRuntimeAssetBase(base: string | null): void {
+  overrideBase = base;
+}
+
 function getDefaultRuntimeBaseUrl(): string {
-  return resolveDefaultRuntimeBaseUrl(import.meta.env.BASE_URL);
+  return overrideBase ?? resolveDefaultRuntimeBaseUrl(import.meta.env.BASE_URL);
 }
 
 export function resolveRuntimeAssetUrl(

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -19,6 +19,15 @@ export default defineConfig({
         find: /^@gltf-transform\/.+$/,
         replacement: resolvePath('./tests/mocks/empty-module.ts'),
       },
+      {
+        // The wasm binary is a build asset, not vendored before `test:unit` in
+        // CI's build-and-test job. Since #196 the main-thread worker bootstrap
+        // imports `openscad.wasm?url` (host-resolved, injected into the worker),
+        // pulling it into the eager unit-test graph; stub it to a URL string so
+        // tests never resolve the 9.6 MB binary.
+        find: /^.+openscad\.wasm(\?.*)?$/,
+        replacement: resolvePath('./tests/mocks/file-mock.ts'),
+      },
     ],
   },
   test: {


### PR DESCRIPTION
Closes #196 — the highest-risk runtime item of the live-`.scad` session epic (#179), de-risked with a real Chromium experiment before implementing.

## The problem (verified)
The compile worker must run inside a VS Code webview. `new Worker(openSCADWorkerUrl)` is **SOP-blocked** (the asset URL is `*.vscode-cdn.net`, cross-origin to the `vscode-webview://` document). The fix is a same-origin `blob:` worker — but a blob worker's `import.meta.url`/`self.location` is `blob:`, and the build emits asset URLs as **eager** `new URL("<literal>", import.meta.url)` (confirmed by a throwaway relative-base Vite build), which **throws at worker-eval time** in a blob worker (confirmed in headless Chromium). So rebasing is dead and both problems must be solved together.

## The fix
The worker no longer derives its own asset base. The **host** resolves the WASM URL + asset base on the main thread (where `import.meta.url` is real) and **injects** them via a one-time `configure` message before any compile:
- `worker-protocol.ts`: `ConfigureRequest { assetBase, wasmUrl }`.
- `worker-bootstrap.ts`: `configureWorkerBootstrap()` (fetch the worker script → same-origin `blob:` URL) + `workerConfigPayload()`; `createOpenSCADWorker()` makes a **classic blob worker** when configured, else the unchanged module worker.
- `openscad-runner.ts`: `getWorker` posts the `configure` message on worker creation (and recycle).
- `openscad-worker.ts`: handles `configure` (sets `appBaseUrl` + wasm + asset base); the eager `import.meta.url` derivation is **removed**.
- `runtime/asset-urls.ts`: `setRuntimeAssetBase()` override for libs/fonts/sources.
- `openscad-runtime.ts`: `createRuntime` takes the injected `wasmUrl` (the `?url` import leaves the worker bundle for the host bundle).

## Validation
- **Behavior-equivalent for the normal page** (host base == the old worker-derived base) — proven by `npm run verify` + **35 e2e compile tests** (real WASM compile, library loading, render).
- New unit tests: `setRuntimeAssetBase` resolution + the bootstrap's default-vs-blob branch + the config payload.
- **The webview blob boot itself** (that no eager `self.location` resolution survives, real `WebAssembly.instantiateStreaming` under the webview CSP) is validated by **#193's real-WASM-boot EDH test** in the extension — flagged honestly.

## Downstream (extension)
The session-entry (#193) calls `configureWorkerBootstrap({ assetBase: document.baseURI })`. The **session webview CSP** needs `worker-src blob:` + `'wasm-unsafe-eval'` (extension-side, #193).