### PR TITLE
fix(scripts): use named js-yaml import in deploy-configure

### DIFF
--- a/scripts/deploy-configure.mjs
+++ b/scripts/deploy-configure.mjs
@@ -1,7 +1,7 @@
 #!/usr/bin/env node
 
 import AdmZip from 'adm-zip';
-import yaml from 'js-yaml';
+import { load as loadYaml } from 'js-yaml';
 import os from 'node:os';
 import path from 'node:path';
 import { cp, mkdir, mkdtemp, readFile, readdir, rm, stat, writeFile } from 'node:fs/promises';
@@ -184,7 +184,7 @@ function parseCliArgs(argv) {
 function parseYamlConfig(fileContents, configPath) {
   let parsedConfig;
   try {
-    parsedConfig = yaml.load(fileContents);
+    parsedConfig = loadYaml(fileContents);
   } catch (error) {
     throw new Error(
       `Failed to parse publish config ${configPath}: ${error instanceof Error ? error.message : String(error)}`,


### PR DESCRIPTION
## Problem

Dependabot PR #207 bumps `js-yaml` 4.2.0 → 5.1.0 and its CI fails:

```
Error: Failed to parse publish config …/openscad-publish.yml:
  Cannot read properties of undefined (reading 'load')
```

js-yaml v5 [drops the ESM default export by design](https://github.com/nodeca/js-yaml/blob/master/docs/migrate_v4_to_v5.md), so `import yaml from 'js-yaml'; yaml.load(...)` breaks.

## Fix

Use the named export: `import { load as loadYaml } from 'js-yaml'`. This resolves identically under **v4** (currently pinned) and **v5**, so it lands cleanly on `main` now and unblocks #207 on rebase.

## Verification

- `vitest run scripts/__tests__/deploy-configure.test.mjs` → **8 passed** (under installed v4)
- Isolated `js-yaml@5.1.0` install: `import { load }` → `typeof === 'function'`, parses correctly

Once merged, #207 rebases green.