### PR TITLE
feat(session): binary project assets in the multi-file contract (#172)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,14 @@ release (changelog upkeep and tagging had lapsed between `0.1.0` and `0.2.0`).
 
 ### Added
 
+- Binary project assets in the multi-file contract (#172): `setProject` files
+  are now `{path, content}` (editable text) **or** `{path, bytes}` — a binary
+  asset's exact bytes as a `Uint8Array` (never base64), landing as a
+  content-less `local` source whose bytes live on the session FS and are
+  materialized into the compile request when referenced (ADR 0006). A project
+  that `import()`s an `.stl`/`surface()`s a `.dat` can now be pushed whole over
+  the wire. A binary `entryPoint` rejects atomically; `updateFile` stays
+  text-only (re-push binary changes via `setProject`).
 - L1 session protocol **v2**: `getArtifact { artifactId, requestId }` →
   `artifact { requestId, available, artifact?, bytes? }` (#197). A host can now
   fetch a produced artifact's exact bytes by its immutable id (ADR 0008) to save

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,8 +33,11 @@ release (changelog upkeep and tagging had lapsed between `0.1.0` and `0.2.0`).
   content-less `local` source whose bytes live on the session FS and are
   materialized into the compile request when referenced (ADR 0006). A project
   that `import()`s an `.stl`/`surface()`s a `.dat` can now be pushed whole over
-  the wire. A binary `entryPoint` rejects atomically; `updateFile` stays
-  text-only (re-push binary changes via `setProject`).
+  the wire — a binary entry point renders too, via the engine's own `import()`
+  wrapper (#121). `bytes` at a text-suffix path must be valid UTF-8 and become
+  an ordinary text source (hosts may read everything as buffers; invalid bytes
+  at a text path reject atomically instead of silently corrupting).
+  `updateFile` stays text-only (re-push binary changes via `setProject`).
 - L1 session protocol **v2**: `getArtifact { artifactId, requestId }` →
   `artifact { requestId, available, artifact?, bytes? }` (#197). A host can now
   fetch a produced artifact's exact bytes by its immutable id (ADR 0008) to save

--- a/docs/EMBEDDING-VSCODE.md
+++ b/docs/EMBEDDING-VSCODE.md
@@ -315,7 +315,9 @@ before sending. Then **drive a project** rather than push geometry:
 - **Host → session:** `setProject { files, entryPoint? }` where each file is
   `{path, content}` (editable text) **or** `{path, bytes}` (a binary asset's
   exact bytes as a `Uint8Array` — #172; e.g. an `.stl` referenced via
-  `import()`), `updateFile { path, content }` (text-only — re-push binary
+  `import()`; a binary entry point renders via the engine's `import()` wrapper;
+  `bytes` at a text-suffix path must be valid UTF-8 and are treated as text),
+  `updateFile { path, content }` (text-only — re-push binary
   changes via `setProject`), `removeFile { path }`, `setEntryPoint { path }`,
   `getArtifact { artifactId, requestId }`, `cancel`, `dispose`.
 - **Session → host:** `ready`, `operation-result { result }` (a **push stream** —

--- a/docs/EMBEDDING-VSCODE.md
+++ b/docs/EMBEDDING-VSCODE.md
@@ -312,8 +312,11 @@ The handshake is the same shape as §4: wait for `ready` (its `capabilities` are
 inbound command names) and assert `protocolVersion === SESSION_PROTOCOL_VERSION`
 before sending. Then **drive a project** rather than push geometry:
 
-- **Host → session:** `setProject { files:[{path,content}], entryPoint? }`,
-  `updateFile { path, content }`, `removeFile { path }`, `setEntryPoint { path }`,
+- **Host → session:** `setProject { files, entryPoint? }` where each file is
+  `{path, content}` (editable text) **or** `{path, bytes}` (a binary asset's
+  exact bytes as a `Uint8Array` — #172; e.g. an `.stl` referenced via
+  `import()`), `updateFile { path, content }` (text-only — re-push binary
+  changes via `setProject`), `removeFile { path }`, `setEntryPoint { path }`,
   `getArtifact { artifactId, requestId }`, `cancel`, `dispose`.
 - **Session → host:** `ready`, `operation-result { result }` (a **push stream** —
   one edit fans out to multiple terminal results; correlate by the nested

--- a/src/protocol/__tests__/session-transport.test.ts
+++ b/src/protocol/__tests__/session-transport.test.ts
@@ -63,6 +63,76 @@ describe('validateSessionInbound', () => {
     expect(ok({ type: 'setProject', files: [] })).toMatchObject({ ok: true });
   });
 
+  it('accepts binary project files (bytes as Uint8Array) and enforces one-of content|bytes (#172)', () => {
+    const bytes = Uint8Array.from([1, 2, 3]);
+    expect(
+      ok({
+        type: 'setProject',
+        files: [
+          { path: '/home/main.scad', content: 'import("part.stl");' },
+          { path: '/home/part.stl', bytes },
+        ],
+      }),
+    ).toEqual({
+      ok: true,
+      message: {
+        type: 'setProject',
+        files: [
+          { path: '/home/main.scad', content: 'import("part.stl");' },
+          { path: '/home/part.stl', bytes },
+        ],
+      },
+    });
+    // exactly one of content | bytes
+    expect(ok({ type: 'setProject', files: [{ path: '/a', content: 'x', bytes }] })).toMatchObject({
+      ok: false,
+      code: 'invalid-payload',
+    });
+    expect(ok({ type: 'setProject', files: [{ path: '/a' }] })).toMatchObject({
+      ok: false,
+      code: 'invalid-payload',
+    });
+    // bytes must be a genuine Uint8Array, not an array/ArrayBuffer/base64 string
+    expect(ok({ type: 'setProject', files: [{ path: '/a', bytes: [1, 2, 3] }] })).toMatchObject({
+      ok: false,
+      code: 'invalid-payload',
+    });
+    expect(
+      ok({ type: 'setProject', files: [{ path: '/a', bytes: new ArrayBuffer(3) }] }),
+    ).toMatchObject({ ok: false, code: 'invalid-payload' });
+  });
+
+  it('enforces the byte caps on binary files (per-file and total)', () => {
+    const tooLarge = { ok: false, code: 'too-large' };
+    const maxBytes = new Uint8Array(SESSION_MAX_FILE_LENGTH);
+    expect(
+      ok({
+        type: 'setProject',
+        files: [{ path: '/a', bytes: new Uint8Array(SESSION_MAX_FILE_LENGTH + 1) }],
+      }),
+    ).toMatchObject(tooLarge);
+    // two max-size binaries exceed the total budget
+    expect(
+      ok({
+        type: 'setProject',
+        files: [
+          { path: '/a', bytes: maxBytes },
+          { path: '/b', bytes: maxBytes },
+        ],
+      }),
+    ).toMatchObject(tooLarge);
+    // mixed text + binary share one budget
+    expect(
+      ok({
+        type: 'setProject',
+        files: [
+          { path: '/a', content: 'x'.repeat(SESSION_MAX_FILE_LENGTH) },
+          { path: '/b', bytes: maxBytes },
+        ],
+      }),
+    ).toMatchObject(tooLarge);
+  });
+
   it('rejects malformed setProject payloads', () => {
     expect(ok({ type: 'setProject', files: 'nope' })).toMatchObject({
       ok: false,

--- a/src/protocol/session-contract.ts
+++ b/src/protocol/session-contract.ts
@@ -39,7 +39,9 @@ export interface Diagnostic {
  * binary asset's exact bytes (e.g. an `.stl`/`.png` referenced via `import()` /
  * `surface()`). Bytes ride structured clone as a `Uint8Array` — never base64 —
  * and land as a content-less `local` source whose bytes live on the session FS
- * (ADR 0006). Exactly one of `content`/`bytes` per file.
+ * (ADR 0006). Exactly one of `content`/`bytes` per file. `bytes` at a
+ * text-suffix path must be valid UTF-8 and are treated as `content` (so a host
+ * may read every workspace file as a buffer and push uniformly).
  */
 export type ProjectFile =
   | { path: string; content: string; bytes?: never }

--- a/src/protocol/session-contract.ts
+++ b/src/protocol/session-contract.ts
@@ -34,11 +34,16 @@ export interface Diagnostic {
   path?: string;
 }
 
-/** A text source file in a project (text-first; binary deferred, #121). */
-export interface ProjectFile {
-  path: string;
-  content: string;
-}
+/**
+ * A source file in a host-supplied project (#123/#172): editable text, or a
+ * binary asset's exact bytes (e.g. an `.stl`/`.png` referenced via `import()` /
+ * `surface()`). Bytes ride structured clone as a `Uint8Array` — never base64 —
+ * and land as a content-less `local` source whose bytes live on the session FS
+ * (ADR 0006). Exactly one of `content`/`bytes` per file.
+ */
+export type ProjectFile =
+  | { path: string; content: string; bytes?: never }
+  | { path: string; bytes: Uint8Array; content?: never };
 
 export type OperationKind = 'syntaxCheck' | 'preview' | 'render' | 'export';
 

--- a/src/protocol/session-transport.ts
+++ b/src/protocol/session-transport.ts
@@ -94,17 +94,18 @@ function readProjectFiles(value: unknown): SessionValidation | { files: ProjectF
       return err('invalid-payload', 'each file must have exactly one of content or bytes');
     }
     if (hasBytes) {
-      if (!(entry.bytes instanceof Uint8Array)) {
+      const bytes = entry.bytes; // read once — validate and forward one value
+      if (!(bytes instanceof Uint8Array)) {
         return err('invalid-payload', 'file bytes must be a Uint8Array');
       }
-      if (entry.bytes.byteLength > SESSION_MAX_FILE_LENGTH) {
+      if (bytes.byteLength > SESSION_MAX_FILE_LENGTH) {
         return err('too-large', 'a file is too large');
       }
-      total += entry.bytes.byteLength + path.length;
+      total += bytes.byteLength + path.length;
       if (total > SESSION_MAX_TOTAL_LENGTH) {
         return err('too-large', 'project exceeds the size limit');
       }
-      files.push({ path, bytes: entry.bytes });
+      files.push({ path, bytes });
       continue;
     }
     const content = readString(entry.content);

--- a/src/protocol/session-transport.ts
+++ b/src/protocol/session-transport.ts
@@ -8,10 +8,11 @@
 //
 // Render is internal to the session webview (it embeds the viewer, #179), so this
 // protocol carries NO geometry/artifact bytes for display. Bytes cross the wire in
-// exactly one place: the `getArtifact` → `artifact` round-trip (#197), which lets a
-// host fetch a produced artifact's exact bytes BY ID to export/save it (STL/3MF/…).
-// Bytes travel as a `Uint8Array` via structured clone — never base64 (VS Code
-// webview `postMessage` has revived typed arrays since ~1.57).
+// exactly two places: inbound, a project file's binary-asset `bytes` (#172), and
+// outbound, the `getArtifact` → `artifact` round-trip (#197) fetching a produced
+// artifact's exact bytes BY ID to save it. Bytes always travel as a `Uint8Array`
+// via structured clone — never base64 (VS Code webview `postMessage` has revived
+// typed arrays since ~1.57).
 
 import { isRecord, stampOutbound, type ProtocolErrorCode } from './envelope.ts';
 import type { ArtifactRef, OperationResult, ProjectFile } from './session-contract.ts';
@@ -70,7 +71,13 @@ function err(code: ProtocolErrorCode, reason: string): SessionValidation {
   return { ok: false, code, reason };
 }
 
-/** Validate a `ProjectFile[]` payload: shape + the DoS caps. */
+/**
+ * Validate a `ProjectFile[]` payload: shape + the DoS caps. Each file is text
+ * (`content`, editable) OR a binary asset (`bytes` as a `Uint8Array` via
+ * structured clone, #172) — exactly one of the two. The size budget mixes
+ * UTF-16 code units (text) and bytes (binary); it is a pre-filter, not the real
+ * enforcer (`ProjectStore` re-validates paths; the engine owns the FS budget).
+ */
 function readProjectFiles(value: unknown): SessionValidation | { files: ProjectFile[] } {
   if (!Array.isArray(value)) return err('invalid-payload', 'files must be an array');
   if (value.length > SESSION_MAX_FILES) return err('too-large', 'too many files');
@@ -79,11 +86,29 @@ function readProjectFiles(value: unknown): SessionValidation | { files: ProjectF
   for (const entry of value) {
     if (!isRecord(entry)) return err('invalid-payload', 'each file must be an object');
     const path = readString(entry.path);
-    const content = readString(entry.content);
-    if (path === undefined || content === undefined) {
-      return err('invalid-payload', 'file path and content must be strings');
-    }
+    if (path === undefined) return err('invalid-payload', 'file path must be a string');
     if (path.length > SESSION_MAX_PATH_LENGTH) return err('too-large', 'a file path is too long');
+    const hasContent = entry.content !== undefined;
+    const hasBytes = entry.bytes !== undefined;
+    if (hasContent === hasBytes) {
+      return err('invalid-payload', 'each file must have exactly one of content or bytes');
+    }
+    if (hasBytes) {
+      if (!(entry.bytes instanceof Uint8Array)) {
+        return err('invalid-payload', 'file bytes must be a Uint8Array');
+      }
+      if (entry.bytes.byteLength > SESSION_MAX_FILE_LENGTH) {
+        return err('too-large', 'a file is too large');
+      }
+      total += entry.bytes.byteLength + path.length;
+      if (total > SESSION_MAX_TOTAL_LENGTH) {
+        return err('too-large', 'project exceeds the size limit');
+      }
+      files.push({ path, bytes: entry.bytes });
+      continue;
+    }
+    const content = readString(entry.content);
+    if (content === undefined) return err('invalid-payload', 'file content must be a string');
     if (content.length > SESSION_MAX_FILE_LENGTH) return err('too-large', 'a file is too large');
     total += content.length + path.length;
     if (total > SESSION_MAX_TOTAL_LENGTH) return err('too-large', 'project exceeds the size limit');

--- a/src/session-host/controller.ts
+++ b/src/session-host/controller.ts
@@ -98,10 +98,11 @@ export class SessionController {
           break;
       }
     } catch (e) {
-      // ProjectStore throws synchronously on an unsafe / binary-overwrite path
-      // (ProjectPathError); surface it as a protocol error rather than letting it
-      // escape the transport's message pump. Skip if a `dispose` command's teardown
-      // threw — the transport is already gone.
+      // Defensive: `Model` catches contract errors internally (ProjectPathError →
+      // state.error, invisible on the wire — a known gap), so this only fires for
+      // a genuinely escaping throw; surface it rather than letting it kill the
+      // transport's message pump. Skip if a `dispose` command's teardown threw —
+      // the transport is already gone.
       if (this.disposed) return;
       this.transport.send(sessionError('invalid-payload', String((e as Error)?.message ?? e)));
     }

--- a/src/state/__tests__/project-contract.test.ts
+++ b/src/state/__tests__/project-contract.test.ts
@@ -89,9 +89,9 @@ function baseState(): State {
   } as State;
 }
 
-function makeModel(backend: FakeBackend) {
+function makeModel(backend: FakeBackend, fs: ProjectFileSystem = fakeFs) {
   const model = new Model(
-    fakeFs,
+    fs,
     baseState(),
     undefined,
     undefined,
@@ -178,10 +178,8 @@ describe('#123 multi-file project contract — headless end to end', () => {
     expect(wire!.content).toEqual(stlBytes);
   });
 
-  it('setProject rejects a binary entryPoint atomically (a binary cannot compile)', async () => {
+  it('a binary entryPoint is allowed — the engine renders it via its import wrapper (#121)', async () => {
     const { model, ops } = makeModel(new FakeBackend());
-    const before = model.state.params.sources;
-
     model.setProject(
       [
         { path: 'main.scad', content: 'cube(1);' },
@@ -190,14 +188,51 @@ describe('#123 multi-file project contract — headless end to end', () => {
       'part.stl',
     );
     await settle();
+    expect(model.state.params.activePath).toBe('/home/part.stl');
+    expect(ops.find((o) => o.status === 'success' && o.artifact)).toBeDefined();
+  });
 
-    // The whole call rejected before any mutation: sources unchanged, the error
-    // surfaced as a user-facing model error (the generic load message, with the
-    // specific reason in details — the standing mapping for 'model' ops), and
-    // no compile was driven.
+  it('an all-binary project with no entryPoint selects and renders the binary (the implicit door)', async () => {
+    const { model, ops } = makeModel(new FakeBackend());
+    model.setProject([{ path: 'part.stl', bytes: Uint8Array.from([1, 2, 3]) }]);
+    await settle();
+    expect(model.state.params.activePath).toBe('/home/part.stl');
+    expect(model.state.params.sources).toEqual([{ kind: 'local', path: '/home/part.stl' }]);
+    expect(ops.find((o) => o.status === 'success' && o.artifact)).toBeDefined();
+  });
+
+  it('bytes at a text-suffix path decode to an ordinary text source; invalid UTF-8 rejects atomically', async () => {
+    const { model, ops } = makeModel(new FakeBackend());
+    model.setProject([{ path: 'main.scad', bytes: new TextEncoder().encode('cube(2);') }]);
+    await settle();
+    // Valid UTF-8 at .scad → a text source, exactly as if pushed as content.
+    expect(model.state.params.sources).toEqual([
+      { kind: 'text', path: '/home/main.scad', content: 'cube(2);' },
+    ]);
+    expect(ops.find((o) => o.status === 'success' && o.artifact)).toBeDefined();
+
+    // Invalid UTF-8 at a text path rejects the whole push (no silent mojibake).
+    const before = model.state.params.sources;
+    model.setProject([{ path: 'other.scad', bytes: Uint8Array.from([0xff, 0xfe, 0x00, 0xff]) }]);
+    await settle();
     expect(model.state.params.sources).toBe(before);
-    expect(model.state.error).toBeDefined();
-    expect(model.state.errorDetails).toMatch(/binary asset/);
+    expect(model.state.errorDetails).toMatch(/not valid UTF-8/);
+  });
+
+  it('a truly-binary push on a filesystem without writeBytes rejects loudly up front', async () => {
+    const noBytesFs = {
+      readFileSync: () => new Uint8Array(),
+      writeFile: () => {},
+    } as unknown as ProjectFileSystem;
+    const { model, ops } = makeModel(new FakeBackend(), noBytesFs);
+    const before = model.state.params.sources;
+    model.setProject([
+      { path: 'main.scad', content: 'import("p.stl");' },
+      { path: 'p.stl', bytes: Uint8Array.from([1]) },
+    ]);
+    await settle();
+    expect(model.state.params.sources).toBe(before);
+    expect(model.state.errorDetails).toMatch(/cannot store binary assets/);
     expect(ops).toEqual([]);
   });
 

--- a/src/state/__tests__/project-contract.test.ts
+++ b/src/state/__tests__/project-contract.test.ts
@@ -25,8 +25,11 @@ import { AbortablePromise } from '../../utils.ts';
 // in 'hang' mode — never resolves and rejects on kill() like the real delayable.
 class FakeBackend implements CompileBackend {
   mode: 'ok' | 'hang' = 'ok';
+  /** Every invocation received, so tests can assert what crossed to the worker. */
+  invocations: OpenSCADInvocation[] = [];
 
   spawn(invocation: OpenSCADInvocation): AbortablePromise<OpenSCADInvocationResults> {
+    this.invocations.push(invocation);
     if (this.mode === 'hang') {
       return AbortablePromise<OpenSCADInvocationResults>(
         (_res, rej) => () => rej(new Error('Cancelled')),
@@ -55,9 +58,19 @@ const host = {
   baseUrl: () => 'http://localhost/',
 } as unknown as HostAdapter;
 
+// Stateful: binary assets written by setProject (#172) are read back at compile
+// time by materializeBinarySources (ADR 0006), so the fake must round-trip them.
+const fsStore = new Map<string, Uint8Array>();
 const fakeFs = {
-  readFileSync: () => new Uint8Array(),
+  readFileSync: (path: string) => {
+    const bytes = fsStore.get(path);
+    if (!bytes) throw new Error(`ENOENT: ${path}`);
+    return bytes;
+  },
   writeFile: () => {},
+  writeBytes: (path: string, bytes: Uint8Array) => {
+    fsStore.set(path, bytes);
+  },
 } as unknown as ProjectFileSystem;
 
 function baseState(): State {
@@ -96,7 +109,10 @@ function makeModel(backend: FakeBackend) {
 const settle = () => vi.advanceTimersByTimeAsync(1200);
 
 describe('#123 multi-file project contract — headless end to end', () => {
-  beforeEach(() => vi.useFakeTimers());
+  beforeEach(() => {
+    vi.useFakeTimers();
+    fsStore.clear();
+  });
   afterEach(() => vi.useRealTimers());
 
   it('setProject → render commits a retrievable artifact and a success result', async () => {
@@ -127,6 +143,62 @@ describe('#123 multi-file project contract — headless end to end', () => {
       expect(stored).toBeDefined();
       expect(stored!.bytes).toBe(model.state.output!.outFile);
     }
+  });
+
+  it('setProject with a binary asset lands a local source and ships its exact bytes to the worker (#172)', async () => {
+    const backend = new FakeBackend();
+    const { model, ops } = makeModel(backend);
+    const stlBytes = Uint8Array.from([0x53, 0x54, 0x4c, 0x00, 0xff, 0x01]);
+
+    model.setProject(
+      [
+        { path: 'main.scad', content: 'import("part.stl");' },
+        { path: 'assets/part.stl', bytes: stlBytes },
+      ],
+      'main.scad',
+    );
+    await settle();
+
+    // The binary landed as a content-less `local` source; the text stayed editable.
+    expect(model.state.params.sources).toEqual(
+      expect.arrayContaining([
+        { kind: 'local', path: '/home/assets/part.stl' },
+        { kind: 'text', path: '/home/main.scad', content: 'import("part.stl");' },
+      ]),
+    );
+    expect(model.state.params.activePath).toBe('/home/main.scad');
+
+    // The compile succeeded, and the worker request carried the asset's EXACT
+    // bytes (materialized off the FS — ADR 0006), not a stringified corruption.
+    expect(ops.find((o) => o.status === 'success' && o.artifact)).toBeDefined();
+    const wire = backend.invocations
+      .flatMap((i) => i.inputs ?? [])
+      .find((s) => s.path === '/home/assets/part.stl');
+    expect(wire).toBeDefined();
+    expect(wire!.content).toEqual(stlBytes);
+  });
+
+  it('setProject rejects a binary entryPoint atomically (a binary cannot compile)', async () => {
+    const { model, ops } = makeModel(new FakeBackend());
+    const before = model.state.params.sources;
+
+    model.setProject(
+      [
+        { path: 'main.scad', content: 'cube(1);' },
+        { path: 'part.stl', bytes: Uint8Array.from([1, 2, 3]) },
+      ],
+      'part.stl',
+    );
+    await settle();
+
+    // The whole call rejected before any mutation: sources unchanged, the error
+    // surfaced as a user-facing model error (the generic load message, with the
+    // specific reason in details — the standing mapping for 'model' ops), and
+    // no compile was driven.
+    expect(model.state.params.sources).toBe(before);
+    expect(model.state.error).toBeDefined();
+    expect(model.state.errorDetails).toMatch(/binary asset/);
+    expect(ops).toEqual([]);
   });
 
   it('updateFile → setEntryPoint → removeFile drive deterministic recompiles', async () => {

--- a/src/state/model.ts
+++ b/src/state/model.ts
@@ -349,7 +349,8 @@ export class Model extends EventTarget {
   // state the editor uses. Each funnels through one `mutate` (one revision bump,
   // one 'state' event) then drives `processSource`, so the existing supersession
   // + revision-stale-drop machinery keeps a superseded in-flight compile from
-  // clobbering the result. Text files only for now (binary is deferred — #121).
+  // clobbering the result. Files are editable text or binary assets (#172);
+  // `updateFile` stays text-only — a binary change re-pushes via `setProject`.
 
   /** Replace the whole project with `files`, selecting `entryPoint` (or the
    *  main.scad→first-.scad→first rule) as the active file. */

--- a/src/state/project-contract.ts
+++ b/src/state/project-contract.ts
@@ -5,7 +5,7 @@ export type { ProjectFile };
 /**
  * The host-drivable project + lifecycle operations a session exposes (#123, Gate
  * B). Typed methods over the same `params.sources` / `activePath` state the
- * editor uses — text files first (#121). Each mutation funnels through one
+ * editor uses — editable text and binary assets (#121/#172). Each mutation funnels through one
  * `mutate` then drives a recompile; terminal results are observed via the Model's
  * `'operation'` event (correlated on `operationId`), not return values, matching
  * the fire-and-recompile shape of every compile-triggering method.

--- a/src/state/project-store.ts
+++ b/src/state/project-store.ts
@@ -18,8 +18,8 @@ export interface ProjectSnapshot {
   activePath: string;
 }
 
-// `ProjectFile` (one text file in a host-supplied project, the multi-file contract
-// #123; binary variant deferred, #121) is a wire payload, so its type lives in
+// `ProjectFile` (one file in a host-supplied project — editable text or a binary
+// asset's bytes; #123/#172) is a wire payload, so its type lives in
 // src/protocol/session-contract.ts and is re-exported here for existing importers.
 import type { ProjectFile } from '../protocol/session-contract.ts';
 export type { ProjectFile };
@@ -115,6 +115,26 @@ export class ProjectStore {
     return { sources: [...withoutExisting, { kind: 'text', path, content }], activePath: path };
   }
 
+  /** Write a binary file, creating its parent dirs first (mkdir -p). Best-effort
+   *  like {@link writeTextFile}: a failed write surfaces later as the compiler's
+   *  clear "asset not available" error, not an aborted project push. */
+  private writeBinaryFile(path: string, bytes: Uint8Array): void {
+    try {
+      if (this.fs.mkdirSync) {
+        for (const dir of ancestorDirsOf(path)) {
+          try {
+            this.fs.mkdirSync(dir);
+          } catch {
+            /* already exists */
+          }
+        }
+      }
+      this.fs.writeBytes?.(path, bytes);
+    } catch {
+      /* best-effort */
+    }
+  }
+
   /** Write a text file, creating its parent dirs first (mkdir -p). Best-effort:
    *  the in-memory sources drive compilation, so an FS failure must not abort. */
   private writeTextFile(path: string, content: string): void {
@@ -135,18 +155,20 @@ export class ProjectStore {
   }
 
   /**
-   * Replace the whole project with `files` (text only — #121), selecting
-   * `entryPoint` as the active file (or the {@link selectEntryPath} rule when it
-   * is absent/unknown). All paths are validated and canonicalized up front, so a
-   * single unsafe path rejects the whole call before any file is written (atomic,
-   * like ZIP import). An empty file list yields one fresh empty file so the
-   * "there is always an active file" invariant holds.
+   * Replace the whole project with `files` — editable text and/or binary assets
+   * (#172) — selecting `entryPoint` as the active file (or the
+   * {@link selectEntryPath} rule when it is absent). All paths are validated and
+   * canonicalized up front, so a single unsafe path rejects the whole call
+   * before any file is written (atomic, like ZIP import); a requested entry
+   * that names a binary asset rejects too (a binary can't compile), while an
+   * absent/unknown one falls back to the rule as before. Binary
+   * files land as content-less `local` sources whose bytes live on the FS and
+   * are materialized into the compile request when referenced (ADR 0006). An
+   * empty file list yields one fresh empty file so the "there is always an
+   * active file" invariant holds.
    */
   setProject(files: ProjectFile[], entryPoint?: string): ProjectSnapshot {
-    const canon = files.map((f) => ({
-      path: canonicalProjectHomePath(f.path),
-      content: f.content,
-    }));
+    const canon = files.map((f) => ({ ...f, path: canonicalProjectHomePath(f.path) }));
     const seen = new Set<string>();
     for (const f of canon) {
       if (seen.has(f.path)) throw new ProjectPathError(`Duplicate path in project: ${f.path}`);
@@ -155,13 +177,21 @@ export class ProjectStore {
     // Canonicalize the entry point up front too, so an unsafe entryPoint rejects
     // the whole call BEFORE any file is written (truly atomic, like ZIP import).
     const requested = entryPoint !== undefined ? canonicalProjectHomePath(entryPoint) : undefined;
+    if (
+      requested !== undefined &&
+      canon.some((f) => f.path === requested && f.bytes !== undefined)
+    ) {
+      throw new ProjectPathError(`entryPoint ${requested} is a binary asset and cannot compile.`);
+    }
     if (canon.length === 0) return this.newFile([]);
-    for (const f of canon) this.writeTextFile(f.path, f.content);
-    const sources: SerializableSource[] = canon.map((f) => ({
-      kind: 'text',
-      path: f.path,
-      content: f.content,
-    }));
+    const sources: SerializableSource[] = canon.map((f) => {
+      if (f.bytes !== undefined) {
+        this.writeBinaryFile(f.path, f.bytes);
+        return { kind: 'local', path: f.path };
+      }
+      this.writeTextFile(f.path, f.content);
+      return { kind: 'text', path: f.path, content: f.content };
+    });
     const activePath =
       requested && sources.some((s) => s.path === requested)
         ? requested

--- a/src/state/project-store.ts
+++ b/src/state/project-store.ts
@@ -157,18 +157,40 @@ export class ProjectStore {
   /**
    * Replace the whole project with `files` — editable text and/or binary assets
    * (#172) — selecting `entryPoint` as the active file (or the
-   * {@link selectEntryPath} rule when it is absent). All paths are validated and
-   * canonicalized up front, so a single unsafe path rejects the whole call
-   * before any file is written (atomic, like ZIP import); a requested entry
-   * that names a binary asset rejects too (a binary can't compile), while an
-   * absent/unknown one falls back to the rule as before. Binary
-   * files land as content-less `local` sources whose bytes live on the FS and
-   * are materialized into the compile request when referenced (ADR 0006). An
+   * {@link selectEntryPath} rule when it is absent/unknown). All paths are
+   * validated and canonicalized — and every `bytes` file classified — up front,
+   * so a single bad file rejects the whole call before anything is written
+   * (atomic, like ZIP import). Classification: `bytes` at a text-suffix path
+   * (`.scad`/`.svg`/…) must be valid UTF-8 and becomes an ordinary text source
+   * (hosts may read everything as buffers; invalid bytes at a text path reject
+   * rather than silently mojibake); other `bytes` land as content-less `local`
+   * sources whose bytes live on the FS and are materialized into the compile
+   * request when referenced (ADR 0006). A binary entry point is allowed — the
+   * engine renders non-`.scad` actives via its `import()` wrapper (#121). An
    * empty file list yields one fresh empty file so the "there is always an
    * active file" invariant holds.
    */
   setProject(files: ProjectFile[], entryPoint?: string): ProjectSnapshot {
-    const canon = files.map((f) => ({ ...f, path: canonicalProjectHomePath(f.path) }));
+    const utf8 = new TextDecoder('utf-8', { fatal: true });
+    const canon = files.map((f) => {
+      const path = canonicalProjectHomePath(f.path);
+      if (f.bytes === undefined) return { path, content: f.content };
+      if (isProbablyTextPath(path)) {
+        try {
+          return { path, content: utf8.decode(f.bytes) };
+        } catch {
+          throw new ProjectPathError(
+            `${path} has a text extension but its bytes are not valid UTF-8.`,
+          );
+        }
+      }
+      return { path, bytes: f.bytes };
+    });
+    if (canon.some((f) => f.bytes !== undefined) && !this.fs.writeBytes) {
+      // Fail loud and atomically: a silent no-op here would surface much later
+      // as a confusing compile-time "asset not available".
+      throw new ProjectPathError('This host filesystem cannot store binary assets.');
+    }
     const seen = new Set<string>();
     for (const f of canon) {
       if (seen.has(f.path)) throw new ProjectPathError(`Duplicate path in project: ${f.path}`);
@@ -177,20 +199,14 @@ export class ProjectStore {
     // Canonicalize the entry point up front too, so an unsafe entryPoint rejects
     // the whole call BEFORE any file is written (truly atomic, like ZIP import).
     const requested = entryPoint !== undefined ? canonicalProjectHomePath(entryPoint) : undefined;
-    if (
-      requested !== undefined &&
-      canon.some((f) => f.path === requested && f.bytes !== undefined)
-    ) {
-      throw new ProjectPathError(`entryPoint ${requested} is a binary asset and cannot compile.`);
-    }
     if (canon.length === 0) return this.newFile([]);
     const sources: SerializableSource[] = canon.map((f) => {
       if (f.bytes !== undefined) {
         this.writeBinaryFile(f.path, f.bytes);
         return { kind: 'local', path: f.path };
       }
-      this.writeTextFile(f.path, f.content);
-      return { kind: 'text', path: f.path, content: f.content };
+      this.writeTextFile(f.path, f.content!);
+      return { kind: 'text', path: f.path, content: f.content! };
     });
     const activePath =
       requested && sources.some((s) => s.path === requested)

--- a/src/state/services/compile-coordinator.ts
+++ b/src/state/services/compile-coordinator.ts
@@ -120,7 +120,8 @@ export class CompileCoordinator {
           throw new UserFacingOperationError({
             message:
               `Asset not available: ${source.path}. It is referenced by the model but ` +
-              `its bytes are not in this session (a shared link does not carry binary assets).`,
+              `its bytes are not in this session (for example, a shared link does not ` +
+              `carry binary assets).`,
           });
         }
       }),

--- a/tests/session.spec.ts
+++ b/tests/session.spec.ts
@@ -53,7 +53,6 @@ async function embedSession(page: Page): Promise<void> {
   );
 }
 
-
 test.describe('session distributable (#193)', () => {
   test.skip(!sessionServed, 'requires E2E_SERVER_MODE=session (dist-session served)');
 

--- a/tests/session.spec.ts
+++ b/tests/session.spec.ts
@@ -53,12 +53,6 @@ async function embedSession(page: Page): Promise<void> {
   );
 }
 
-async function postToSession(page: Page, message: object): Promise<void> {
-  await page.evaluate((msg) => {
-    const frame = document.getElementById('session-frame') as HTMLIFrameElement;
-    frame.contentWindow!.postMessage(msg, window.location.origin);
-  }, message);
-}
 
 test.describe('session distributable (#193)', () => {
   test.skip(!sessionServed, 'requires E2E_SERVER_MODE=session (dist-session served)');
@@ -72,12 +66,26 @@ test.describe('session distributable (#193)', () => {
     const manifest = await page.request.get(new URL('session-manifest.json', baseUrl).toString());
     const { protocolVersion } = (await manifest.json()) as { protocolVersion: number };
 
-    await postToSession(page, {
-      protocolVersion,
-      type: 'setProject',
-      files: [{ path: 'main.scad', content: 'cube([10, 10, 10]);' }],
-      entryPoint: 'main.scad',
-    });
+    // The project includes a (unreferenced) binary asset (#172), so the push
+    // exercises the bytes branch — wire validation, BrowserFS writeBytes, and
+    // the local-source bookkeeping — against the real artifact. The Uint8Array
+    // must be constructed IN PAGE: Playwright's evaluate-arg serialization would
+    // mangle a Node-side one before it ever reached postMessage.
+    await page.evaluate((v) => {
+      const frame = document.getElementById('session-frame') as HTMLIFrameElement;
+      frame.contentWindow!.postMessage(
+        {
+          protocolVersion: v,
+          type: 'setProject',
+          files: [
+            { path: 'main.scad', content: 'cube([10, 10, 10]);' },
+            { path: 'assets/blob.bin', bytes: new Uint8Array([0xde, 0xad, 0xbe, 0xef]) },
+          ],
+          entryPoint: 'main.scad',
+        },
+        window.location.origin,
+      );
+    }, protocolVersion);
 
     // A genuine WASM compile fans out to a success operation-result carrying an
     // OFF artifact (the render bridge also sets it on the embedded viewer, but the


### PR DESCRIPTION
## Summary

Widens the L1 `ProjectFile` to a discriminated union — `{path, content}` (editable text) **or** `{path, bytes}` (a binary asset's exact bytes as a `Uint8Array` via structured clone, never base64) — so a project that `import()`s an `.stl` or `surface()`s a `.dat` can be pushed whole over the wire. Rides the unreleased protocol v2 (no second bump).

- `setProject` routes bytes to the FS (`mkdir -p` + `writeBytes`) as content-less `{kind:'local'}` sources; the existing `materializeBinarySources` (ADR 0006) ships the exact bytes to the worker — the engine side was already built, this is the wire contract.
- **A binary entry point renders** via the engine's own `load-resource.scad` `import()` wrapper (#121) — a host can push an STL and view it directly.
- **`bytes` at a text-suffix path must be valid UTF-8 and become an ordinary text source** (hosts may read every workspace file as a buffer and push uniformly); invalid bytes at a text path reject atomically instead of silently mojibake-corrupting the source.
- A truly-binary push on a filesystem without `writeBytes` rejects loudly up front.
- `updateFile` stays text-only by decision — the only wire consumer re-pushes the whole closure.
- Wire validation: exactly-one-of `content|bytes`, per-file + shared total byte budgets, single-read of the bytes property.

## Review

Adversarially reviewed pre-PR. Its **major** finding reshaped the semantics: my original "binary entryPoint rejects" guard had a false premise (the engine renders binary actives via its import wrapper) and was bypassable through the implicit entry-selection and `setEntryPoint` doors — replaced with allow-and-render, both doors tested. Also fixed per review: the text-suffix mojibake edge (fatal-UTF-8 decode), loud `writeBytes`-missing rejection, provenance-neutral asset-not-available message, single-read validation, a stale controller comment. Verified non-issues: every real FS entry installs `writeBytes` (BrowserFS, ADR 0006); persistence flattens wire-pushed binaries identically to ZIP/FSAPI locals; no consumer still assumes `content`.

## Testing

- 620 unit tests pass; new: transport accept/reject/caps for bytes, headless capstone proving a pushed asset's **exact bytes reach the worker invocation**, binary-entry (both doors), UTF-8 decode/reject, missing-`writeBytes` rejection.
- Real-WASM session e2e now pushes a binary file too (constructed in-page — Playwright's evaluate-arg serialization would mangle a Node-side `Uint8Array`).

Closes #172.