### PR TITLE
ci(dependabot): hold prettier at 3.8.x

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -17,6 +17,13 @@ updates:
       interval: 'weekly'
     commit-message:
       prefix: 'chore(deps): '
+    # prettier 3.9.x is non-idempotent on our lit-html templates: `--write`
+    # then `--check` still disagrees on indentation inside html`` expressions,
+    # so `format:check` can never pass. Hold at 3.8.x until upstream stabilizes;
+    # 3.10+ is allowed through so the fix isn't blocked.
+    ignore:
+      - dependency-name: 'prettier'
+        versions: ['3.9.x']
     groups:
       npm-production:
         dependency-type: 'production'


### PR DESCRIPTION
## Why

The npm-development dependabot group (#211) tried to bump **prettier 3.8.4 → 3.9.4**. Prettier 3.9.x is **non-idempotent** on this codebase's lit-html templates: running `prettier --write` and then `prettier --check` still disagrees on the indentation of multi-line arrow expressions inside `html``` literals, so `format:check` can never go green (verified locally across the flagged files).

This is a prettier regression in embedded-language formatting (3.8.4 is stable — main's CI is green on it).

## Change

Ignore the `prettier` **3.9.x** line in `dependabot.yml`. 3.10+ is intentionally left un-ignored so an upstream fix flows through automatically. Once merged, rebasing #211 drops prettier from the group, and the remaining 9 dev-dep bumps format-check cleanly.

Decision recorded with the maintainer: hold rather than disable `embeddedLanguageFormatting` or reformat around the bug.