### PR TITLE
feat(build): compile-capable dist-session distributable (#193)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -156,6 +156,9 @@ jobs:
       - name: Browser E2E (Chromium full + Firefox smoke)
         run: npm run test:e2e
 
+      - name: Session real-WASM acceptance (dist-session, #193)
+        run: npm run test:e2e:session
+
       - name: Upload Playwright artifacts
         if: always()
         uses: actions/upload-artifact@v7

--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,7 @@ node_modules/
 dist/
 dist-publish/
 dist-viewer/
+dist-session/
 libs/
 openscad-web-publish.zip
 .publish-e2e/

--- a/.prettierignore
+++ b/.prettierignore
@@ -1,5 +1,8 @@
 node_modules
 dist
+dist-publish
+dist-viewer
+dist-session
 coverage
 libs
 src/wasm

--- a/package.json
+++ b/package.json
@@ -26,6 +26,8 @@
     "test:e2e:dev": "cross-env E2E_SERVER_MODE=dev NODE_ENV=development playwright test",
     "test:e2e:publish": "node ./scripts/run-publish-e2e.mjs",
     "test:e2e:publish:skip-build": "cross-env E2E_PUBLISH_SKIP_BUILD=true node ./scripts/run-publish-e2e.mjs",
+    "test:e2e:session": "node ./scripts/run-session-e2e.mjs",
+    "test:e2e:session:skip-build": "cross-env E2E_SESSION_SKIP_BUILD=true node ./scripts/run-session-e2e.mjs",
     "test:assembly": "vitest run scripts/__tests__ --coverage=false",
     "test:unit": "vitest run",
     "start:development": "cross-env NODE_ENV=development vite",
@@ -35,6 +37,8 @@
     "build:publish": "node ./scripts/build-publish.mjs",
     "build:protocol": "tsc -p tsconfig.protocol.json && node ./scripts/rewrite-protocol-dts.mjs && node ./scripts/verify-protocol-emit.mjs",
     "build:viewer": "cross-env NODE_ENV=production vite build --config vite.viewer.config.ts && npm run build:protocol && node ./scripts/verify-viewer-bundle.mjs --dir dist-viewer && node ./scripts/build-viewer-manifest.mjs",
+    "build:session": "cross-env NODE_ENV=production vite build --config vite.session.config.ts",
+    "serve:session": "serve -l 3000 dist-session",
     "build:libs": "cross-env LIBS_BUILD_MODE=all node ./scripts/build-assets/cli.mjs",
     "build:libs:clean": "cross-env LIBS_BUILD_MODE=clean node ./scripts/build-assets/cli.mjs",
     "build:libs:wasm": "cross-env LIBS_BUILD_MODE=wasm node ./scripts/build-assets/cli.mjs",
@@ -56,7 +60,7 @@
     "security:check-install-scripts": "node ./scripts/security/check-install-scripts.mjs",
     "verify:publish-archive": "node ./scripts/verify-publish-archive.mjs",
     "verify": "npm run format:check && npm run lint && npm run typecheck && npm run test:unit && npm run test:assembly && npm run build && npm run check:budgets && npm run build:publish && npm run verify:publish-archive && npm run build:viewer",
-    "verify:full": "npm run verify && npm run test:e2e && npm run test:e2e:publish:skip-build",
+    "verify:full": "npm run verify && npm run test:e2e && npm run test:e2e:publish:skip-build && npm run test:e2e:session",
     "check:budgets": "node ./scripts/check-bundle-budgets.mjs"
   },
   "browserslist": {

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -4,18 +4,23 @@ const serverMode = process.env.E2E_SERVER_MODE ?? 'prod';
 const isDevelopmentServer = serverMode === 'dev';
 const isPublishRootServer = serverMode === 'publish-root';
 const isPublishSubpathServer = serverMode === 'publish-subpath';
+// The compile-capable distributable (#193): dist-session served at root (base
+// './'), so session.html sits at http://localhost:3000/session.html.
+const isSessionServer = serverMode === 'session';
 const appUrl = isDevelopmentServer
   ? 'http://localhost:4000/'
-  : isPublishRootServer
+  : isPublishRootServer || isSessionServer
     ? 'http://localhost:3000/'
     : isPublishSubpathServer
       ? 'http://localhost:3000/openscad-web/'
       : 'http://localhost:3000/dist/';
 const webServerCommand = isDevelopmentServer
   ? 'npm run start:development'
-  : isPublishRootServer || isPublishSubpathServer
-    ? 'node ./scripts/serve-publish-e2e.mjs'
-    : 'npm run start:production';
+  : isSessionServer
+    ? 'npm run serve:session'
+    : isPublishRootServer || isPublishSubpathServer
+      ? 'node ./scripts/serve-publish-e2e.mjs'
+      : 'npm run start:production';
 
 export default defineConfig({
   testDir: './tests',
@@ -76,6 +81,9 @@ export default defineConfig({
     url: appUrl,
     timeout: 180_000,
     reuseExistingServer:
-      process.env.CI !== 'true' && !isPublishRootServer && !isPublishSubpathServer,
+      process.env.CI !== 'true' &&
+      !isPublishRootServer &&
+      !isPublishSubpathServer &&
+      !isSessionServer,
   },
 });

--- a/scripts/run-session-e2e.mjs
+++ b/scripts/run-session-e2e.mjs
@@ -1,0 +1,51 @@
+#!/usr/bin/env node
+
+// Real-WASM-boot acceptance check for the dist-session distributable (#193).
+// Builds the relative-base session bundle, then runs the session spec against it
+// under a static `serve` of dist-session. Unlike the headless project-contract
+// unit test (which uses a FakeBackend), this boots the actual OpenSCAD WASM in a
+// real browser worker and asserts a genuine OFF artifact comes back — proving the
+// vendored bundle compiles. Mirrors run-publish-e2e.mjs.
+
+import { spawn } from 'node:child_process';
+
+function resolveCommand(baseName) {
+  return process.platform === 'win32' ? `${baseName}.cmd` : baseName;
+}
+
+function runCommand(command, args, envOverrides = {}) {
+  return new Promise((resolve, reject) => {
+    const child = spawn(command, args, {
+      stdio: 'inherit',
+      shell: process.platform === 'win32',
+      env: {
+        ...process.env,
+        ...envOverrides,
+      },
+    });
+
+    child.on('exit', (code) => {
+      if (code === 0) {
+        resolve();
+        return;
+      }
+      reject(new Error(`Command failed with exit code ${code}: ${command} ${args.join(' ')}`));
+    });
+
+    child.on('error', reject);
+  });
+}
+
+async function main() {
+  if (process.env.E2E_SESSION_SKIP_BUILD !== 'true') {
+    await runCommand(resolveCommand('npm'), ['run', 'build:session']);
+  }
+
+  // Filter to the session spec: dist-session has no viewer.html/index.html, so the
+  // other specs (which load those) would fail under this server mode.
+  await runCommand(resolveCommand('npx'), ['playwright', 'test', 'session.spec.ts'], {
+    E2E_SERVER_MODE: 'session',
+  });
+}
+
+await main();

--- a/session.html
+++ b/session.html
@@ -1,0 +1,30 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>OpenSCAD session</title>
+    <meta
+      name="description"
+      content="Compile-capable OpenSCAD session, driven over a postMessage host transport. Boots the OpenSCAD WASM engine and an embedded read-only geometry viewer; no editor or service worker."
+    />
+    <style>
+      html,
+      body {
+        margin: 0;
+        height: 100%;
+        background: var(--osc-viewer-bg, #1e1e1e);
+      }
+      #session-root,
+      osc-geometry-viewer {
+        display: block;
+        width: 100%;
+        height: 100vh;
+      }
+    </style>
+  </head>
+  <body>
+    <div id="session-root"></div>
+    <script type="module" src="/src/session-entry/index.ts"></script>
+  </body>
+</html>

--- a/src/session-entry/index.ts
+++ b/src/session-entry/index.ts
@@ -1,0 +1,50 @@
+// Compile-capable session entry (#193, part of #179): the distributable counterpart
+// to the read-only viewer-entry. It boots the OpenSCAD WASM engine + an embedded
+// <osc-geometry-viewer> in ONE webview and binds them to the Layer-1 session
+// transport via the SessionController (#192). Geometry renders IN-PROCESS — the
+// controller sets the viewer's `offText` locally; nothing but the L1 protocol
+// crosses the wire (bytes only later, for export — #197).
+//
+// Deliberately omits the app shell: no Monaco/editor, no service worker, no state
+// persistence. The host (a VS Code webview) owns the project lifecycle and drives
+// it over the transport; `vite.session.config.ts` builds this to `dist-session`
+// with relative URLs so it loads under an opaque webview origin.
+
+import '../components/elements/osc-geometry-viewer.ts';
+import { SessionController } from '../session-host/controller.ts';
+import { sessionHostOf } from '../session-host/session-host.ts';
+import { OpenScadSession } from '../state/session.ts';
+import { createInitialState } from '../state/initial-state.ts';
+import { createEditorFS } from '../fs/filesystem.ts';
+import { ensureBrowserFSLoaded } from '../runtime/browserfs-runtime.ts';
+import { configureWorkerBootstrap } from '../runner/worker-bootstrap.ts';
+import { selectViewerTransport } from '../viewer-host/transports/select.ts';
+import type { GeometryViewer } from '../viewer-host/controller.ts';
+
+async function main(): Promise<void> {
+  const root = document.getElementById('session-root')!;
+  const viewer = document.createElement('osc-geometry-viewer') as GeometryViewer;
+  // Host-display only — no preview placeholder, so skip thumbnail hashing.
+  viewer.generateThumbnails = false;
+  root.appendChild(viewer);
+
+  // Resolve the same-origin blob worker + asset base (#196) BEFORE the first
+  // compile: under a webview the worker/asset URLs are cross-origin, so the worker
+  // must be instantiated from a same-origin blob and told its asset base. The
+  // worker is created lazily on the first compile, so configuring before the
+  // session is constructed is sufficient. Run it alongside FS init.
+  const [, { fs }] = await Promise.all([
+    configureWorkerBootstrap({ assetBase: document.baseURI }),
+    ensureBrowserFSLoaded().then(() => createEditorFS({ allowPersistence: false })),
+  ]);
+
+  // No `init()`: the embedded-session lifecycle is host-driven (#179). The viewer
+  // stays empty until the host's first `setProject`, which drives the first real
+  // compile — calling `init()` would compile the default state and flash unwanted
+  // geometry. Construct the controller LAST; its ctor subscribes then announces
+  // `ready`, so the host can send a command the instant it sees readiness.
+  const session = new OpenScadSession(fs, createInitialState(null));
+  new SessionController(sessionHostOf(session), viewer, selectViewerTransport());
+}
+
+void main();

--- a/tests/session.spec.ts
+++ b/tests/session.spec.ts
@@ -1,0 +1,98 @@
+import { expect, test, type Page } from '@playwright/test';
+
+// Real-WASM-boot acceptance check for the compile-capable distributable
+// (session.html → dist-session, #193). Unlike the headless project-contract unit
+// test (which drives a FakeBackend), this plays the HOST against the actual
+// bundle: a same-origin harness embeds session.html in an iframe (real embedding —
+// the session posts to its parent over the BrowserParentTransport), pushes a
+// project over the Layer-1 session protocol, and asserts the session boots the
+// OpenSCAD WASM worker and streams back a genuine OFF artifact. It only runs under
+// E2E_SERVER_MODE=session (dist-session served at root), driven by
+// scripts/run-session-e2e.mjs.
+
+const sessionServed = process.env.E2E_SERVER_MODE === 'session';
+
+const baseUrl = new URL('http://localhost:3000/');
+const sessionSrc = new URL('session.html', baseUrl).toString();
+const harnessUrl = new URL('__session_harness.html', baseUrl).toString();
+
+declare global {
+  interface Window {
+    __sessionMessages?: {
+      type?: string;
+      result?: { status?: string; artifact?: { format?: string } };
+    }[];
+  }
+}
+
+/** Load a same-origin harness that embeds session.html in an iframe and collects
+ *  the L1 messages the session posts to the parent. */
+async function embedSession(page: Page): Promise<void> {
+  await page.route('**/__session_harness.html', (route) =>
+    route.fulfill({
+      contentType: 'text/html',
+      body: '<!doctype html><meta charset="utf-8"><title>harness</title><body></body>',
+    }),
+  );
+  await page.goto(harnessUrl);
+  await page.evaluate((src) => {
+    window.__sessionMessages = [];
+    window.addEventListener('message', (e) => window.__sessionMessages!.push(e.data));
+    const frame = document.createElement('iframe');
+    frame.id = 'session-frame';
+    frame.src = src;
+    frame.style.cssText = 'width:400px;height:300px;border:0';
+    document.body.appendChild(frame);
+  }, sessionSrc);
+  // The session announces readiness to the parent once BrowserFS + the worker
+  // bootstrap have resolved. Cold-boot of the bundle can take a moment.
+  await page.waitForFunction(
+    () => window.__sessionMessages?.some((m) => m?.type === 'ready'),
+    null,
+    { timeout: 60_000 },
+  );
+}
+
+async function postToSession(page: Page, message: object): Promise<void> {
+  await page.evaluate((msg) => {
+    const frame = document.getElementById('session-frame') as HTMLIFrameElement;
+    frame.contentWindow!.postMessage(msg, window.location.origin);
+  }, message);
+}
+
+test.describe('session distributable (#193)', () => {
+  test.skip(!sessionServed, 'requires E2E_SERVER_MODE=session (dist-session served)');
+
+  test('boots real WASM and renders a pushed project to an OFF artifact', async ({ page }) => {
+    await embedSession(page);
+
+    await postToSession(page, {
+      protocolVersion: 1,
+      type: 'setProject',
+      files: [{ path: 'main.scad', content: 'cube([10, 10, 10]);' }],
+      entryPoint: 'main.scad',
+    });
+
+    // A genuine WASM compile fans out to a success operation-result carrying an
+    // OFF artifact (the render bridge also sets it on the embedded viewer, but the
+    // wire result is what proves the engine actually ran). Generous timeout for
+    // cold WASM boot + first compile.
+    await page.waitForFunction(
+      () =>
+        window.__sessionMessages?.some(
+          (m) =>
+            m?.type === 'operation-result' &&
+            m?.result?.status === 'success' &&
+            m?.result?.artifact?.format === 'off',
+        ),
+      null,
+      { timeout: 60_000 },
+    );
+
+    // No protocol/compile error was reported for the valid project.
+    const hadError = await page.evaluate(() =>
+      window.__sessionMessages?.some((m) => m?.type === 'error'),
+    );
+    expect(hadError).toBeFalsy();
+  });
+});

--- a/vite.session.config.ts
+++ b/vite.session.config.ts
@@ -1,0 +1,46 @@
+import { cpSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+
+import { defineConfig, type Plugin } from 'vite';
+
+import { createAppViteConfig } from './vite.shared.ts';
+
+// The DISTRIBUTABLE compile-capable build (#193, part of #179): session.html + its
+// chunk graph (BrowserFS + OpenSCAD WASM worker + the embedded viewer), with
+// RELATIVE asset URLs so it loads under an opaque VS Code webview origin — the
+// same relocation the read-only `dist-viewer` solved, but compile-capable.
+//
+// Unlike the viewer, this MUST ship the runtime assets the compile path fetches:
+// the OpenSCAD library zips + fonts. The WASM and worker auto-bundle into the
+// graph (`openscad.wasm?url`, `openscad-worker.ts?worker&url`); only the zips live
+// in `public/` and must be copied. We copy ONLY `public/libraries/` (not the rest
+// of `public/` — logos, sounds, test fixtures) to keep the vendored artifact lean;
+// #194 will hash every shipped file into a session-manifest, so dead weight there
+// is real cost.
+function copySessionLibraries(outDir: string): Plugin {
+  return {
+    name: 'session-copy-libraries',
+    apply: 'build',
+    closeBundle() {
+      cpSync(
+        fileURLToPath(new URL('./public/libraries', import.meta.url)),
+        fileURLToPath(new URL(`./${outDir}/libraries`, import.meta.url)),
+        { recursive: true },
+      );
+    },
+  };
+}
+
+const outDir = 'dist-session';
+
+export default defineConfig({
+  ...createAppViteConfig({
+    base: './',
+    outDir,
+    entries: ['session.html'],
+    // No verbatim `public/` copy — the curated `libraries/` copy below ships
+    // exactly the runtime assets the compile path fetches, nothing else.
+    publicDir: false,
+  }),
+  plugins: [copySessionLibraries(outDir)],
+});


### PR DESCRIPTION
Part of epic #179 (live-`.scad` session in VS Code, WASM-only, embedded-viewer model). Closes #193.

## What

A relative-base, **compile-capable** build target — `session.html` → `dist-session` — mirroring the read-only `dist-viewer` tier but booting the OpenSCAD WASM engine + an embedded geometry viewer. This is the self-contained, relocatable bundle the VS Code extension will vendor into its webview (`dist` uses absolute `/openscad-web/` URLs that don't resolve under `vscode-webview://`; `dist-viewer` has no compiler).

## Pieces

- **`session.html` + `src/session-entry/index.ts`** — composition root: boots BrowserFS, an `OpenScadSession` (worker + WASM), the `SessionController` (#192), and the parent/webview transport, with an embedded `<osc-geometry-viewer>` that renders **in-process** (no geometry over the wire). Deliberately omits the app shell: no Monaco/editor, no service worker, no persistence. Lifecycle is **host-driven** — no `init()`; the viewer stays empty until the host's first `setProject` drives the first real compile.
- **`vite.session.config.ts`** — `base: './'`, `outDir: dist-session`. WASM (`openscad.wasm?url`) and the worker (`?worker&url`) auto-bundle; a `closeBundle` plugin copies **only** `public/libraries` (zips + `fonts.zip`) — the curated runtime assets the compile path fetches, keeping the artifact lean (the rest of `public/` is dead weight a #194 manifest would have to account for).
- **`build:session`** + a **real-WASM-boot acceptance check**. The existing headless project-contract test uses a `FakeBackend`, so it doesn't prove the bundle compiles. `tests/session.spec.ts` (run by `scripts/run-session-e2e.mjs` under a new `session` Playwright server mode) iframe-embeds the **built** bundle, pushes `cube([10,10,10]);` over the L1 session protocol, and asserts a genuine `operation-result` with an OFF artifact streams back — a real worker + WASM compile through the same blob-worker path the webview uses. Wired into `verify:full` and the CI `e2e` job (which vendors WASM first).

## Out of scope (→ #194)

The strict inverse-isolation bundle gate (assert WASM/worker present + service-worker absent), the hashed `session-manifest.json`, and the CSP doc. `build:session` is intentionally **not** in `verify` yet — it joins once its bundle gate lands, mirroring how `build:viewer` carries `verify-viewer-bundle`.

## Verification

- `npm run verify` — green (format, lint, typecheck, unit, assembly, build, budgets, publish, viewer).
- `npm run test:e2e:session` — **green**: real WASM boots and compiles the cube to OFF in ~1.7s, served from `dist-session`.
- `dist-session` contents confirmed: `session.html` + worker + `*.wasm` + three chunk + `libraries/` — **no** service worker, **no** Monaco chunk.