### PR TITLE
fix(session): hand the webview worker blob: URLs for its assets (#203)

### DIFF
--- a/docs/EMBEDDING-VSCODE.md
+++ b/docs/EMBEDDING-VSCODE.md
@@ -281,7 +281,7 @@ script-src ${webview.cspSource} 'nonce-${nonce}' 'wasm-unsafe-eval';
 worker-src blob:;
 style-src ${webview.cspSource} 'unsafe-inline';
 img-src ${webview.cspSource} data: blob:;
-connect-src ${webview.cspSource};
+connect-src ${webview.cspSource} blob:;
 ```
 
 - **`'wasm-unsafe-eval'`** — required to `WebAssembly.instantiate` the OpenSCAD
@@ -290,8 +290,12 @@ connect-src ${webview.cspSource};
   URL. Under a webview the packaged worker/asset URLs are cross-origin to the
   `vscode-webview://` document, so `new Worker(crossOriginUrl)` is SOP-blocked; the
   bundle instead `fetch`es the worker script (allowed) and runs it from a blob.
-- **`connect-src ${webview.cspSource}`** covers the runtime `fetch`es of the worker
-  script, the `.wasm`, and the library zips — all from the session dir.
+- **`connect-src ${webview.cspSource} blob:`** — `cspSource` covers the main
+  thread's `fetch`es of the worker script, the `.wasm`, and the library zips; `blob:`
+  is required because the worker itself fetches those assets from same-origin `blob:`
+  URLs. A `blob:` dedicated worker's `vscode-resource` fetches bypass the webview's
+  resource service worker (they 408), so the session pre-fetches each asset on the
+  main thread and hands the worker blob: URLs it can fetch instead (#203).
 - **No COOP/COEP headers.** The engine is single-threaded WASM (no
   `SharedArrayBuffer`), so cross-origin isolation is **not** required — do not add
   them.

--- a/src/runner/__tests__/worker-bootstrap.test.ts
+++ b/src/runner/__tests__/worker-bootstrap.test.ts
@@ -56,4 +56,15 @@ describe('worker bootstrap (#196)', () => {
 
     expect(workerConfigPayload().assetBase).toBe('https://abc.vscode-cdn.net/mount/');
   });
+
+  it('configure with blob asset URLs → the payload carries them + the blob wasm (#203)', async () => {
+    await configureWorkerBootstrap({
+      assetBase: 'https://abc.vscode-cdn.net/mount/',
+      assetUrls: { 'libraries/fonts.zip': 'blob:fonts' },
+      wasmUrl: 'blob:wasm',
+    });
+    const payload = workerConfigPayload();
+    expect(payload.wasmUrl).toBe('blob:wasm');
+    expect(payload.assetUrls).toEqual({ 'libraries/fonts.zip': 'blob:fonts' });
+  });
 });

