### PR TITLE
fix(deps): bump dompurify override to >=3.4.11

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4762,9 +4762,9 @@
       "license": "BSD-3-Clause"
     },
     "node_modules/dompurify": {
-      "version": "3.4.0",
-      "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-3.4.0.tgz",
-      "integrity": "sha512-nolgK9JcaUXMSmW+j1yaSvaEaoXYHwWyGJlkoCTghc97KgGDDSnpoU/PlEnw63Ah+TGKFOyY+X5LnxaWbCSfXg==",
+      "version": "3.4.11",
+      "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-3.4.11.tgz",
+      "integrity": "sha512-zhlUV12GsaRzMsf9q5M254YhA4+VuF0fG+QFqu6aYpoGlKtz+w8//jBcGVYBgQkR5GHjUomejY84AV+/uPbWdw==",
       "license": "(MPL-2.0 OR Apache-2.0)",
       "optionalDependencies": {
         "@types/trusted-types": "^2.0.7"

--- a/package.json
+++ b/package.json
@@ -78,7 +78,7 @@
   },
   "overrides": {
     "serialize-javascript": ">=7.0.5",
-    "dompurify": ">=3.3.2"
+    "dompurify": ">=3.4.11"
   },
   "devDependencies": {
     "@playwright/test": "^1.61.0",


### PR DESCRIPTION
## Problem

The scheduled **Production Dependency Audit** on `main` is red:

```
dompurify  <=3.4.10  (moderate + low)
  DOMPurify IN_PLACE / hook-pollution / clobbering XSS advisories
fix available via `npm audit fix --force`  (would downgrade monaco — breaking)
```

`dompurify` is pulled transitively via `monaco-editor@0.55.1`. Our existing override floor (`>=3.3.2`) resolved to `3.4.0`, still under the vulnerable ceiling.

## Fix

Raise the override floor to the patched **3.4.11**. This dedupes monaco onto `dompurify@3.4.11`; `npm audit --omit=dev` reports **0 vulnerabilities**.

## Verification

- `npm audit --omit=dev` → `found 0 vulnerabilities`
- `npm run verify` → green (typecheck, unit, assembly, build, viewer + session bundles, budgets)

Closes the audit red on main.