### PR TITLE
ci: install firefox for the node compatibility e2e run

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -31,9 +31,9 @@ jobs:
       - run: npm ci
       - run: npm run security:check-install-scripts
 
-      - name: Install Playwright Chromium
+      - name: Install Playwright browsers
         if: matrix.node.name == 'supported'
-        run: npx playwright install --with-deps chromium
+        run: npx playwright install --with-deps chromium firefox
 
       - name: Cache build libs
         id: cache-libs


### PR DESCRIPTION
## Problem

The scheduled **Node Compatibility Matrix** is red:

```
✘ [firefox] › tests/cross-browser.spec.ts › loads and renders the default model @firefox
  Error: browserType.launch: Executable doesn't exist at .../firefox-1532/firefox/firefox
```

`test.yml` installs only `chromium`, but `npm run test:e2e` runs the full Playwright config — including the `@firefox` cross-browser project. The browser binary is missing, so every `@firefox` spec fails.

## Fix

Install `chromium firefox` in the matrix's Playwright step, matching what the main `ci.yml` workflow already does. One-line, CI-only.

## Verification

Correctness is by parity with `ci.yml` (line 140: `npx playwright install --with-deps chromium firefox`), which runs the same suite green. The scheduled workflow can be confirmed via `workflow_dispatch` after merge.