--- a/src/runner/openscad-worker.ts
+++ b/src/runner/openscad-worker.ts
@@ -11,7 +11,7 @@ import {
 import { markPerf, measurePerf } from '../perf/runtime-performance.ts';
 import { createSerialQueue } from './serial-queue.ts';
 import { ensureWorkerBrowserFSLoaded } from '../runtime/browserfs-runtime.ts';
-import { setRuntimeAssetBase } from '../runtime/asset-urls.ts';
+import { setRuntimeAssetBase, setRuntimeAssetUrls } from '../runtime/asset-urls.ts';
 import { createRuntime, OpenSCADRuntime } from './openscad-runtime.ts';
 import {
   CompileRequest,
@@ -107,6 +107,9 @@ self.addEventListener('message', (e: MessageEvent<WorkerRequest>) => {
     appBaseUrl = msg.assetBase;
     wasmUrl = msg.wasmUrl;
     setRuntimeAssetBase(msg.assetBase); // libraries/fonts/sources resolve here
+    // In a webview the worker can't fetch vscode-resource URLs; the host hands it
+    // same-origin blob: URLs for each runtime asset (#203). null on a normal page.
+    setRuntimeAssetUrls(msg.assetUrls ?? null);
     return;
   }
   if (msg.type === 'cancel') {

--- a/src/runner/worker-bootstrap.ts
+++ b/src/runner/worker-bootstrap.ts
@@ -20,6 +20,8 @@ import type { ConfigureRequest } from './worker-protocol.ts';
 
 let blobWorkerUrl: string | null = null;
 let assetBaseOverride: string | undefined;
+let assetUrlsOverride: Record<string, string> | undefined;
+let wasmUrlOverride: string | undefined;
 
 /**
  * Configure the bootstrap for a host whose worker/asset URLs are cross-origin to
@@ -28,13 +30,24 @@ let assetBaseOverride: string | undefined;
  * same-origin `blob:` URL to instantiate from, and pin the base the worker resolves
  * assets against. Call once, before constructing the session. Idempotent-ish: the
  * blob URL is created once and reused across worker recycles.
+ *
+ * `assetUrls`/`wasmUrl` (optional): a webview's blob worker can't fetch the
+ * `vscode-resource` asset URLs (its fetches bypass the resource service worker,
+ * #203), so the host pre-fetches each asset on the main thread and passes
+ * same-origin `blob:` URLs the worker can fetch (`wasmUrl` becomes a blob too).
  */
-export async function configureWorkerBootstrap(opts: { assetBase: string }): Promise<void> {
+export async function configureWorkerBootstrap(opts: {
+  assetBase: string;
+  assetUrls?: Record<string, string>;
+  wasmUrl?: string;
+}): Promise<void> {
   if (!blobWorkerUrl) {
     const source = await fetch(openSCADWorkerUrl).then((r) => r.text());
     blobWorkerUrl = URL.createObjectURL(new Blob([source], { type: 'text/javascript' }));
   }
   assetBaseOverride = opts.assetBase;
+  assetUrlsOverride = opts.assetUrls;
+  wasmUrlOverride = opts.wasmUrl;
 }
 
 export function createOpenSCADWorker(): Worker {
@@ -54,7 +67,8 @@ export function workerConfigPayload(): ConfigureRequest {
   return {
     type: 'configure',
     assetBase: assetBaseOverride ?? resolveDefaultRuntimeBaseUrl(import.meta.env.BASE_URL),
-    wasmUrl: openSCADWasmUrl,
+    wasmUrl: wasmUrlOverride ?? openSCADWasmUrl,
+    ...(assetUrlsOverride ? { assetUrls: assetUrlsOverride } : {}),
   };
 }
 

--- a/src/runner/worker-protocol.ts
+++ b/src/runner/worker-protocol.ts
@@ -32,6 +32,14 @@ export type ConfigureRequest = {
   assetBase: string;
   /** Host-resolved URL of the OpenSCAD WASM binary (Emscripten `locateFile`). */
   wasmUrl: string;
+  /**
+   * Optional per-spec asset URL overrides (normalized spec → URL), consulted before
+   * `assetBase`. In a VS Code webview the worker is a `blob:` worker whose
+   * `vscode-resource` fetches bypass the webview's resource service worker (HTTP 408,
+   * #203); the host pre-fetches each runtime asset on the main thread and provides a
+   * same-origin `blob:` URL the worker CAN fetch. `wasmUrl` is likewise a blob then.
+   */
+  assetUrls?: Record<string, string>;
 };
 
 export type WorkerRequest = CompileRequest | CancelRequest | ConfigureRequest;

--- a/src/runtime/__tests__/asset-urls.test.ts
+++ b/src/runtime/__tests__/asset-urls.test.ts
@@ -4,6 +4,7 @@ import {
   resolveDefaultRuntimeBaseUrl,
   resolveRuntimeAssetUrl,
   setRuntimeAssetBase,
+  setRuntimeAssetUrls,
 } from '../asset-urls.ts';
 
 describe('resolveRuntimeAssetUrl', () => {
@@ -71,6 +72,39 @@ describe('setRuntimeAssetBase (#196)', () => {
 
   it('an explicit base argument still overrides the pinned default', () => {
     setRuntimeAssetBase('https://abc.vscode-cdn.net/mount/');
+    expect(resolveRuntimeAssetUrl('x.zip', 'https://other.example/d/')).toBe(
+      'https://other.example/d/x.zip',
+    );
+  });
+});
+
+describe('setRuntimeAssetUrls (#203)', () => {
+  afterEach(() => {
+    setRuntimeAssetUrls(null); // restore default resolution
+    setRuntimeAssetBase(null);
+  });
+
+  it('returns a per-spec blob URL override for default-base lookups (normalized key)', () => {
+    setRuntimeAssetBase('https://abc.vscode-cdn.net/mount/');
+    setRuntimeAssetUrls({
+      'libraries/fonts.zip': 'blob:fonts',
+      'libraries/BOSL2.zip': 'blob:bosl',
+    });
+    // `./`-prefixed and bare specs both normalize to the map key.
+    expect(resolveRuntimeAssetUrl('libraries/fonts.zip')).toBe('blob:fonts');
+    expect(resolveRuntimeAssetUrl('./libraries/BOSL2.zip')).toBe('blob:bosl');
+  });
+
+  it('falls through to the base for specs not in the map', () => {
+    setRuntimeAssetBase('https://abc.vscode-cdn.net/mount/');
+    setRuntimeAssetUrls({ 'libraries/fonts.zip': 'blob:fonts' });
+    expect(resolveRuntimeAssetUrl('libraries/MCAD.zip')).toBe(
+      'https://abc.vscode-cdn.net/mount/libraries/MCAD.zip',
+    );
+  });
+
+  it('is bypassed when an explicit base is given (override is default-base only)', () => {
+    setRuntimeAssetUrls({ 'x.zip': 'blob:should-not-win' });
     expect(resolveRuntimeAssetUrl('x.zip', 'https://other.example/d/')).toBe(
       'https://other.example/d/x.zip',
     );

--- a/src/runtime/asset-urls.ts
+++ b/src/runtime/asset-urls.ts
@@ -1,6 +1,6 @@
 import { normalizeBasePath } from './base-path.ts';
 
-function normalizeAssetSpecifier(assetSpecifier: string): string {
+export function normalizeAssetSpecifier(assetSpecifier: string): string {
   return assetSpecifier.replace(/^\.\//, '');
 }
 
@@ -70,9 +70,26 @@ function getDefaultRuntimeBaseUrl(): string {
   return overrideBase ?? resolveDefaultRuntimeBaseUrl(import.meta.env.BASE_URL);
 }
 
-export function resolveRuntimeAssetUrl(
-  assetSpecifier: string,
-  baseUrl = getDefaultRuntimeBaseUrl(),
-): string {
-  return new URL(normalizeAssetSpecifier(assetSpecifier), baseUrl).toString();
+let assetUrlOverrides: Record<string, string> | null = null;
+
+/**
+ * Pin per-spec asset URL overrides (normalized spec → URL), consulted before the
+ * default base. A `blob:` compile worker in a VS Code webview can't fetch the
+ * `vscode-resource` asset URLs (its fetches bypass the resource service worker,
+ * #203), so the host pre-fetches each asset and hands the worker same-origin
+ * `blob:` URLs via the `configure` handshake. `null` (the default) disables it.
+ * Only consulted for default-base lookups — an explicit `baseUrl` bypasses it.
+ */
+export function setRuntimeAssetUrls(overrides: Record<string, string> | null): void {
+  assetUrlOverrides = overrides;
+}
+
+export function resolveRuntimeAssetUrl(assetSpecifier: string, baseUrl?: string): string {
+  const normalized = normalizeAssetSpecifier(assetSpecifier);
+  if (baseUrl === undefined) {
+    const override = assetUrlOverrides?.[normalized];
+    if (override !== undefined) return override;
+    return new URL(normalized, getDefaultRuntimeBaseUrl()).toString();
+  }
+  return new URL(normalized, baseUrl).toString();
 }

--- a/src/session-entry/index.ts
+++ b/src/session-entry/index.ts
@@ -18,8 +18,47 @@ import { createInitialState } from '../state/initial-state.ts';
 import { createEditorFS } from '../fs/filesystem.ts';
 import { ensureBrowserFSLoaded } from '../runtime/browserfs-runtime.ts';
 import { configureWorkerBootstrap } from '../runner/worker-bootstrap.ts';
+import { openSCADWasmUrl } from '../runner/openscad-asset-urls.ts';
+import {
+  normalizeAssetSpecifier,
+  resolveRuntimeAssetUrl,
+  setRuntimeAssetUrls,
+} from '../runtime/asset-urls.ts';
+import { fetchAssetBytes } from '../runtime/fetch-asset.ts';
+import { zipArchives } from '../fs/zip-archives.generated.ts';
 import { selectViewerTransport } from '../viewer-host/transports/select.ts';
 import type { GeometryViewer } from '../viewer-host/controller.ts';
+
+/**
+ * Pre-fetch every runtime asset the compile worker needs (the WASM binary, fonts,
+ * and all bundled library zips) and wrap each in a same-origin `blob:` URL (#203).
+ *
+ * Why: under a VS Code webview the compile worker is a `blob:` dedicated worker
+ * whose `vscode-resource` fetches bypass the webview's resource service worker
+ * (they 408). The main thread CAN fetch those resources (the SW serves them), so
+ * we fetch here and hand the worker blob: URLs it can fetch instead. The worker
+ * demand-loads libraries asynchronously but can't ask the host mid-compile (the FS
+ * is synchronous), so every candidate asset is pre-fetched up front. Used on a
+ * normal page too (harmless — same-origin), so the served acceptance test exercises
+ * this exact path.
+ */
+async function prefetchAssetBlobs(): Promise<{
+  assetUrls: Record<string, string>;
+  wasmUrl: string;
+}> {
+  const specs = ['libraries/fonts.zip', ...zipArchives.map((a) => a.zipPath)];
+  const toBlobUrl = async (url: string, type: string): Promise<string> =>
+    URL.createObjectURL(new Blob([await fetchAssetBytes(url)], { type }));
+
+  const [wasmUrl, ...zipUrls] = await Promise.all([
+    toBlobUrl(openSCADWasmUrl, 'application/wasm'),
+    ...specs.map((spec) => toBlobUrl(resolveRuntimeAssetUrl(spec), 'application/zip')),
+  ]);
+  const assetUrls = Object.fromEntries(
+    specs.map((spec, i) => [normalizeAssetSpecifier(spec), zipUrls[i]]),
+  );
+  return { assetUrls, wasmUrl };
+}
 
 async function main(): Promise<void> {
   const root = document.getElementById('session-root')!;
@@ -28,14 +67,21 @@ async function main(): Promise<void> {
   viewer.generateThumbnails = false;
   root.appendChild(viewer);
 
-  // Resolve the same-origin blob worker + asset base (#196) BEFORE the first
-  // compile: under a webview the worker/asset URLs are cross-origin, so the worker
-  // must be instantiated from a same-origin blob and told its asset base. The
-  // worker is created lazily on the first compile, so configuring before the
-  // session is constructed is sufficient. Run it alongside FS init.
+  // Pre-fetch the runtime assets into same-origin blob: URLs the worker can fetch
+  // in a webview (#203), in parallel with BrowserFS init.
+  const [{ assetUrls, wasmUrl }] = await Promise.all([
+    prefetchAssetBlobs(),
+    ensureBrowserFSLoaded(),
+  ]);
+  // The main thread's own createEditorFS resolves the same specs — reuse the blobs.
+  setRuntimeAssetUrls(assetUrls);
+
+  // Resolve the same-origin blob worker + asset base (#196) and the blob asset URLs
+  // (#203) BEFORE the first compile: the worker is created lazily on the first
+  // compile, so configuring before the session is constructed is sufficient.
   const [, { fs }] = await Promise.all([
-    configureWorkerBootstrap({ assetBase: document.baseURI }),
-    ensureBrowserFSLoaded().then(() => createEditorFS({ allowPersistence: false })),
+    configureWorkerBootstrap({ assetBase: document.baseURI, assetUrls, wasmUrl }),
+    createEditorFS({ allowPersistence: false }),
   ]);
 
   // No `init()`: the embedded-session lifecycle is host-driven (#179). The viewer


### PR DESCRIPTION
Part of #179. Closes #203. Unblocks openscad-web-vscode #8 P3 (live `.scad` preview).

## The bug
In a VS Code webview, the live-session compile worker **couldn't load its runtime assets**. `setProject` reached the session and `syntaxCheck` ran, but no geometry was ever produced. The worker logged, from `blob:vscode-webview://…`:

```
AssetFetchError: Failed to fetch …/media/session/libraries/fonts.zip: HTTP 408
```

VS Code serves webview resources through a **service worker in the main frame**. The main thread's `vscode-resource` fetches work (so `ready` fires), but the engine runs in a **blob: dedicated worker** (#196), and a blob-worker's fetches **bypass that service worker** → they hit the non-existent real cdn host → HTTP 408. So #196 fixed loading the worker *script*, but **not** the worker's *runtime asset* fetches (wasm, fonts, library zips). The synchronous worker FS means it can't lazily request assets mid-compile.

## The fix (blob-URL asset provision)
The session entry pre-fetches every runtime asset on the **main thread** (where the SW serves them) and hands the worker same-origin **`blob:` URLs** it can fetch (blob: is in-memory, no SW needed), via the existing `configure` handshake:

- `ConfigureRequest` gains optional `assetUrls` (normalized spec → URL); `wasmUrl` becomes a blob too.
- `setRuntimeAssetUrls()` adds a per-spec override consulted before the default base (explicit-base callers bypass it).
- The worker applies the override on `configure`; `worker-bootstrap` accepts + emits it.
- `session-entry.prefetchAssetBlobs()` fetches the wasm + `fonts.zip` + all bundled library zips into blob: URLs (library mounting is async + demand-based, but the sync FS can't ask mid-compile, so every candidate is pre-fetched up front), sets them on the main thread too (so its own `createEditorFS` reuses them), and injects them.
- `EMBEDDING-VSCODE.md` §6: `connect-src` now needs `blob:` (the worker fetches blob asset URLs).

Pure session-bundle change — no L1 protocol change, no host involvement beyond the CSP. The blob path is on for normal pages too (harmless, same-origin), so the acceptance e2e exercises the exact webview mechanism.

## Verification
- `npm run verify` green (incl. the main app / viewer / publish builds — `resolveRuntimeAssetUrl` change is behavior-identical when no override is set).
- **`npm run test:e2e:session` green** — real Chromium compiles a cube to an OFF artifact through the new blob-asset path (the worker fetches blob URLs created on the main thread, cross-thread, and still produces geometry).
- New unit tests: the `assetUrls` payload injection + the per-spec override resolution (normalized key, fall-through, explicit-base bypass).

The webview HTTP 408 itself is confirmed fixed once `dist-session` is re-vendored into the extension and the EDH compile test is un-skipped (openscad-web-vscode #8 P3).