### PR TITLE
build(deps-dev): prettier 3.9.4 + reformat to its fixpoint

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -36,7 +36,7 @@
         "eslint": "^10.5.0",
         "js-yaml": "^4.2.0",
         "jsdom": "^29.1.1",
-        "prettier": "^3.8.4",
+        "prettier": "^3.9.4",
         "puppeteer": "^25.1.0",
         "serve": "^14.2.4",
         "tslib": "^2.8.1",
@@ -7654,9 +7654,9 @@
       }
     },
     "node_modules/prettier": {
-      "version": "3.8.4",
-      "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.8.4.tgz",
-      "integrity": "sha512-N2MylSdi48+5N/6S5j+maeHbUSIzzZ5uOcX5Hm4QpV8Dkb1HFjfAKTKX6yNPJQD9AhcT3ifHNB66tWTTJDi11Q==",
+      "version": "3.9.4",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.9.4.tgz",
+      "integrity": "sha512-yWG/o/4oJfo036EKAfK6ACAoDOfHeRHx4tuxkfBZiauURiaSmYwlpOr5LQqKtIkRD2z1PLteme2WoxEnj4tHTg==",
       "dev": true,
       "license": "MIT",
       "bin": {

--- a/package.json
+++ b/package.json
@@ -95,7 +95,7 @@
     "eslint": "^10.5.0",
     "js-yaml": "^4.2.0",
     "jsdom": "^29.1.1",
-    "prettier": "^3.8.4",
+    "prettier": "^3.9.4",
     "puppeteer": "^25.1.0",
     "serve": "^14.2.4",
     "tslib": "^2.8.1",

--- a/src/components/elements/osc-app-shell.ts
+++ b/src/components/elements/osc-app-shell.ts
@@ -134,31 +134,37 @@ export class OscAppShell extends LitElement {
         ${shellStyles}
         <osc-panel-switcher></osc-panel-switcher>
         <div class="panels-multi">
-          ${layout.editor
-            ? html`
-                <osc-editor-panel
-                  id="panel-editor"
-                  style="flex:1 1 ${pct};max-width:${pct};min-width:0;overflow:hidden;"
-                ></osc-editor-panel>
-              `
-            : ''}
-          ${layout.viewer
-            ? html`
-                <osc-viewer-panel
-                  id="panel-viewer"
-                  ?active=${true}
-                  style="flex:1 1 ${pct};max-width:${pct};min-width:0;overflow:hidden;"
-                ></osc-viewer-panel>
-              `
-            : ''}
-          ${layout.customizer
-            ? html`
-                <osc-customizer-panel
-                  id="panel-customizer"
-                  style="flex:1 1 ${pct};max-width:${pct};min-width:0;overflow-y:auto;"
-                ></osc-customizer-panel>
-              `
-            : ''}
+          ${
+            layout.editor
+              ? html`
+                  <osc-editor-panel
+                    id="panel-editor"
+                    style="flex:1 1 ${pct};max-width:${pct};min-width:0;overflow:hidden;"
+                  ></osc-editor-panel>
+                `
+              : ''
+          }
+          ${
+            layout.viewer
+              ? html`
+                  <osc-viewer-panel
+                    id="panel-viewer"
+                    ?active=${true}
+                    style="flex:1 1 ${pct};max-width:${pct};min-width:0;overflow:hidden;"
+                  ></osc-viewer-panel>
+                `
+              : ''
+          }
+          ${
+            layout.customizer
+              ? html`
+                  <osc-customizer-panel
+                    id="panel-customizer"
+                    style="flex:1 1 ${pct};max-width:${pct};min-width:0;overflow-y:auto;"
+                  ></osc-customizer-panel>
+                `
+              : ''
+          }
         </div>
         <osc-footer></osc-footer>
         <osc-update-banner></osc-update-banner>

--- a/src/components/elements/osc-editor-panel.ts
+++ b/src/components/elements/osc-editor-panel.ts
@@ -519,62 +519,64 @@ export class OscEditorPanel extends LitElement {
           >
             ⋯
           </button>
-          ${this._menuOpen
-            ? html`
-                <div class="osc-editor-menu" role="menu" aria-label="Editor menu">
-                  <a
-                    href="#new-project"
-                    role="menuitem"
-                    @click=${async (e: Event) => {
-                      e.preventDefault();
-                      window.open(
-                        await buildUrlForStateParams(getBlankProjectState()),
-                        '_blank',
-                        'noopener,noreferrer',
-                      );
-                      this._menuOpen = false;
-                    }}
-                    >New project</a
-                  >
-                  <hr />
-                  <button disabled role="menuitem">Share project</button>
-                  <hr />
-                  <button disabled role="menuitem">New file</button>
-                  <button disabled role="menuitem">Copy to new file</button>
-                  <button disabled role="menuitem">Upload file(s)</button>
-                  <button disabled role="menuitem">Download sources</button>
-                  <hr />
-                  <button
-                    role="menuitem"
-                    @click=${async () => {
-                      this._menuOpen = false;
-                      await this._pasteFromClipboard();
-                    }}
-                  >
-                    Paste
-                  </button>
-                  <button
-                    role="menuitem"
-                    @click=${() => {
-                      this._editor?.trigger(activePath, 'editor.action.selectAll', null);
-                      this._menuOpen = false;
-                    }}
-                  >
-                    Select All
-                  </button>
-                  <hr />
-                  <button
-                    role="menuitem"
-                    @click=${() => {
-                      this._editor?.trigger(activePath, 'actions.find', null);
-                      this._menuOpen = false;
-                    }}
-                  >
-                    Find
-                  </button>
-                </div>
-              `
-            : ''}
+          ${
+            this._menuOpen
+              ? html`
+                  <div class="osc-editor-menu" role="menu" aria-label="Editor menu">
+                    <a
+                      href="#new-project"
+                      role="menuitem"
+                      @click=${async (e: Event) => {
+                        e.preventDefault();
+                        window.open(
+                          await buildUrlForStateParams(getBlankProjectState()),
+                          '_blank',
+                          'noopener,noreferrer',
+                        );
+                        this._menuOpen = false;
+                      }}
+                      >New project</a
+                    >
+                    <hr />
+                    <button disabled role="menuitem">Share project</button>
+                    <hr />
+                    <button disabled role="menuitem">New file</button>
+                    <button disabled role="menuitem">Copy to new file</button>
+                    <button disabled role="menuitem">Upload file(s)</button>
+                    <button disabled role="menuitem">Download sources</button>
+                    <hr />
+                    <button
+                      role="menuitem"
+                      @click=${async () => {
+                        this._menuOpen = false;
+                        await this._pasteFromClipboard();
+                      }}
+                    >
+                      Paste
+                    </button>
+                    <button
+                      role="menuitem"
+                      @click=${() => {
+                        this._editor?.trigger(activePath, 'editor.action.selectAll', null);
+                        this._menuOpen = false;
+                      }}
+                    >
+                      Select All
+                    </button>
+                    <hr />
+                    <button
+                      role="menuitem"
+                      @click=${() => {
+                        this._editor?.trigger(activePath, 'actions.find', null);
+                        this._menuOpen = false;
+                      }}
+                    >
+                      Find
+                    </button>
+                  </div>
+                `
+              : ''
+          }
         </div>
 
         <select
@@ -604,42 +606,48 @@ export class OscEditorPanel extends LitElement {
           )}
         </select>
 
-        ${st.params.autoCompile === false
-          ? html`
-              <button
-                class="toolbar-btn"
-                @click=${() => this._model.render({ isPreview: false, now: true })}
-                title="Build (F6)"
-              >
-                ▶ Build
-              </button>
-            `
-          : ''}
-        ${activePath !== defaultSourcePath
-          ? html`
-              <button
-                class="toolbar-btn"
-                @click=${() => this._model.openFile(defaultSourcePath)}
-                title="Go back to ${defaultSourcePath}"
-              >
-                ← Back
-              </button>
-            `
-          : ''}
+        ${
+          st.params.autoCompile === false
+            ? html`
+                <button
+                  class="toolbar-btn"
+                  @click=${() => this._model.render({ isPreview: false, now: true })}
+                  title="Build (F6)"
+                >
+                  ▶ Build
+                </button>
+              `
+            : ''
+        }
+        ${
+          activePath !== defaultSourcePath
+            ? html`
+                <button
+                  class="toolbar-btn"
+                  @click=${() => this._model.openFile(defaultSourcePath)}
+                  title="Go back to ${defaultSourcePath}"
+                >
+                  ← Back
+                </button>
+              `
+            : ''
+        }
       </div>
 
       <div class="osc-editor-body">
-        ${isMonacoSupported
-          ? html`<div class="osc-editor-monaco"></div>`
-          : html`<textarea
-              class="osc-editor-textarea"
-              aria-label="OpenSCAD source editor"
-              ?readonly=${this._isActiveBinary(st)}
-              .value=${this._model?.source ?? ''}
-              @input=${(e: Event) => {
-                this._model.source = (e.target as HTMLTextAreaElement).value;
-              }}
-            ></textarea>`}
+        ${
+          isMonacoSupported
+            ? html`<div class="osc-editor-monaco"></div>`
+            : html`<textarea
+                class="osc-editor-textarea"
+                aria-label="OpenSCAD source editor"
+                ?readonly=${this._isActiveBinary(st)}
+                .value=${this._model?.source ?? ''}
+                @input=${(e: Event) => {
+                  this._model.source = (e.target as HTMLTextAreaElement).value;
+                }}
+              ></textarea>`
+        }
       </div>
 
       <div

--- a/src/components/elements/osc-embed-shell.ts
+++ b/src/components/elements/osc-embed-shell.ts
@@ -280,16 +280,20 @@ export class OscEmbedShell extends LitElement {
       <div class="viewer-wrap">
         <osc-viewer-panel></osc-viewer-panel>
       </div>
-      ${params?.embedControls
-        ? html`<osc-customizer-panel style="max-height:40vh;"></osc-customizer-panel>`
-        : ''}
-      ${params?.embedDownload
-        ? html`
-            <div class="download-bar">
-              <button @click=${() => this._model.export()}>Download STL</button>
-            </div>
-          `
-        : ''}
+      ${
+        params?.embedControls
+          ? html`<osc-customizer-panel style="max-height:40vh;"></osc-customizer-panel>`
+          : ''
+      }
+      ${
+        params?.embedDownload
+          ? html`
+              <div class="download-bar">
+                <button @click=${() => this._model.export()}>Download STL</button>
+              </div>
+            `
+          : ''
+      }
     `;
   }
 }

--- a/src/components/elements/osc-export-button.ts
+++ b/src/components/elements/osc-export-button.ts
@@ -158,49 +158,55 @@ export class OscExportButton extends LitElement {
           ▾
         </button>
       </div>
-      ${this._open
-        ? html`
-            <div
-              class="menu"
-              role="menu"
-              aria-label="Export format options"
-              style="position:absolute; z-index:1000; margin-top:30px;"
-            >
-              ${options.map(
-                (f) => html`
-                  <button
-                    class="menu-item"
-                    role="menuitemradio"
-                    aria-checked=${currentKey === f.key ? 'true' : 'false'}
-                    @click=${() => this._selectFormat(f.key, is2D)}
-                  >
-                    ${f.label}
-                  </button>
-                `,
-              )}
-              ${!is2D
-                ? html`
-                    <hr />
+      ${
+        this._open
+          ? html`
+              <div
+                class="menu"
+                role="menu"
+                aria-label="Export format options"
+                style="position:absolute; z-index:1000; margin-top:30px;"
+              >
+                ${options.map(
+                  (f) => html`
                     <button
                       class="menu-item"
-                      role="menuitem"
-                      @click=${() => {
-                        this._open = false;
-                        this._model.mutate((s) => {
-                          s.view.extruderPickerVisibility = 'editing';
-                        });
-                      }}
+                      role="menuitemradio"
+                      aria-checked=${currentKey === f.key ? 'true' : 'false'}
+                      @click=${() => this._selectFormat(f.key, is2D)}
                     >
-                      Edit
-                      materials${(st.params.extruderColors ?? []).length > 0
-                        ? ` (${(st.params.extruderColors ?? []).length})`
-                        : ''}
+                      ${f.label}
                     </button>
-                  `
-                : ''}
-            </div>
-          `
-        : ''}
+                  `,
+                )}
+                ${
+                  !is2D
+                    ? html`
+                        <hr />
+                        <button
+                          class="menu-item"
+                          role="menuitem"
+                          @click=${() => {
+                            this._open = false;
+                            this._model.mutate((s) => {
+                              s.view.extruderPickerVisibility = 'editing';
+                            });
+                          }}
+                        >
+                          Edit
+                          materials${
+                            (st.params.extruderColors ?? []).length > 0
+                              ? ` (${(st.params.extruderColors ?? []).length})`
+                              : ''
+                          }
+                        </button>
+                      `
+                    : ''
+                }
+              </div>
+            `
+          : ''
+      }
     `;
   }
 

--- a/src/components/elements/osc-footer.ts
+++ b/src/components/elements/osc-footer.ts
@@ -172,40 +172,46 @@ export class OscFooter extends LitElement {
     );
 
     return html`
-      ${st.error
-        ? html`
-            <div class="error-banner" data-testid="error-banner" role="alert">
-              <div class="error-banner-header">
-                <div class="error-banner-message">${st.error}</div>
-                <button class="foot-btn danger" @click=${() => this._model.clearError()}>
-                  Dismiss
-                </button>
+      ${
+        st.error
+          ? html`
+              <div class="error-banner" data-testid="error-banner" role="alert">
+                <div class="error-banner-header">
+                  <div class="error-banner-message">${st.error}</div>
+                  <button class="foot-btn danger" @click=${() => this._model.clearError()}>
+                    Dismiss
+                  </button>
+                </div>
+                <div class="error-banner-actions">
+                  ${
+                    st.currentRunLogs?.length
+                      ? html`
+                          <button
+                            class="foot-btn"
+                            @click=${() => {
+                              this._model.logsVisible = true;
+                            }}
+                          >
+                            Show Logs
+                          </button>
+                        `
+                      : ''
+                  }
+                </div>
+                ${
+                  st.errorDetails
+                    ? html`
+                        <details class="error-details">
+                          <summary>Technical details</summary>
+                          <pre>${st.errorDetails}</pre>
+                        </details>
+                      `
+                    : ''
+                }
               </div>
-              <div class="error-banner-actions">
-                ${st.currentRunLogs?.length
-                  ? html`
-                      <button
-                        class="foot-btn"
-                        @click=${() => {
-                          this._model.logsVisible = true;
-                        }}
-                      >
-                        Show Logs
-                      </button>
-                    `
-                  : ''}
-              </div>
-              ${st.errorDetails
-                ? html`
-                    <details class="error-details">
-                      <summary>Technical details</summary>
-                      <pre>${st.errorDetails}</pre>
-                    </details>
-                  `
-                : ''}
-            </div>
-          `
-        : ''}
+            `
+          : ''
+      }
       <div
         class="progress-bar-track"
         style="visibility:${busy ? 'visible' : 'hidden'};"
@@ -216,43 +222,45 @@ export class OscFooter extends LitElement {
         <div class="progress-bar-indeterminate"></div>
       </div>
       <div class="footer-row">
-        ${st.output && !st.output.isPreview
-          ? html`<osc-export-button></osc-export-button>`
-          : st.previewing
-            ? html`<button class="foot-btn" disabled>⚡ Previewing…</button>`
-            : st.output?.isPreview
-              ? html`<button
-                  class="foot-btn"
-                  @click=${() => this._model.render({ isPreview: false, now: true })}
-                  ?disabled=${st.rendering}
-                >
-                  ⚡ ${st.rendering ? 'Rendering…' : 'Render'}
-                </button>`
-              : ''}
+        ${
+          st.output && !st.output.isPreview
+            ? html`<osc-export-button></osc-export-button>`
+            : st.previewing
+              ? html`<button class="foot-btn" disabled>⚡ Previewing…</button>`
+              : st.output?.isPreview
+                ? html`<button
+                    class="foot-btn"
+                    @click=${() => this._model.render({ isPreview: false, now: true })}
+                    ?disabled=${st.rendering}
+                  >
+                    ⚡ ${st.rendering ? 'Rendering…' : 'Render'}
+                  </button>`
+                : ''
+        }
 
         <osc-multimaterial-dialog></osc-multimaterial-dialog>
 
-        ${hasDiagnostics
-          ? html`
-              <button
-                class="foot-btn ${maxSev === 'error'
-                  ? 'danger'
-                  : maxSev === 'warning'
-                    ? 'warning'
-                    : ''}"
-                title="Toggle log output"
-                aria-label="Toggle log output"
-                aria-pressed=${st.view.logs ? 'true' : 'false'}
-                @click=${() => {
-                  this._model.logsVisible = !st.view.logs;
-                }}
-              >
-                ≡ ${errCount > 0 ? html`<span class="badge badge-danger">${errCount}</span>` : ''}
-                ${warnCount > 0 ? html`<span class="badge badge-warning">${warnCount}</span>` : ''}
-                ${infoCount > 0 ? html`<span class="badge badge-info">${infoCount}</span>` : ''}
-              </button>
-            `
-          : ''}
+        ${
+          hasDiagnostics
+            ? html`
+                <button
+                  class="foot-btn ${
+                    maxSev === 'error' ? 'danger' : maxSev === 'warning' ? 'warning' : ''
+                  }"
+                  title="Toggle log output"
+                  aria-label="Toggle log output"
+                  aria-pressed=${st.view.logs ? 'true' : 'false'}
+                  @click=${() => {
+                    this._model.logsVisible = !st.view.logs;
+                  }}
+                >
+                  ≡ ${errCount > 0 ? html`<span class="badge badge-danger">${errCount}</span>` : ''}
+                  ${warnCount > 0 ? html`<span class="badge badge-warning">${warnCount}</span>` : ''}
+                  ${infoCount > 0 ? html`<span class="badge badge-info">${infoCount}</span>` : ''}
+                </button>
+              `
+            : ''
+        }
 
         <div class="spacer"></div>
 

--- a/src/components/elements/osc-geometry-viewer.ts
+++ b/src/components/elements/osc-geometry-viewer.ts
@@ -202,30 +202,32 @@ export class OscGeometryViewer extends LitElement {
         style="flex:1;position:relative;width:100%;height:100%;"
       ></div>
       ${this._toastMessage ? html`<div class="osc-toast">${this._toastMessage}</div>` : ''}
-      ${this.showControls
-        ? html`
-            <div
-              aria-label="Viewer camera presets"
-              style="position:absolute;bottom:8px;right:8px;display:flex;flex-direction:column;gap:2px;z-index:2;"
-            >
-              ${NAMED_POSITIONS.map(
-                ({ name }) => html`
-                  <button
-                    title="${name} view"
-                    aria-label=${`Set ${name} view`}
-                    @click=${() => {
-                      this._scene?.setCameraPosition(name);
-                      this._showToast(`${name} view`);
-                    }}
-                    style="font-size:0.65rem;padding:2px 6px;cursor:pointer;opacity:0.75;background:var(--osc-viewer-control-background, var(--osc-overlay, rgba(0, 0, 0, 0.6)));color:var(--osc-viewer-control-foreground, var(--osc-on-accent, #fff));border:none;border-radius:3px;"
-                  >
-                    ${name}
-                  </button>
-                `,
-              )}
-            </div>
-          `
-        : ''}
+      ${
+        this.showControls
+          ? html`
+              <div
+                aria-label="Viewer camera presets"
+                style="position:absolute;bottom:8px;right:8px;display:flex;flex-direction:column;gap:2px;z-index:2;"
+              >
+                ${NAMED_POSITIONS.map(
+                  ({ name }) => html`
+                    <button
+                      title="${name} view"
+                      aria-label=${`Set ${name} view`}
+                      @click=${() => {
+                        this._scene?.setCameraPosition(name);
+                        this._showToast(`${name} view`);
+                      }}
+                      style="font-size:0.65rem;padding:2px 6px;cursor:pointer;opacity:0.75;background:var(--osc-viewer-control-background, var(--osc-overlay, rgba(0, 0, 0, 0.6)));color:var(--osc-viewer-control-foreground, var(--osc-on-accent, #fff));border:none;border-radius:3px;"
+                    >
+                      ${name}
+                    </button>
+                  `,
+                )}
+              </div>
+            `
+          : ''
+      }
     `;
   }
 }

