### PR TITLE
feat(build): session bundle isolation gate + manifest + L1 protocol emit (#194)

### DIFF
--- a/docs/EMBEDDING-VSCODE.md
+++ b/docs/EMBEDDING-VSCODE.md
@@ -8,6 +8,11 @@ iframe/`postMessage` integration) — the **same `viewer.html` runs in both** an
 iframe and a VS Code webview; only the transport binding differs, and it is
 auto-selected at runtime.
 
+§1–5 cover the **read-only viewer** (L0). [§6](#6-the-session-compile-artifact)
+covers the separate **compile-capable session artifact** (`dist-session`) that runs
+the OpenSCAD WASM engine in the webview and speaks the Layer-1 (L1) session
+protocol — vendor it instead of the viewer when you need live `.scad` compilation.
+
 The extension itself is a **separate codebase**. The boundary between the two
 repos is exactly: the built viewer assets + the L0 protocol. Nothing in this repo
 depends on VS Code (`@types/vscode` is not a dependency), and the extension never
@@ -228,9 +233,94 @@ GPU-capable job.
 
 ---
 
-## 6. Out of scope (future)
+## 6. The session (compile) artifact
 
-Live `.scad` preview (compile `.scad` → OFF and feed it to this same viewer host)
-depends on a separate **session webview** build — see the live-`.scad` session
-architecture issue. The read-only viewer host documented here is unchanged by
-that later milestone.
+Everything above is the **read-only** viewer: the extension already holds OFF
+geometry and just displays it. To compile `.scad` **inside** the webview — feed it
+a project, get geometry back — vendor the separate **session artifact**
+(`dist-session`, built by `npm run build:session`, gated by
+`scripts/verify-session-bundle.mjs`). It is the compile-capable sibling of
+`dist-viewer`: same relocatable, relative-URL, vendor-and-pin model, but it carries
+the OpenSCAD WASM + compile worker + BrowserFS and an **embedded** geometry viewer.
+
+Why a second artifact and not a flag on the viewer: the viewer artifact is
+gate-enforced to contain **no** WASM/worker/BrowserFS (so its CSP can stay strict);
+the session artifact is gate-enforced to contain them (and to **not** leak the
+editor shell or a service worker). The two never merge.
+
+### What it ships
+
+```
+dist-session/
+  session.html                 # entry; relative URLs (load exactly like viewer.html)
+  assets/                       # session chunk, three, openscad.wasm, openscad-worker-*.js
+  libraries/                    # OpenSCAD library zips + fonts.zip (fetched at compile time)
+  protocol/                     # the L1 session protocol, compiled (session.js + .d.ts)
+  session-manifest.json         # hashed integrity manifest (verify like viewer-manifest.json)
+```
+
+`session-manifest.json` mirrors `viewer-manifest.json` (§1): `schemaVersion`,
+`sessionVersion`, `protocolVersion` (the `SESSION_PROTOCOL_VERSION` source of
+truth), `sourceCommit`, per-file `sha256`, and an `allowlist`. Verify it on ingest
+the same way — it covers the multi-MB WASM and the zips, so a corrupt or
+partial vendor is caught before load.
+
+### Loading + CSP (the deltas vs the viewer)
+
+Load `session.html` exactly as `viewer.html` (§2): inject a `<base href>` for the
+relative URLs, restrict `localResourceRoots` to the session dir. Prefer
+`retainContextWhenHidden: true` here — a live compile session holds worker + WASM +
+FS state that is expensive to rebuild on every reveal.
+
+The CSP needs two directives the viewer's does **not**, because this bundle
+actually compiles WASM in a worker:
+
+```
+default-src 'none';
+script-src ${webview.cspSource} 'nonce-${nonce}' 'wasm-unsafe-eval';
+worker-src blob:;
+style-src ${webview.cspSource} 'unsafe-inline';
+img-src ${webview.cspSource} data: blob:;
+connect-src ${webview.cspSource};
+```
+
+- **`'wasm-unsafe-eval'`** — required to `WebAssembly.instantiate` the OpenSCAD
+  engine (the viewer needs none).
+- **`worker-src blob:`** — the worker is instantiated from a same-origin `blob:`
+  URL. Under a webview the packaged worker/asset URLs are cross-origin to the
+  `vscode-webview://` document, so `new Worker(crossOriginUrl)` is SOP-blocked; the
+  bundle instead `fetch`es the worker script (allowed) and runs it from a blob.
+- **`connect-src ${webview.cspSource}`** covers the runtime `fetch`es of the worker
+  script, the `.wasm`, and the library zips — all from the session dir.
+- **No COOP/COEP headers.** The engine is single-threaded WASM (no
+  `SharedArrayBuffer`), so cross-origin isolation is **not** required — do not add
+  them.
+
+### Speaking the L1 session protocol
+
+Import from the vendored session protocol (not the viewer's `index.js`):
+
+```ts
+import { SESSION_PROTOCOL_VERSION, type SessionInbound } from '<vendored>/protocol/session.js'; // .d.ts ships alongside
+```
+
+The handshake is the same shape as §4: wait for `ready` (its `capabilities` are the
+inbound command names) and assert `protocolVersion === SESSION_PROTOCOL_VERSION`
+before sending. Then **drive a project** rather than push geometry:
+
+- **Host → session:** `setProject { files:[{path,content}], entryPoint? }`,
+  `updateFile { path, content }`, `removeFile { path }`, `setEntryPoint { path }`,
+  `cancel`, `dispose`.
+- **Session → host:** `ready`, `operation-result { result }` (a **push stream** —
+  one edit fans out to multiple terminal results; correlate by the nested
+  `result.operationId` / `kind` / `sourceRevision`, **not** 1:1 with commands),
+  and `error { code, reason }`.
+
+Geometry is **not** sent over the wire: the session renders it **in-process** into
+its embedded viewer. The `operation-result` carries an `artifact` _reference_
+(id + format), not bytes; retrieving exported bytes (STL/3MF) to save to disk is a
+later, separate message (tracked by the export issue in the epic).
+
+> Compiling arbitrary `.scad` runs the full OpenSCAD engine on host-supplied input.
+> Push only files the user opened/trusts; the protocol caps file count/size, but
+> the compiler itself is the trust boundary.

--- a/package.json
+++ b/package.json
@@ -37,7 +37,8 @@
     "build:publish": "node ./scripts/build-publish.mjs",
     "build:protocol": "tsc -p tsconfig.protocol.json && node ./scripts/rewrite-protocol-dts.mjs && node ./scripts/verify-protocol-emit.mjs",
     "build:viewer": "cross-env NODE_ENV=production vite build --config vite.viewer.config.ts && npm run build:protocol && node ./scripts/verify-viewer-bundle.mjs --dir dist-viewer && node ./scripts/build-viewer-manifest.mjs",
-    "build:session": "cross-env NODE_ENV=production vite build --config vite.session.config.ts",
+    "build:session": "cross-env NODE_ENV=production vite build --config vite.session.config.ts && npm run build:session:protocol && node ./scripts/verify-session-bundle.mjs --dir dist-session && node ./scripts/build-session-manifest.mjs",
+    "build:session:protocol": "tsc -p tsconfig.session-protocol.json && node ./scripts/rewrite-protocol-dts.mjs --dir dist-session/protocol && node ./scripts/verify-session-protocol-emit.mjs",
     "serve:session": "serve -l 3000 dist-session",
     "build:libs": "cross-env LIBS_BUILD_MODE=all node ./scripts/build-assets/cli.mjs",
     "build:libs:clean": "cross-env LIBS_BUILD_MODE=clean node ./scripts/build-assets/cli.mjs",
@@ -59,7 +60,7 @@
     "perf:ci": "npm run perf:capture:series && npm run perf:compare",
     "security:check-install-scripts": "node ./scripts/security/check-install-scripts.mjs",
     "verify:publish-archive": "node ./scripts/verify-publish-archive.mjs",
-    "verify": "npm run format:check && npm run lint && npm run typecheck && npm run test:unit && npm run test:assembly && npm run build && npm run check:budgets && npm run build:publish && npm run verify:publish-archive && npm run build:viewer",
+    "verify": "npm run format:check && npm run lint && npm run typecheck && npm run test:unit && npm run test:assembly && npm run build && npm run check:budgets && npm run build:publish && npm run verify:publish-archive && npm run build:viewer && npm run build:session",
     "verify:full": "npm run verify && npm run test:e2e && npm run test:e2e:publish:skip-build && npm run test:e2e:session",
     "check:budgets": "node ./scripts/check-bundle-budgets.mjs"
   },

--- a/scripts/build-session-manifest.mjs
+++ b/scripts/build-session-manifest.mjs
@@ -1,0 +1,91 @@
+// Emit dist-session/session-manifest.json (#194, part of #179): a versioned, hashed
+// integrity manifest for the compile-capable session artifact, so the consuming VS
+// Code extension can pin and verify exactly what it vendors — including the
+// multi-MB WASM and the library zips. Mirrors build-viewer-manifest.mjs. The
+// extension, on ingest, asserts: protocolVersion matches what it compiled against,
+// every shipped file is on the allowlist, and every sha256 recomputes.
+
+import { createHash } from 'node:crypto';
+import { execSync } from 'node:child_process';
+import { readFileSync, readdirSync, statSync, writeFileSync } from 'node:fs';
+import path from 'node:path';
+
+const DIST = path.resolve('dist-session');
+const MANIFEST_NAME = 'session-manifest.json';
+
+function fail(message) {
+  console.error(`[build-session-manifest] ${message}`);
+  process.exit(1);
+}
+
+// The single source of truth for the session WIRE version — read, never
+// hand-copied, so the manifest and the runtime `validateSessionInbound` guard
+// cannot disagree.
+function protocolVersion() {
+  const src = readFileSync('src/protocol/session-transport.ts', 'utf8');
+  const m = src.match(/SESSION_PROTOCOL_VERSION\s*=\s*(\d+)/);
+  if (!m) fail('could not read SESSION_PROTOCOL_VERSION from src/protocol/session-transport.ts');
+  return Number(m[1]);
+}
+
+function sessionVersion() {
+  return JSON.parse(readFileSync('package.json', 'utf8')).version;
+}
+
+function sourceCommit() {
+  try {
+    const commit = execSync('git rev-parse HEAD', { encoding: 'utf8' }).trim();
+    // A build from a dirty tree doesn't correspond to `commit`; mark it so the
+    // manifest's provenance is honest (CI builds from a clean checkout).
+    const dirty = execSync('git status --porcelain', { encoding: 'utf8' }).trim() !== '';
+    return dirty ? `${commit}-dirty` : commit;
+  } catch {
+    return 'unknown';
+  }
+}
+
+// Every file under dist-session relative to it, excluding the manifest itself.
+function listFiles(dir, rel = '') {
+  const out = [];
+  for (const name of readdirSync(dir)) {
+    const abs = path.join(dir, name);
+    const relPath = rel ? `${rel}/${name}` : name;
+    if (statSync(abs).isDirectory()) out.push(...listFiles(abs, relPath));
+    else if (relPath !== MANIFEST_NAME) out.push(relPath);
+  }
+  return out;
+}
+
+const sha256 = (abs) => createHash('sha256').update(readFileSync(abs)).digest('hex');
+
+const relFiles = listFiles(DIST).sort();
+if (!relFiles.includes('session.html'))
+  fail('dist-session/session.html missing — run the session vite build first');
+
+const files = {};
+for (const rel of relFiles) {
+  const abs = path.join(DIST, rel);
+  files[rel] = { bytes: statSync(abs).size, sha256: sha256(abs) };
+}
+
+// Top-level entries the extension should expect (dirs with a trailing slash).
+const topLevel = [
+  ...new Set(relFiles.map((f) => (f.includes('/') ? `${f.split('/')[0]}/` : f))),
+].sort();
+const allowlist = [...topLevel, MANIFEST_NAME];
+
+const manifest = {
+  schemaVersion: 1,
+  sessionVersion: sessionVersion(),
+  protocolVersion: protocolVersion(),
+  sourceCommit: sourceCommit(),
+  builtAt: new Date().toISOString(),
+  files,
+  allowlist,
+};
+
+writeFileSync(path.join(DIST, MANIFEST_NAME), `${JSON.stringify(manifest, null, 2)}\n`);
+console.log(
+  `[build-session-manifest] wrote dist-session/${MANIFEST_NAME} ` +
+    `(${relFiles.length} files, session v${manifest.sessionVersion}, protocol v${manifest.protocolVersion})`,
+);

--- a/scripts/rewrite-protocol-dts.mjs
+++ b/scripts/rewrite-protocol-dts.mjs
@@ -8,7 +8,14 @@
 import { readdirSync, readFileSync, writeFileSync } from 'node:fs';
 import path from 'node:path';
 
-const DIR = path.resolve('dist-viewer/protocol');
+// Defaults to the Layer-0 viewer emit; `--dir` points it at the session emit
+// (dist-session/protocol) — the rewrite is identical for both.
+const dirArgIndex = process.argv.indexOf('--dir');
+const DIR = path.resolve(
+  dirArgIndex === -1
+    ? 'dist-viewer/protocol'
+    : (process.argv[dirArgIndex + 1] ?? 'dist-viewer/protocol'),
+);
 // A relative module specifier ending in `.ts` in any emitted form: a top-level
 // `from './x.ts'` or an inline `import('./x.ts')` type. Anchored on `from`/
 // `import(` so a `.ts` mention in a comment isn't rewritten.

--- a/scripts/verify-session-bundle.mjs
+++ b/scripts/verify-session-bundle.mjs
@@ -1,0 +1,93 @@
+// Inverse acceptance gate for the compile-capable session bundle (#194, part of
+// #179). The READ-ONLY viewer gate (verify-viewer-bundle.mjs) fails if the bundle
+// reaches BrowserFS / WASM / a service worker — the opposite of what a compiler
+// needs. A session bundle MUST carry the OpenSCAD WASM + worker + BrowserFS, and
+// MUST NOT leak the editor shell (Monaco) or register a service worker. Crawl
+// session.html's transitive chunk graph and assert both directions.
+
+import { readFile, readdir } from 'node:fs/promises';
+import path from 'node:path';
+
+function distRoot() {
+  const i = process.argv.indexOf('--dir');
+  return path.resolve(i === -1 ? 'dist-session' : (process.argv[i + 1] ?? 'dist-session'));
+}
+
+function basename(p) {
+  return p.split('/').pop();
+}
+
+function fail(message) {
+  console.error(`[verify-session-bundle] ${message}`);
+  process.exit(1);
+}
+
+const dist = distRoot();
+const assetsDir = path.join(dist, 'assets');
+
+const sessionHtml = await readFile(path.join(dist, 'session.html'), 'utf8').catch(() => {
+  fail(`session.html not found under ${dist}`);
+});
+const entryMatch = sessionHtml.match(/<script[^>]*\btype="module"[^>]*\bsrc="([^"]+)"/);
+if (!entryMatch) fail('session.html has no module entry script');
+const entryFile = basename(entryMatch[1]);
+
+// BFS the reachable chunk graph (same reference regex as the viewer gate: any
+// quoted `*.js` basename — static/dynamic import + vite preload lists — which
+// over-approximates reachability, safe for both the must-reach and must-not-reach
+// assertions below). Accumulate the concatenated reachable source for marker scans.
+const referenceRe = /["'`](?:[^"'`]*\/)?([\w-]+\.js)["'`]/g;
+const reachable = new Set();
+const queue = [entryFile];
+let reachableSource = '';
+while (queue.length) {
+  const file = queue.shift();
+  if (reachable.has(file)) continue;
+  reachable.add(file);
+  let content;
+  try {
+    content = await readFile(path.join(assetsDir, file), 'utf8');
+  } catch {
+    continue; // not an emitted assets chunk
+  }
+  reachableSource += content;
+  for (const m of content.matchAll(referenceRe)) {
+    if (!reachable.has(m[1])) queue.push(m[1]);
+  }
+}
+
+// --- Must NOT leak the editor shell or a service worker ---
+const monaco = [...reachable].filter((f) => f.startsWith('monaco-'));
+if (monaco.length) fail(`session bundle reaches Monaco chunk(s): ${monaco.join(', ')}`);
+
+const forbidden = [
+  { marker: 'serviceWorker', what: 'a service worker registration' },
+  { marker: 'osc-editor-panel', what: 'the editor panel (app-shell leak)' },
+  { marker: 'osc-app-shell', what: 'the app shell (app-shell leak)' },
+];
+for (const { marker, what } of forbidden) {
+  if (reachableSource.includes(marker)) {
+    fail(`session bundle references ${what} ("${marker}")`);
+  }
+}
+
+// --- Must carry the compiler: WASM + worker + BrowserFS ---
+const assets = await readdir(assetsDir).catch(() => fail(`no assets/ under ${dist}`));
+if (!assets.some((f) => f.endsWith('.wasm'))) fail('no OpenSCAD WASM (*.wasm) in assets/');
+if (!assets.some((f) => /worker.*\.js$/.test(f)))
+  fail('no compile worker (*worker*.js) in assets/');
+if (!reachableSource.includes('BFSRequire'))
+  fail('reachable graph does not wire in BrowserFS ("BFSRequire")');
+if (!reachableSource.includes('.wasm'))
+  fail('reachable graph does not reference the OpenSCAD WASM (".wasm")');
+
+// The runtime library assets the compile path fetches must ship (fonts.zip is
+// always loaded; the rest are mounted on demand).
+const libs = await readdir(path.join(dist, 'libraries')).catch(() => []);
+if (!libs.includes('fonts.zip'))
+  fail('libraries/fonts.zip missing — the curated zips did not ship');
+
+console.log(
+  `[verify-session-bundle] OK — ${reachable.size} reachable chunks; WASM + worker + BrowserFS present, ` +
+    `no Monaco/service-worker/app-shell leak.`,
+);

--- a/scripts/verify-session-protocol-emit.mjs
+++ b/scripts/verify-session-protocol-emit.mjs
@@ -1,0 +1,28 @@
+// Smoke-check the EMITTED distributable session protocol (#194): a broken emit — a
+// bad extension rewrite, a circular import, a runtime error — must fail CI here,
+// rather than only surfacing when a separate extension vendors the artifact. The
+// unit tests import the SOURCE; this imports the BUILT barrel. Mirrors
+// verify-protocol-emit.mjs (the Layer-0 viewer emit).
+
+import path from 'node:path';
+import { pathToFileURL } from 'node:url';
+
+function fail(message) {
+  console.error(`[verify-session-protocol-emit] ${message}`);
+  process.exit(1);
+}
+
+const entry = pathToFileURL(path.resolve('dist-session/protocol/session.js')).href;
+const m = await import(entry).catch((e) => fail(`emitted session protocol failed to import: ${e}`));
+
+const v = m.SESSION_PROTOCOL_VERSION;
+if (typeof v !== 'number') fail(`SESSION_PROTOCOL_VERSION is not a number (${v})`);
+if (typeof m.validateSessionInbound !== 'function') fail('validateSessionInbound is not exported');
+if (!m.validateSessionInbound({ protocolVersion: v, type: 'cancel' }).ok) {
+  fail('validateSessionInbound rejected a well-formed message');
+}
+if (typeof m.sessionReady !== 'function') fail('sessionReady builder is not exported');
+
+console.log(
+  `[verify-session-protocol-emit] OK — emitted session protocol imports and runs (protocol v${v}).`,
+);

--- a/src/protocol/session.ts
+++ b/src/protocol/session.ts
@@ -1,0 +1,11 @@
+// The Layer-1 session protocol — the public, DOM-free wire contract a host (e.g. a
+// VS Code extension) imports to drive a compile session type-safely (ADR 0009 /
+// #194). The session counterpart to the Layer-0 viewer barrel (index.ts): it is
+// compiled (JS + .d.ts) to `dist-session/protocol/` by `build:session` and shipped
+// inside the versioned, hashed session artifact (see build-session-manifest.mjs).
+// Nothing here imports outside src/protocol/ (lint-enforced), so it stays
+// distributable on its own.
+
+export * from './session-transport.ts';
+export * from './session-contract.ts';
+export { isRecord, stampOutbound, type ProtocolErrorCode } from './envelope.ts';

--- a/tsconfig.session-protocol.json
+++ b/tsconfig.session-protocol.json
@@ -1,0 +1,26 @@
+// Emit ONLY the Layer-1 session protocol (src/protocol/session*) as a standalone,
+// distributable module — compiled JS + .d.ts — into the session artifact (#194).
+// Mirrors tsconfig.protocol.json (the Layer-0 viewer emit). The repo authors
+// `.ts`-extension imports for the bundler; `rewriteRelativeImportExtensions`
+// rewrites those to `.js` in the emitted output so the protocol is importable on
+// its own by a separate consumer (a VS Code extension). The session protocol
+// imports nothing outside src/protocol/ (lint-enforced), so the emit is
+// self-contained.
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "noEmit": false,
+    "rewriteRelativeImportExtensions": true,
+    "declaration": true,
+    "emitDeclarationOnly": false,
+    "rootDir": "src/protocol",
+    "outDir": "dist-session/protocol"
+  },
+  "include": [
+    "src/protocol/session.ts",
+    "src/protocol/session-transport.ts",
+    "src/protocol/session-contract.ts",
+    "src/protocol/envelope.ts"
+  ],
+  "exclude": ["src/protocol/__tests__/**"]
+}


### PR DESCRIPTION
Part of epic #179 (live-`.scad` session in VS Code). Closes #194.

Completes the `dist-session` distributable from #193 so the VS Code extension can **vendor, pin, and verify** a compile-capable bundle.

## What

- **Inverse isolation gate** (`scripts/verify-session-bundle.mjs`). The read-only viewer gate fails a bundle that reaches WASM/BrowserFS/SW — the opposite of what a compiler needs. This new gate crawls `session.html`'s chunk graph and asserts **both** directions:
  - **must be present:** the OpenSCAD WASM, the compile worker, BrowserFS (`BFSRequire`), and the curated library zips (`libraries/fonts.zip`).
  - **must be absent:** any `monaco-*` chunk, `serviceWorker` registration, and the editor shell (`osc-editor-panel` / `osc-app-shell`).
  - Proven **load-bearing in both directions** (tamper tests: app-shell-leak injection, missing WASM, and missing `fonts.zip` each exit non-zero; clean bundle passes).
- **Hashed manifest** (`scripts/build-session-manifest.mjs` → `session-manifest.json`). Near-copy of the viewer manifest: `schemaVersion`, `sessionVersion`, `protocolVersion` (read from `SESSION_PROTOCOL_VERSION`), `sourceCommit`, per-file `sha256`, and an `allowlist` — covering the multi-MB WASM and the zips so a corrupt/partial vendor fails before load.
- **L1 protocol emit.** `src/protocol/session.ts` (barrel) + `tsconfig.session-protocol.json` compile the session protocol (`session-transport` + `session-contract` + `envelope`) to `dist-session/protocol/` as JS + `.d.ts`, so the extension gets typed L1 messages. `verify-session-protocol-emit.mjs` smoke-checks the built barrel; `rewrite-protocol-dts.mjs` gained a `--dir` arg (viewer default unchanged). The session protocol is fully self-contained (`session-contract` imports nothing; `session-transport` imports only `envelope` + `session-contract`).
- **Wiring.** `build:session` now chains `vite → protocol emit → inverse gate → manifest` (mirroring `build:viewer`) and joins `verify`. CI covers it through the existing `test:e2e:session` step.
- **CSP doc.** `docs/EMBEDDING-VSCODE.md` gains a session-artifact section: manifest verify, the CSP delta (`'wasm-unsafe-eval'` + `worker-src blob:`, **no** COOP/COEP since the engine is single-threaded), and the L1 handshake.

## Verification

- `npm run build:session` — full chain green: protocol emit (v1), inverse gate (`5 reachable chunks; WASM + worker + BrowserFS present, no Monaco/service-worker/app-shell leak`), manifest (`36 files, session v0.2.0, protocol v1`).
- Gate tamper tests confirm it fails on app-shell leak / missing WASM / missing `fonts.zip` and passes clean.
- `npm run verify` green (now includes `build:session`); `npm run test:e2e:session` green (real WASM still compiles the cube through the gated bundle).

## Out of scope (→ later epic issues)

`#197` (export `getArtifact` bytes over the wire) and `#195` (user libs / `OPENSCADPATH`) remain deferred.