--- a/src/components/elements/osc-panel-switcher.ts
+++ b/src/components/elements/osc-panel-switcher.ts
@@ -98,37 +98,39 @@ export class OscPanelSwitcher extends LitElement {
           role=${layout.mode === 'single' ? 'tablist' : 'group'}
           aria-label=${layout.mode === 'single' ? 'Visible panel' : 'Visible panels'}
         >
-          ${layout.mode === 'multi'
-            ? targets.map(({ id, label, title }) => {
-                const on = !!(layout as unknown as Record<string, boolean>)[id];
-                return html`
-                  <button
-                    class="tab ${on ? 'toggled' : 'untoggled'}"
-                    title="${title}"
-                    aria-label=${`${title} panel`}
-                    aria-pressed=${on ? 'true' : 'false'}
-                    aria-controls=${`panel-${id}`}
-                    @click=${() => this._model.changeMultiVisibility(id, !on)}
-                  >
-                    ${label}
-                  </button>
-                `;
-              })
-            : targets.map(
-                ({ id, label, title }) => html`
-                  <button
-                    class="tab ${layout.focus === id ? 'active' : ''}"
-                    title="${title}"
-                    role="tab"
-                    aria-label=${`${title} panel`}
-                    aria-selected=${layout.focus === id ? 'true' : 'false'}
-                    aria-controls=${`panel-${id}`}
-                    @click=${() => this._model.changeSingleVisibility(id)}
-                  >
-                    ${label}
-                  </button>
-                `,
-              )}
+          ${
+            layout.mode === 'multi'
+              ? targets.map(({ id, label, title }) => {
+                  const on = !!(layout as unknown as Record<string, boolean>)[id];
+                  return html`
+                    <button
+                      class="tab ${on ? 'toggled' : 'untoggled'}"
+                      title="${title}"
+                      aria-label=${`${title} panel`}
+                      aria-pressed=${on ? 'true' : 'false'}
+                      aria-controls=${`panel-${id}`}
+                      @click=${() => this._model.changeMultiVisibility(id, !on)}
+                    >
+                      ${label}
+                    </button>
+                  `;
+                })
+              : targets.map(
+                  ({ id, label, title }) => html`
+                    <button
+                      class="tab ${layout.focus === id ? 'active' : ''}"
+                      title="${title}"
+                      role="tab"
+                      aria-label=${`${title} panel`}
+                      aria-selected=${layout.focus === id ? 'true' : 'false'}
+                      aria-controls=${`panel-${id}`}
+                      @click=${() => this._model.changeSingleVisibility(id)}
+                    >
+                      ${label}
+                    </button>
+                  `,
+                )
+          }
         </div>
       </div>
     `;

--- a/src/components/elements/osc-settings-menu.ts
+++ b/src/components/elements/osc-settings-menu.ts
@@ -113,9 +113,11 @@ export class OscSettingsMenu extends LitElement {
             @click=${() =>
               this._model.changeLayout(st.view.layout.mode === 'multi' ? 'single' : 'multi')}
           >
-            ${st.view.layout.mode === 'multi'
-              ? 'Switch to single panel mode'
-              : 'Switch to side-by-side mode'}
+            ${
+              st.view.layout.mode === 'multi'
+                ? 'Switch to single panel mode'
+                : 'Switch to side-by-side mode'
+            }
           </button>
           <hr />
           <button
@@ -149,9 +151,11 @@ export class OscSettingsMenu extends LitElement {
                 s.params.autoCompile = !(s.params.autoCompile ?? true);
               })}
           >
-            ${(st.params.autoCompile ?? true)
-              ? 'Disable auto-compile on edit'
-              : 'Enable auto-compile on edit'}
+            ${
+              (st.params.autoCompile ?? true)
+                ? 'Disable auto-compile on edit'
+                : 'Enable auto-compile on edit'
+            }
           </button>
           <button
             class="item"
@@ -162,9 +166,11 @@ export class OscSettingsMenu extends LitElement {
                 s.view.customizerGroupsCollapsed = !(s.view.customizerGroupsCollapsed ?? false);
               })}
           >
-            ${(st.view.customizerGroupsCollapsed ?? false)
-              ? 'Expand customizer groups by default'
-              : 'Collapse customizer groups by default'}
+            ${
+              (st.view.customizerGroupsCollapsed ?? false)
+                ? 'Expand customizer groups by default'
+                : 'Collapse customizer groups by default'
+            }
           </button>
           <hr />
           <button
@@ -177,14 +183,16 @@ export class OscSettingsMenu extends LitElement {
           >
             ${backend === 'manifold' ? 'Switch to CGAL backend' : 'Switch to Manifold backend'}
           </button>
-          ${isInStandaloneMode()
-            ? html`
-                <hr />
-                <button class="item danger" role="menuitem" @click=${this._clearLocalData}>
-                  Clear local data
-                </button>
-              `
-            : ''}
+          ${
+            isInStandaloneMode()
+              ? html`
+                  <hr />
+                  <button class="item danger" role="menuitem" @click=${this._clearLocalData}>
+                    Clear local data
+                  </button>
+                `
+              : ''
+          }
         </div>
       </details>
     `;

--- a/src/components/elements/osc-viewer-panel.ts
+++ b/src/components/elements/osc-viewer-panel.ts
@@ -143,47 +143,51 @@ export class OscViewerPanel extends LitElement {
           line-height: 1.5;
         }
       </style>
-      ${isCompiling && placeholderUri
-        ? html`
-            <img
-              src=${placeholderUri}
-              alt=""
-              style="animation:osc-pulse 1.5s ease-in-out infinite;position:absolute;pointer-events:none;width:100%;height:100%;z-index:1;"
-            />
-          `
-        : ''}
-      ${shows3DViewer
-        ? html`
-            <osc-geometry-viewer
-              .offText=${this._offText}
-              color=${st?.view.color ?? DEFAULT_COLOR}
-              ?showAxes=${!!st?.view.showAxes}
-              ?active=${this.active}
-              .camera=${(st?.view.camera ?? null) as CameraState | null}
-              @camera-change=${(e: CustomEvent<CameraState>) =>
-                this._model.mutate((s) => {
-                  s.view.camera = e.detail;
-                })}
-              @geometry-loaded=${(e: CustomEvent<{ thumbhash: string }>) =>
-                this._model.mutate((s) => {
-                  s.preview = { thumbhash: e.detail.thumbhash };
-                })}
-            ></osc-geometry-viewer>
-          `
-        : outputMode === 'svg'
+      ${
+        isCompiling && placeholderUri
           ? html`
               <img
-                class="svg-preview"
-                data-testid="viewer-svg"
-                src=${st?.output?.outFileURL ?? ''}
-                alt="Rendered SVG preview"
+                src=${placeholderUri}
+                alt=""
+                style="animation:osc-pulse 1.5s ease-in-out infinite;position:absolute;pointer-events:none;width:100%;height:100%;z-index:1;"
               />
             `
-          : html`
-              <div class="dxf-placeholder" data-testid="viewer-dxf-placeholder">
-                DXF exported. Click Download to open it in your CAD tool.
-              </div>
-            `}
+          : ''
+      }
+      ${
+        shows3DViewer
+          ? html`
+              <osc-geometry-viewer
+                .offText=${this._offText}
+                color=${st?.view.color ?? DEFAULT_COLOR}
+                ?showAxes=${!!st?.view.showAxes}
+                ?active=${this.active}
+                .camera=${(st?.view.camera ?? null) as CameraState | null}
+                @camera-change=${(e: CustomEvent<CameraState>) =>
+                  this._model.mutate((s) => {
+                    s.view.camera = e.detail;
+                  })}
+                @geometry-loaded=${(e: CustomEvent<{ thumbhash: string }>) =>
+                  this._model.mutate((s) => {
+                    s.preview = { thumbhash: e.detail.thumbhash };
+                  })}
+              ></osc-geometry-viewer>
+            `
+          : outputMode === 'svg'
+            ? html`
+                <img
+                  class="svg-preview"
+                  data-testid="viewer-svg"
+                  src=${st?.output?.outFileURL ?? ''}
+                  alt="Rendered SVG preview"
+                />
+              `
+            : html`
+                <div class="dxf-placeholder" data-testid="viewer-dxf-placeholder">
+                  DXF exported. Click Download to open it in your CAD tool.
+                </div>
+              `
+      }
     `;
   }
 }

--- a/src/protocol/session-transport.ts
+++ b/src/protocol/session-transport.ts
@@ -51,8 +51,7 @@ export type SessionInbound =
   | { type: 'dispose' };
 
 export type SessionValidation =
-  | { ok: true; message: SessionInbound }
-  | { ok: false; code: ProtocolErrorCode; reason: string };
+  { ok: true; message: SessionInbound } | { ok: false; code: ProtocolErrorCode; reason: string };
 
 function readString(v: unknown): string | undefined {
   return typeof v === 'string' ? v : undefined;

--- a/src/runner/worker-protocol.ts
+++ b/src/runner/worker-protocol.ts
@@ -79,8 +79,4 @@ export type CompileError = {
 export type MergedOutput = { stdout?: string; stderr?: string; error?: string };
 
 export type WorkerResponse =
-  | CompileStarted
-  | CompileStdout
-  | CompileStderr
-  | CompileResult
-  | CompileError;
+  CompileStarted | CompileStdout | CompileStderr | CompileResult | CompileError;

--- a/src/state/__tests__/model.test.ts
+++ b/src/state/__tests__/model.test.ts
@@ -119,8 +119,7 @@ describe('Model — render triggering', () => {
 
     expect(mockRender).toHaveBeenCalledTimes(1);
     const scheduledRender = mockRender.mock.results[0]?.value as
-      | ReturnType<typeof vi.fn>
-      | undefined;
+      ReturnType<typeof vi.fn> | undefined;
     expect(scheduledRender).toBeDefined();
     expect(scheduledRender).toHaveBeenCalledWith({ now: true });
   });
@@ -166,8 +165,7 @@ describe('Model — render triggering', () => {
     await nextTicks();
     expect(mockRender).toHaveBeenCalled();
     const scheduledRender = mockRender.mock.results[0]?.value as
-      | ReturnType<typeof vi.fn>
-      | undefined;
+      ReturnType<typeof vi.fn> | undefined;
     expect(scheduledRender).toBeDefined();
     expect(scheduledRender).toHaveBeenCalledWith({ now: false });
   });
@@ -323,8 +321,7 @@ describe('Model — format changes', () => {
     const renderCall = mockRender.mock.calls[0]?.[0];
     expect(renderCall.renderFormat).toBe('dxf');
     const scheduledRender = mockRender.mock.results[0]?.value as
-      | ReturnType<typeof vi.fn>
-      | undefined;
+      ReturnType<typeof vi.fn> | undefined;
     expect(scheduledRender).toHaveBeenCalledWith({ now: true });
   });
 });

--- a/tests/cross-browser.spec.ts
+++ b/tests/cross-browser.spec.ts
@@ -179,8 +179,7 @@ test('imports a nested-dir ZIP project, lists the nested file, and compiles @fir
   // compile path in the browser.
   await page.evaluate(async (data) => {
     const shell = document.querySelector('osc-app-shell') as
-      | (Element & { _model?: { importProjectZip(buf: ArrayBuffer): Promise<void> } })
-      | null;
+      (Element & { _model?: { importProjectZip(buf: ArrayBuffer): Promise<void> } }) | null;
     const buf = new Uint8Array(data).buffer;
     await shell?._model?.importProjectZip(buf);
   }, Array.from(bytes));
@@ -197,8 +196,7 @@ test('imports a nested-dir ZIP project, lists the nested file, and compiles @fir
   // Navigating to the nested file makes it the active source.
   await page.evaluate(() => {
     const shell = document.querySelector('osc-app-shell') as
-      | (Element & { _model?: { openFile(path: string): void } })
-      | null;
+      (Element & { _model?: { openFile(path: string): void } }) | null;
     shell?._model?.openFile('/home/lib/part.scad');
   });
   await page.waitForFunction(
@@ -234,8 +232,7 @@ test('imports a binary STL asset and compiles a model that import()s it @firefox
 
   await page.evaluate(async (data) => {
     const shell = document.querySelector('osc-app-shell') as
-      | (Element & { _model?: { importProjectZip(buf: ArrayBuffer): Promise<void> } })
-      | null;
+      (Element & { _model?: { importProjectZip(buf: ArrayBuffer): Promise<void> } }) | null;
     await shell?._model?.importProjectZip(new Uint8Array(data).buffer);
   }, Array.from(bytes));
 

--- a/tests/e2e.spec.ts
+++ b/tests/e2e.spec.ts
@@ -302,8 +302,7 @@ async function waitForCustomizerShell(page: Page): Promise<void> {
   await page.waitForFunction(
     () => {
       const shell = document.querySelector('osc-customizer-shell') as
-        | (Element & { _st?: unknown })
-        | null;
+        (Element & { _st?: unknown }) | null;
       const state =
         shell && '_st' in shell ? (shell._st as Record<string, unknown> | undefined) : null;
       const output =
@@ -334,8 +333,7 @@ async function waitForEmbedViewer(frame: Frame): Promise<void> {
   await frame.waitForFunction(
     () => {
       const shell = document.querySelector('osc-embed-shell') as
-        | (Element & { _st?: unknown })
-        | null;
+        (Element & { _st?: unknown }) | null;
       const state =
         shell && '_st' in shell ? (shell._st as Record<string, unknown> | undefined) : null;
       const output =
@@ -353,8 +351,7 @@ async function waitForEmbedParameter(frame: Frame, name: string, timeout = 45_00
   await frame.waitForFunction(
     (expectedName) => {
       const shell = document.querySelector('osc-embed-shell') as
-        | (Element & { _st?: unknown })
-        | null;
+        (Element & { _st?: unknown }) | null;
       const state =
         shell && '_st' in shell ? (shell._st as Record<string, unknown> | undefined) : null;
       const parameterSet =
@@ -581,8 +578,7 @@ test.describe('worker integration', () => {
     await page.waitForFunction(
       () => {
         const shell = document.querySelector('osc-app-shell') as
-          | (Element & { _st?: unknown })
-          | null;
+          (Element & { _st?: unknown }) | null;
         const state =
           shell && '_st' in shell ? (shell._st as Record<string, unknown> | undefined) : null;
         const lastCheckerRun =
@@ -654,8 +650,7 @@ test.describe('embed mode', () => {
     await frame.waitForFunction(
       () => {
         const shell = document.querySelector('osc-embed-shell') as
-          | (Element & { _st?: unknown })
-          | null;
+          (Element & { _st?: unknown }) | null;
         const state =
           shell && '_st' in shell ? (shell._st as Record<string, unknown> | undefined) : null;
         return (
@@ -694,8 +689,7 @@ test.describe('embed mode', () => {
     expect(
       (
         parameterSetMessage?.data?.parameterSet as
-          | { parameters?: Array<{ name?: string }> }
-          | undefined
+          { parameters?: Array<{ name?: string }> } | undefined
       )?.parameters?.some((parameter) => parameter?.name === 'myVar'),
     ).toBe(true);
     expect(varsChangedMessage?.data?.vars).toMatchObject({ myVar: 20 });
@@ -889,8 +883,7 @@ test.describe('embed mode', () => {
     const messages = await getEmbedMessages(page);
     const vars = await frame.evaluate(() => {
       const shell = document.querySelector('osc-embed-shell') as
-        | (Element & { _st?: unknown })
-        | null;
+        (Element & { _st?: unknown }) | null;
       const state =
         shell && '_st' in shell ? (shell._st as Record<string, unknown> | undefined) : null;
       return (state?.params as { vars?: Record<string, unknown> } | undefined)?.vars ?? null;
@@ -978,8 +971,7 @@ test.describe('conformance — geometry primitives', () => {
     const thumbhash = await page.evaluate(async () => {
       for (let i = 0; i < 50; i++) {
         const shell = document.querySelector('osc-app-shell') as
-          | (Element & { _st?: unknown })
-          | null;
+          (Element & { _st?: unknown }) | null;
         const state =
           shell && '_st' in shell ? (shell._st as Record<string, unknown> | undefined) : null;
         const preview =
@@ -1009,8 +1001,7 @@ test.describe('e2e — keyboard shortcuts', () => {
     await page.waitForFunction(
       (prevUrl) => {
         const shell = document.querySelector('osc-app-shell') as
-          | (Element & { _st?: unknown })
-          | null;
+          (Element & { _st?: unknown }) | null;
         const state =
           shell && '_st' in shell ? (shell._st as Record<string, unknown> | undefined) : null;
         const output =
@@ -1039,8 +1030,7 @@ test.describe('e2e — keyboard shortcuts', () => {
     await page.waitForFunction(
       (prevUrl) => {
         const shell = document.querySelector('osc-app-shell') as
-          | (Element & { _st?: unknown })
-          | null;
+          (Element & { _st?: unknown }) | null;
         const state =
           shell && '_st' in shell ? (shell._st as Record<string, unknown> | undefined) : null;
         const output =

--- a/tests/paste.spec.ts
+++ b/tests/paste.spec.ts
@@ -27,8 +27,7 @@ async function waitForEditor(page: Page): Promise<void> {
   await page.waitForFunction(
     () => {
       const p = document.querySelector('osc-editor-panel') as
-        | (Element & { _editor?: { getValue(): string } })
-        | null;
+        (Element & { _editor?: { getValue(): string } }) | null;
       return Boolean(p && p._editor);
     },
     null,
@@ -39,8 +38,7 @@ async function waitForEditor(page: Page): Promise<void> {
 async function editorValue(page: Page): Promise<string> {
   return page.evaluate(() => {
     const p = document.querySelector('osc-editor-panel') as
-      | (Element & { _editor?: { getValue(): string } })
-      | null;
+      (Element & { _editor?: { getValue(): string } }) | null;
     return p?._editor?.getValue() ?? '<no-editor>';
   });
 }


### PR DESCRIPTION
## What

Bumps **prettier 3.8.4 → 3.9.4** and applies its formatting (15 files, all whitespace/indentation inside lit-html `html`` templates + a few test rewraps).

## Why it's a standalone PR

Prettier 3.9.4 changed embedded-template indentation. Migrating off 3.8.4-formatted files takes **2–3 `prettier --write` passes** to reach a stable fixpoint (nested embedded templates settle over successive passes) — a single pass leaves some files still "unformatted", which is what made this bump look un-mergeable at first. The committed tree is that fixpoint, so CI's single `prettier --check` is clean and stays clean (verified: pass 3+ is byte-identical).

Split out of the npm-development dependabot group (#211) so the reformat diff is reviewable on its own. Once merged, #211 rebases and drops prettier, and its remaining 9 dev bumps format-check cleanly.

## Verification

`npm run verify` green end-to-end: `format:check`, `lint`, `typecheck`, `test:unit`, `test:assembly`, `build`, `check:budgets`, `build:publish`, `verify:publish-archive`, `build:viewer`, `build:session`.