### PR TITLE
feat(session): host-driven export over the L1 wire (#216)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,13 @@ release (changelog upkeep and tagging had lapsed between `0.1.0` and `0.2.0`).
 
 ### Fixed
 
+- Export (found by #216's adversarial review; all three pre-existing in the app
+  UI too): the pass-through path now keys on the output file's ACTUAL format
+  instead of the format setting — a stale setting could label a DXF as a
+  requested SVG; a pass-through export no longer lets a later conversion revoke
+  the live output's blob URL (which broke the next conversion's worker fetch);
+  and a conversion's `ArtifactRef` now carries the consumed output's
+  `sourceRevision` rather than the current edit counter.
 - OFF import: canonical multi-line headers (`OFF` on its own line, counts on the
   next — as emitted by Meshlab and many tools) are no longer rejected with
   "invalid vertex or face counts". The same-line form (`OFF 8 6 12`, as OpenSCAD
@@ -31,8 +38,12 @@ release (changelog upkeep and tagging had lapsed between `0.1.0` and `0.2.0`).
   (stl/off/glb/3mf/svg/dxf) drives the standard export flow; the terminal lands
   on the push stream as a `kind: 'export'` result whose `ArtifactRef` is then
   fetched via `getArtifact` (#197) — STL/3MF/GLB are now reachable from a host.
-  A dimensionality mismatch terminates as an `export-format-mismatch` failure
-  result instead of silence. In the session artifact, the in-page download side
+  The format is per-request (never written to the persisted export settings, so
+  it cannot flip subsequent 2D previews' render format), an export converts the
+  last completed output (its `ArtifactRef` carries that geometry's
+  `sourceRevision`), and every rejection is a terminal failure result:
+  `no-output` before a first completed compile, `export-format-mismatch` for
+  the wrong dimensionality. In the session artifact, the in-page download side
   effect and the 3MF multimaterial picker are disabled (the host owns saving;
   default colors apply).
 - Binary project assets in the multi-file contract (#172): `setProject` files

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,14 @@ release (changelog upkeep and tagging had lapsed between `0.1.0` and `0.2.0`).
 
 ### Added
 
+- Host-driven export over the L1 wire (#216): new `export { format }` command
+  (stl/off/glb/3mf/svg/dxf) drives the standard export flow; the terminal lands
+  on the push stream as a `kind: 'export'` result whose `ArtifactRef` is then
+  fetched via `getArtifact` (#197) — STL/3MF/GLB are now reachable from a host.
+  A dimensionality mismatch terminates as an `export-format-mismatch` failure
+  result instead of silence. In the session artifact, the in-page download side
+  effect and the 3MF multimaterial picker are disabled (the host owns saving;
+  default colors apply).
 - Binary project assets in the multi-file contract (#172): `setProject` files
   are now `{path, content}` (editable text) **or** `{path, bytes}` — a binary
   asset's exact bytes as a `Uint8Array` (never base64), landing as a

--- a/docs/EMBEDDING-VSCODE.md
+++ b/docs/EMBEDDING-VSCODE.md
@@ -319,6 +319,7 @@ before sending. Then **drive a project** rather than push geometry:
   `bytes` at a text-suffix path must be valid UTF-8 and are treated as text),
   `updateFile { path, content }` (text-only — re-push binary
   changes via `setProject`), `removeFile { path }`, `setEntryPoint { path }`,
+  `export { format }` (`stl`/`off`/`glb`/`3mf`/`svg`/`dxf` — #216),
   `getArtifact { artifactId, requestId }`, `cancel`, `dispose`.
 - **Session → host:** `ready`, `operation-result { result }` (a **push stream** —
   one edit fans out to multiple terminal results; correlate by the nested
@@ -335,15 +336,19 @@ as a **`Uint8Array`** via structured clone (never base64), or `available: false`
 if the id is unknown, was evicted from the small per-session LRU (fetch promptly
 after the result you want), or its blob read failed.
 
-Two scoping notes:
+**Exporting STL/3MF/GLB** (#216): send `export { format }` — the terminal arrives
+on the push stream as a `kind: 'export'` result (fire-and-observe, like the
+mutation commands). On success it carries the converted artifact's `ArtifactRef`;
+fetch the bytes with `getArtifact` and save them. The session exports the current
+model's dimensionality — a mismatched request (e.g. `svg` for a 3D model)
+terminates as an export-kind **failure** result (`export-format-mismatch`), never
+silence. The in-page download side effect and the 3MF multimaterial picker are
+disabled in the session artifact (the host owns saving; default colors apply).
 
-- `getArtifact` fetches bytes of artifacts the session **already produced** — OFF
-  for 3D compiles, SVG/DXF for 2D. There is **no wire command yet that triggers an
-  export operation** (STL/3MF/GLB conversion), so those formats are not reachable
-  over L1 until the export-trigger follow-up lands (tracked in epic #179).
-- Typed arrays only survive VS Code's webview `postMessage` when the consuming
-  extension declares `engines.vscode >= 1.57` (VS Code gates buffer serialization
-  per extension); older declarations silently mangle the bytes.
+One transport note: typed arrays only survive VS Code's webview `postMessage`
+when the consuming extension declares `engines.vscode >= 1.57` (VS Code gates
+buffer serialization per extension); older declarations silently mangle the
+bytes.
 
 > Compiling arbitrary `.scad` runs the full OpenSCAD engine on host-supplied input.
 > Push only files the user opened/trusts; the protocol caps file count/size, but

--- a/docs/EMBEDDING-VSCODE.md
+++ b/docs/EMBEDDING-VSCODE.md
@@ -339,11 +339,23 @@ after the result you want), or its blob read failed.
 **Exporting STL/3MF/GLB** (#216): send `export { format }` — the terminal arrives
 on the push stream as a `kind: 'export'` result (fire-and-observe, like the
 mutation commands). On success it carries the converted artifact's `ArtifactRef`;
-fetch the bytes with `getArtifact` and save them. The session exports the current
-model's dimensionality — a mismatched request (e.g. `svg` for a 3D model)
-terminates as an export-kind **failure** result (`export-format-mismatch`), never
-silence. The in-page download side effect and the 3MF multimaterial picker are
-disabled in the session artifact (the host owns saving; default colors apply).
+fetch the bytes with `getArtifact` and save them. Semantics a host should know:
+
+- An export converts the **last completed output**; its
+  `ArtifactRef.sourceRevision` is that geometry's revision (compare it against
+  your latest push to detect "exported before the new preview landed"). Before
+  any completed compile, `export` fails with `no-output` — wait for a success
+  result first.
+- A dimensionality mismatch (e.g. `svg` for a 3D model) terminates as an
+  export-kind **failure** (`export-format-mismatch`), never silence. The
+  request's format is per-request only — it does not alter the session's
+  preview settings.
+- Exports derive from **preview-quality** geometry (`$preview = true`): a model
+  that gates detail on `$preview` exports its preview variant. A wire command
+  for full-render exports is a tracked follow-up in epic #179.
+- The in-page download side effect and the 3MF multimaterial picker are
+  disabled in the session artifact (the host owns saving; default colors
+  apply).
 
 One transport note: typed arrays only survive VS Code's webview `postMessage`
 when the consuming extension declares `engines.vscode >= 1.57` (VS Code gates

--- a/src/protocol/__tests__/session-transport.test.ts
+++ b/src/protocol/__tests__/session-transport.test.ts
@@ -211,6 +211,24 @@ describe('validateSessionInbound', () => {
     expect(ok({ type: 'dispose' })).toEqual({ ok: true, message: { type: 'dispose' } });
   });
 
+  it('accepts export with a known format and rejects unknown/missing ones (#216)', () => {
+    for (const format of ['stl', 'off', 'glb', '3mf', 'svg', 'dxf']) {
+      expect(ok({ type: 'export', format })).toEqual({
+        ok: true,
+        message: { type: 'export', format },
+      });
+    }
+    expect(ok({ type: 'export' })).toMatchObject({ ok: false, code: 'invalid-payload' });
+    expect(ok({ type: 'export', format: 'step' })).toMatchObject({
+      ok: false,
+      code: 'invalid-payload',
+    });
+    expect(ok({ type: 'export', format: 7 })).toMatchObject({
+      ok: false,
+      code: 'invalid-payload',
+    });
+  });
+
   it('accepts getArtifact and requires string artifactId + requestId', () => {
     expect(ok({ type: 'getArtifact', artifactId: 'a-1', requestId: 'r-1' })).toEqual({
       ok: true,
@@ -246,6 +264,7 @@ describe('validateSessionInbound', () => {
       updateFile: { path: '/a', content: 'x' },
       removeFile: { path: '/a' },
       setEntryPoint: { path: '/a' },
+      export: { format: 'stl' },
       getArtifact: { artifactId: 'a', requestId: 'r' },
       cancel: {},
       dispose: {},

--- a/src/protocol/session-transport.ts
+++ b/src/protocol/session-transport.ts
@@ -22,7 +22,9 @@ import type { ArtifactRef, OperationResult, ProjectFile } from './session-contra
  * is the session WIRE version — distinct from `L1_PROTOCOL_VERSION`, which versions
  * the nested `OperationResult` payload (ADR 0005: each binding owns its version).
  *
- * v2: added the `getArtifact` command + `artifact` reply (#197).
+ * v2: added the `getArtifact` command + `artifact` reply (#197), binary project
+ * files (#172), and the `export` command (#216) — one bump; v2 never shipped
+ * between them.
  */
 export const SESSION_PROTOCOL_VERSION = 2;
 
@@ -44,18 +46,28 @@ export const SESSION_COMMANDS = [
   'updateFile',
   'removeFile',
   'setEntryPoint',
+  'export',
   'getArtifact',
   'cancel',
   'dispose',
 ] as const;
 
+/** The export formats a host may request (#216) — the app's own format set.
+ *  3D: stl/off/glb/3mf; 2D: svg/dxf. The session exports the CURRENT model's
+ *  dimensionality; a mismatched request (e.g. `svg` for a 3D model) terminates
+ *  as an export-kind failure result, never silence. */
+export const SESSION_EXPORT_FORMATS = ['stl', 'off', 'glb', '3mf', 'svg', 'dxf'] as const;
+export type SessionExportFormat = (typeof SESSION_EXPORT_FORMATS)[number];
+
 /** Host → session. Mirrors `ProjectContract` (src/state/project-contract.ts) 1:1,
- *  plus `getArtifact` (bytes-by-id, #197) and `dispose` for worker teardown. */
+ *  plus `export` (#216), `getArtifact` (bytes-by-id, #197), and `dispose` for
+ *  worker teardown. */
 export type SessionInbound =
   | { type: 'setProject'; files: ProjectFile[]; entryPoint?: string }
   | { type: 'updateFile'; path: string; content: string }
   | { type: 'removeFile'; path: string }
   | { type: 'setEntryPoint'; path: string }
+  | { type: 'export'; format: SessionExportFormat }
   | { type: 'getArtifact'; artifactId: string; requestId: string }
   | { type: 'cancel' }
   | { type: 'dispose' };
@@ -164,6 +176,16 @@ export function validateSessionInbound(data: unknown): SessionValidation {
       if (path === undefined) return err('invalid-payload', 'path must be a string');
       if (path.length > SESSION_MAX_PATH_LENGTH) return err('too-large', 'path is too long');
       return { ok: true, message: { type: data.type, path } };
+    }
+    case 'export': {
+      // Fire-and-observe like the mutation commands: the terminal arrives on the
+      // push stream as a `kind: 'export'` OperationResult (success with an
+      // ArtifactRef to then fetch via getArtifact, or a failure).
+      const format = readString(data.format);
+      if (format === undefined || !(SESSION_EXPORT_FORMATS as readonly string[]).includes(format)) {
+        return err('invalid-payload', `format must be one of ${SESSION_EXPORT_FORMATS.join(', ')}`);
+      }
+      return { ok: true, message: { type: 'export', format: format as SessionExportFormat } };
     }
     case 'getArtifact': {
       // Unlike the push-stream commands, this is a correlated request/response:

--- a/src/session-entry/index.ts
+++ b/src/session-entry/index.ts
@@ -27,6 +27,7 @@ import {
 import { fetchAssetBytes } from '../runtime/fetch-asset.ts';
 import { zipArchives } from '../fs/zip-archives.generated.ts';
 import { selectViewerTransport } from '../viewer-host/transports/select.ts';
+import { WebHostAdapter } from '../state/web-host-adapter.ts';
 import type { GeometryViewer } from '../viewer-host/controller.ts';
 
 /**
@@ -89,7 +90,20 @@ async function main(): Promise<void> {
   // compile — calling `init()` would compile the default state and flash unwanted
   // geometry. Construct the controller LAST; its ctor subscribes then announces
   // `ready`, so the host can send a command the instant it sees readiness.
-  const session = new OpenScadSession(fs, createInitialState(null));
+  //
+  // Host-driven export (#216) deltas vs the app: the HOST saves bytes (via
+  // getArtifact), so the in-page download side effect is a no-op — a webview
+  // can't meaningfully service an <a download> click anyway — and the 3MF
+  // multimaterial picker must never block (there is no UI here; default colors
+  // apply).
+  const state = createInitialState(null);
+  state.params.skipMultimaterialPrompt = true;
+  const host = new (class extends WebHostAdapter {
+    override download(): void {}
+    override downloadBlob(): void {}
+    override playCompletionChime(): void {}
+  })();
+  const session = new OpenScadSession(fs, state, undefined, undefined, host);
   new SessionController(sessionHostOf(session), viewer, selectViewerTransport());
 }
 

--- a/src/session-host/__tests__/controller.test.ts
+++ b/src/session-host/__tests__/controller.test.ts
@@ -31,6 +31,9 @@ class FakeSession implements SessionHost {
   setEntryPoint(path: string) {
     this.calls.push(`setEntryPoint:${path}`);
   }
+  exportArtifact(format: string) {
+    this.calls.push(`export:${format}`);
+  }
   cancel() {
     this.calls.push('cancel');
   }
@@ -134,6 +137,7 @@ describe('SessionController', () => {
         'updateFile',
         'removeFile',
         'setEntryPoint',
+        'export',
         'getArtifact',
         'cancel',
         'dispose',
@@ -151,12 +155,14 @@ describe('SessionController', () => {
     transport.receive({ protocolVersion: V, type: 'updateFile', path: '/a', content: 'y' });
     transport.receive({ protocolVersion: V, type: 'removeFile', path: '/a' });
     transport.receive({ protocolVersion: V, type: 'setEntryPoint', path: '/a' });
+    transport.receive({ protocolVersion: V, type: 'export', format: 'stl' });
     transport.receive({ protocolVersion: V, type: 'cancel' });
     expect(session.calls).toEqual([
       'setProject:1:',
       'updateFile:/a',
       'removeFile:/a',
       'setEntryPoint:/a',
+      'export:stl',
       'cancel',
     ]);
   });

--- a/src/session-host/controller.ts
+++ b/src/session-host/controller.ts
@@ -17,6 +17,7 @@ import {
   sessionReady,
   validateSessionInbound,
 } from '../protocol/session-transport.ts';
+import type { SessionExportFormat } from '../protocol/session-transport.ts';
 import type { ArtifactRef, OperationResult, ProjectFile } from '../protocol/session-contract.ts';
 import type { Transport } from '../viewer-host/transport.ts';
 
@@ -26,6 +27,10 @@ export interface SessionHost {
   updateFile(path: string, content: string): void;
   removeFile(path: string): void;
   setEntryPoint(path: string): void;
+  /** Export the current model as `format` (#216). Fire-and-observe: the terminal
+   *  lands on the operation stream as a `kind: 'export'` result (success with an
+   *  ArtifactRef, or a failure — e.g. a dimensionality mismatch). */
+  exportArtifact(format: SessionExportFormat): void;
   cancel(): void;
   dispose(): void;
   /** Subscribe to terminal operation results (the Model's `'operation'` stream);
@@ -86,6 +91,9 @@ export class SessionController {
           break;
         case 'setEntryPoint':
           this.session.setEntryPoint(msg.path);
+          break;
+        case 'export':
+          this.session.exportArtifact(msg.format);
           break;
         case 'getArtifact':
           void this.sendArtifact(msg.requestId, msg.artifactId);

--- a/src/session-host/session-host.ts
+++ b/src/session-host/session-host.ts
@@ -12,6 +12,7 @@ export function sessionHostOf(session: OpenScadSession): SessionHost {
     updateFile: (path, content) => session.updateFile(path, content),
     removeFile: (path) => session.removeFile(path),
     setEntryPoint: (path) => session.setEntryPoint(path),
+    exportArtifact: (format) => session.exportArtifact(format),
     cancel: () => session.cancel(),
     dispose: () => session.dispose(),
     onOperation: (handler) => {

--- a/src/state/__tests__/project-contract.test.ts
+++ b/src/state/__tests__/project-contract.test.ts
@@ -267,6 +267,43 @@ describe('#123 multi-file project contract — headless end to end', () => {
     expect(model.state.params.activePath).toBe('/home/main.scad');
   });
 
+  it('exportArtifact drives a kind:export success carrying the requested format (#216)', async () => {
+    const backend = new FakeBackend();
+    const { model, ops } = makeModel(backend);
+    model.setProject([{ path: 'main.scad', content: 'cube(1);' }], 'main.scad');
+    await settle();
+    expect(ops.find((o) => o.status === 'success' && o.artifact)).toBeDefined();
+
+    model.exportArtifact('stl');
+    await settle();
+
+    const exported = ops.find((o) => o.kind === 'export');
+    expect(exported).toBeDefined();
+    expect(exported!.status).toBe('success');
+    if (exported!.status === 'success') {
+      expect(exported!.artifact?.format).toBe('stl');
+      // The export's exact bytes are retrievable by id — the getArtifact flow.
+      expect(model.getStoredArtifact(exported!.artifact!.artifactId)).toBeDefined();
+    }
+  });
+
+  it('exportArtifact terminates a dimensionality mismatch as an export failure, not silence (#216)', async () => {
+    const { model, ops } = makeModel(new FakeBackend());
+    model.setProject([{ path: 'main.scad', content: 'cube(1);' }], 'main.scad');
+    await settle();
+
+    model.exportArtifact('svg'); // 2D format, 3D model
+    await settle();
+
+    const exported = ops.find((o) => o.kind === 'export');
+    expect(exported).toBeDefined();
+    expect(exported!.status).toBe('error');
+    if (exported!.status === 'error') {
+      expect(exported!.code).toBe('export-format-mismatch');
+      expect(exported!.reason).toMatch(/3D/);
+    }
+  });
+
   it('cancel() surfaces a terminal cancelled result for the in-flight compile', async () => {
     const backend = new FakeBackend();
     const { model, ops } = makeModel(backend);

--- a/src/state/__tests__/project-contract.test.ts
+++ b/src/state/__tests__/project-contract.test.ts
@@ -49,9 +49,12 @@ class FakeBackend implements CompileBackend {
 }
 
 let urlN = 0;
+const revokedUrls: string[] = [];
 const host = {
   createObjectURL: () => `blob:fake-${urlN++}`,
-  revokeObjectURL: () => {},
+  revokeObjectURL: (url: string) => {
+    revokedUrls.push(url);
+  },
   download: () => {},
   downloadBlob: () => {},
   playCompletionChime: () => {},
@@ -112,6 +115,7 @@ describe('#123 multi-file project contract — headless end to end', () => {
   beforeEach(() => {
     vi.useFakeTimers();
     fsStore.clear();
+    revokedUrls.length = 0;
   });
   afterEach(() => vi.useRealTimers());
 
@@ -284,6 +288,74 @@ describe('#123 multi-file project contract — headless end to end', () => {
       expect(exported!.artifact?.format).toBe('stl');
       // The export's exact bytes are retrievable by id — the getArtifact flow.
       expect(model.getStoredArtifact(exported!.artifact!.artifactId)).toBeDefined();
+    }
+  });
+
+  it('exportArtifact does not mutate the persisted format settings, and off pass-through works (#216 review)', async () => {
+    const { model, ops } = makeModel(new FakeBackend());
+    model.setProject([{ path: 'main.scad', content: 'cube(1);' }], 'main.scad');
+    await settle();
+
+    // 'off' pass-through: the preview output IS the OFF — same artifact identity.
+    model.exportArtifact('off');
+    await settle();
+    const exported = ops.find((o) => o.kind === 'export');
+    expect(exported?.status).toBe('success');
+    if (exported?.status === 'success') {
+      expect(exported.artifact?.format).toBe('off');
+    }
+    // The persisted settings are untouched (a per-request format must not flip
+    // subsequent previews' render format — the review's pollution finding).
+    expect(model.state.params.exportFormat3D).toBe('stl');
+    expect(model.state.params.exportFormat2D).toBe('svg');
+  });
+
+  it("an export's ArtifactRef carries the CONSUMED output's revision, not the edit counter (#216 review)", async () => {
+    const { model, ops } = makeModel(new FakeBackend());
+    model.setProject([{ path: 'main.scad', content: 'cube(1);' }], 'main.scad');
+    await settle();
+    const preview = ops.find((o) => o.status === 'success' && o.artifact);
+    expect(preview).toBeDefined();
+    const previewRevision = (preview as { artifact: { sourceRevision: number } }).artifact
+      .sourceRevision;
+
+    // Edit (bumps the revision) then export IMMEDIATELY — before the new
+    // preview lands. The export converts the OLD output and must say so.
+    model.updateFile('/home/main.scad', 'cube(2);');
+    model.exportArtifact('stl');
+    await settle();
+
+    const exported = ops.find((o) => o.kind === 'export' && o.status === 'success');
+    expect(exported).toBeDefined();
+    expect((exported as { artifact: { sourceRevision: number } }).artifact.sourceRevision).toBe(
+      previewRevision,
+    );
+  });
+
+  it('a pass-through export does not let a later conversion revoke the live output URL (#216 review)', async () => {
+    const { model, ops } = makeModel(new FakeBackend());
+    model.setProject([{ path: 'main.scad', content: 'cube(1);' }], 'main.scad');
+    await settle();
+    const outputUrl = model.state.output!.outFileURL;
+
+    model.exportArtifact('off'); // pass-through: aliases the output URL
+    await settle();
+    model.exportArtifact('stl'); // conversion: must NOT revoke the aliased URL
+    await settle();
+
+    expect(ops.filter((o) => o.kind === 'export' && o.status === 'success')).toHaveLength(2);
+    expect(revokedUrls).not.toContain(outputUrl);
+  });
+
+  it('exportArtifact before any completed compile fails with no-output, not a misleading mismatch (#216 review)', async () => {
+    const { model, ops } = makeModel(new FakeBackend());
+    // No compile has run (makeModel never calls init()).
+    model.exportArtifact('svg');
+    await settle();
+    const exported = ops.find((o) => o.kind === 'export');
+    expect(exported?.status).toBe('error');
+    if (exported?.status === 'error') {
+      expect(exported.code).toBe('no-output');
     }
   });
 

--- a/src/state/formats.ts
+++ b/src/state/formats.ts
@@ -13,6 +13,10 @@ export const VALID_EXPORT_FORMATS_3D = {
   '3mf': true,
 };
 
+/** Any exportable format, 2D or 3D — the host-facing export surface (#216). */
+export type ExportFormat =
+  keyof typeof VALID_EXPORT_FORMATS_2D | keyof typeof VALID_EXPORT_FORMATS_3D;
+
 export function is2DFormatExtension(ext: string) {
   return ext === 'svg' || ext === 'dxf';
 }

--- a/src/state/model.ts
+++ b/src/state/model.ts
@@ -338,17 +338,16 @@ export class Model extends EventTarget {
 
   /**
    * Export the current model as `format` (#216, the wire-drivable variant of
-   * `export()`): select the format, then run the standard export flow. A
-   * dimensionality mismatch (e.g. `svg` for a 3D model) terminates as an
-   * export-kind FAILURE on the operation stream rather than silently exporting
-   * the other dimensionality's configured format — a wire host observes results,
-   * not state, so silence would strand it. Pre-compile (`is2D` unknown) the
-   * model is treated as 3D, matching the export flow's own routing.
+   * `export()`). The format travels as an explicit argument — NEVER via the
+   * persisted `exportFormat2D/3D` settings, which would silently flip subsequent
+   * 2D previews' render format. Every rejection terminates as an export-kind
+   * FAILURE on the operation stream — a wire host observes results, not state,
+   * so silence would strand it: `no-output` before any completed compile
+   * (exports convert the LAST completed output), `export-format-mismatch` for
+   * the wrong dimensionality.
    */
   exportArtifact(format: ExportFormat): void {
-    const want2D = is2DFormatExtension(format);
-    const is2D = !!this.state.is2D;
-    if (want2D !== is2D) {
+    const fail = (code: string, reason: string) =>
       this.dispatchEvent(
         new CustomEvent('operation', {
           detail: operationFailure(
@@ -361,18 +360,28 @@ export class Model extends EventTarget {
               diagnostics: [],
               logText: '',
             },
-            'export-format-mismatch',
-            `cannot export ${format}: the current model is ${is2D ? '2D' : '3D'}`,
+            code,
+            reason,
           ),
         }),
       );
+    if (!this.state.output) {
+      fail(
+        'no-output',
+        'nothing to export yet: exports convert the last completed output — wait for a success result first',
+      );
       return;
     }
-    this.mutate((s) => {
-      if (want2D) s.params.exportFormat2D = format as keyof typeof VALID_EXPORT_FORMATS_2D;
-      else s.params.exportFormat3D = format as keyof typeof VALID_EXPORT_FORMATS_3D;
-    });
-    void this.exportService.export();
+    const want2D = is2DFormatExtension(format);
+    const is2D = !!this.state.is2D;
+    if (want2D !== is2D) {
+      fail(
+        'export-format-mismatch',
+        `cannot export ${format}: the current model is ${is2D ? '2D' : '3D'}`,
+      );
+      return;
+    }
+    void this.exportService.export(format);
   }
 
   /** Creates a new empty .scad file in /home/ and activates it. */

--- a/src/state/model.ts
+++ b/src/state/model.ts
@@ -6,7 +6,12 @@ import {
   State,
   StatePersister,
 } from './app-state.ts';
-import { VALID_EXPORT_FORMATS_2D, VALID_EXPORT_FORMATS_3D } from './formats.ts';
+import {
+  is2DFormatExtension,
+  VALID_EXPORT_FORMATS_2D,
+  VALID_EXPORT_FORMATS_3D,
+  type ExportFormat,
+} from './formats.ts';
 import type { OpenScadValue } from '../openscad-value.ts';
 import { bubbleUpDeepMutations } from './deep-mutate.ts';
 import { openLocalFile, saveViaHandle } from '../fs/filesystem.ts';
@@ -16,7 +21,7 @@ import { ProjectStore, type ProjectFile } from './project-store.ts';
 import { canonicalProjectHomePath } from '../fs/project-path.ts';
 import { HostAdapter, WebHostAdapter } from './web-host-adapter.ts';
 import { WasmWorkerBackend, type CompileBackend } from '../runner/openscad-runner.ts';
-import { newId } from '../runner/compile-contract.ts';
+import { newId, operationFailure } from '../runner/compile-contract.ts';
 import { ArtifactStore, type StoredArtifact } from './artifact-store.ts';
 import { applyUserFacingError } from './apply-user-facing-error.ts';
 import { CompileCoordinator } from './services/compile-coordinator.ts';
@@ -329,6 +334,45 @@ export class Model extends EventTarget {
 
   export() {
     return this.exportService.export();
+  }
+
+  /**
+   * Export the current model as `format` (#216, the wire-drivable variant of
+   * `export()`): select the format, then run the standard export flow. A
+   * dimensionality mismatch (e.g. `svg` for a 3D model) terminates as an
+   * export-kind FAILURE on the operation stream rather than silently exporting
+   * the other dimensionality's configured format — a wire host observes results,
+   * not state, so silence would strand it. Pre-compile (`is2D` unknown) the
+   * model is treated as 3D, matching the export flow's own routing.
+   */
+  exportArtifact(format: ExportFormat): void {
+    const want2D = is2DFormatExtension(format);
+    const is2D = !!this.state.is2D;
+    if (want2D !== is2D) {
+      this.dispatchEvent(
+        new CustomEvent('operation', {
+          detail: operationFailure(
+            {
+              sessionId: this.sessionId,
+              operationId: newId(),
+              sourceRevision: this._sourceRevision,
+              kind: 'export',
+              elapsedMillis: 0,
+              diagnostics: [],
+              logText: '',
+            },
+            'export-format-mismatch',
+            `cannot export ${format}: the current model is ${is2D ? '2D' : '3D'}`,
+          ),
+        }),
+      );
+      return;
+    }
+    this.mutate((s) => {
+      if (want2D) s.params.exportFormat2D = format as keyof typeof VALID_EXPORT_FORMATS_2D;
+      else s.params.exportFormat3D = format as keyof typeof VALID_EXPORT_FORMATS_3D;
+    });
+    void this.exportService.export();
   }
 
   /** Creates a new empty .scad file in /home/ and activates it. */

--- a/src/state/services/export-service.ts
+++ b/src/state/services/export-service.ts
@@ -18,6 +18,7 @@ import { isExpectedJobCancellation, type ProcessStreams } from '../../runner/ope
 import { isUserFacingOperationError, normalizeOperationFailure } from '../../user-facing-errors.ts';
 import { formatBytes, formatMillis, type AbortablePromise } from '../../utils.ts';
 import { applyUserFacingError } from '../apply-user-facing-error.ts';
+import type { ExportFormat } from '../formats.ts';
 import type { ServiceContext } from './service-context.ts';
 
 /**
@@ -85,7 +86,14 @@ export class ExportService {
     }
   }
 
-  async export() {
+  /**
+   * Export the current output. With no argument (the app's export button) the
+   * target format comes from the persisted `exportFormat2D/3D` settings; a wire
+   * host passes `requested` explicitly (#216) so a per-request format never
+   * mutates persistent state (which would silently flip subsequent 2D previews'
+   * render format — and via the pass-through, could even mislabel the result).
+   */
+  async export(requested?: ExportFormat) {
     const { mutate, host } = this.ctx;
     // Claim the export token at entry — before any early return — so that EVERY
     // export (pass-through, picker, or async conversion) supersedes an in-flight
@@ -120,12 +128,14 @@ export class ExportService {
     // Snapshot is safe: export never mutates output/params/is2D, only the
     // export/exporting/error/log/view fields it writes via the mutate callback.
     const state = this.ctx.getState();
+    const targetFormat: ExportFormat =
+      requested ?? (state.is2D ? state.params.exportFormat2D : state.params.exportFormat3D);
     if (state.output) {
-      // The preview/render output is already in the target format (the SVG for a
-      // 2D model, the OFF for a 3D `off` export), so download it directly.
-      const normalPassThrough =
-        (state.is2D && state.params.exportFormat2D === 'svg') ||
-        (!state.is2D && state.params.exportFormat3D === 'off');
+      // The rendered output is ALREADY in the target format (the SVG/DXF of a 2D
+      // preview, the OFF of a 3D one), so download it directly. Keyed on the
+      // output file's ACTUAL format, not a format setting — a setting can point
+      // at a format the current output is not (review of #216, mislabeling).
+      const normalPassThrough = formatOfName(state.output.outFile.name) === targetFormat;
 
       if (normalPassThrough) {
         // Synchronous, so this export stays current through commit. Clear
@@ -153,7 +163,7 @@ export class ExportService {
         return;
       }
     }
-    if (!state.is2D && state.params.exportFormat3D == '3mf' && !state.params.extruderColors) {
+    if (!state.is2D && targetFormat == '3mf' && !state.params.extruderColors) {
       if (!state.params.skipMultimaterialPrompt) {
         // Showing the picker ends this export request; take spinner ownership.
         mutate((s) => {
@@ -178,8 +188,8 @@ export class ExportService {
         throw new Error('No output file to export');
       }
 
-      const { features, exportFormat2D, exportFormat3D } = state.params;
-      const exportFormat = state.is2D ? exportFormat2D : exportFormat3D;
+      const { features } = state.params;
+      const exportFormat = targetFormat;
       let output: RenderOutput;
       if (exportFormat === '3mf') {
         const start = performance.now();
@@ -251,7 +261,10 @@ export class ExportService {
       // One immutable artifact id, shared by state.export and the store entry, so
       // getArtifact(artifactId) returns these exact exported bytes (ADR 0008).
       const artifactId = newId();
-      const sourceRevision = this.ctx.getSourceRevision();
+      // The ref carries the GEOMETRY's provenance — the revision of the output
+      // this conversion consumed — matching the pass-through branch. Stamping the
+      // current counter would claim a just-edited revision for old geometry.
+      const sourceRevision = state.output.sourceRevision;
       const format = formatOfName(output.outFile.name);
       const artifactRef = {
         artifactId,
@@ -265,7 +278,13 @@ export class ExportService {
       this.ctx.artifacts.put(output.outFile, artifactRef);
       mutate((s) => {
         s.exporting = false;
-        if (s.export?.outFileURL?.startsWith('blob:') ?? false) {
+        // A prior pass-through export ALIASES the live output's URL
+        // (s.export = s.output); revoking it would break the next conversion's
+        // worker fetch of state.output.outFileURL (review of #216).
+        if (
+          (s.export?.outFileURL?.startsWith('blob:') ?? false) &&
+          s.export!.outFileURL !== s.output?.outFileURL
+        ) {
           host.revokeObjectURL(s.export!.outFileURL);
         }
         s.export = {

--- a/src/state/session.ts
+++ b/src/state/session.ts
@@ -6,6 +6,7 @@ import type { ProjectFile, ProjectContract } from './project-contract.ts';
 import type { ProjectFileSystem } from '../fs/project-filesystem.ts';
 import type { State, StatePersister } from './app-state.ts';
 import type { HostAdapter } from './web-host-adapter.ts';
+import type { ExportFormat } from './formats.ts';
 
 /**
  * An instance-scoped OpenSCAD session: the unit of isolation (ADR 0007). It owns
@@ -61,6 +62,12 @@ export class OpenScadSession implements ProjectContract {
   }
   setEntryPoint(path: string): void {
     this.model.setEntryPoint(path);
+  }
+
+  /** Export the current model as `format` (#216); the terminal lands on the
+   *  operation stream as a `kind: 'export'` result. */
+  exportArtifact(format: ExportFormat): void {
+    this.model.exportArtifact(format);
   }
 
   /** Cancel this session's in-flight compile/export operations (#123). */

--- a/tests/session.spec.ts
+++ b/tests/session.spec.ts
@@ -20,7 +20,15 @@ declare global {
   interface Window {
     __sessionMessages?: {
       type?: string;
-      result?: { status?: string; artifact?: { format?: string } };
+      result?: {
+        status?: string;
+        kind?: string;
+        artifact?: { format?: string; artifactId?: string };
+      };
+      requestId?: string;
+      available?: boolean;
+      artifact?: { format?: string };
+      bytes?: Uint8Array;
     }[];
   }
 }
@@ -107,5 +115,60 @@ test.describe('session distributable (#193)', () => {
       window.__sessionMessages?.some((m) => m?.type === 'error'),
     );
     expect(hadError).toBeFalsy();
+
+    // Export round-trip (#216 + #197): trigger a real STL export over the wire,
+    // then fetch the produced artifact's exact bytes by id. This is the flow a
+    // VS Code host uses to save STL/3MF to disk.
+    await postToSession(page, { protocolVersion, type: 'export', format: 'stl' });
+    await page.waitForFunction(
+      () =>
+        window.__sessionMessages?.some(
+          (m) =>
+            m?.type === 'operation-result' &&
+            m?.result?.kind === 'export' &&
+            m?.result?.status === 'success' &&
+            m?.result?.artifact?.format === 'stl',
+        ),
+      null,
+      { timeout: 60_000 },
+    );
+    const artifactId = await page.evaluate(
+      () =>
+        window.__sessionMessages?.find(
+          (m) =>
+            m?.type === 'operation-result' &&
+            m?.result?.kind === 'export' &&
+            m?.result?.status === 'success',
+        )?.result?.artifact?.artifactId,
+    );
+    expect(artifactId).toBeTruthy();
+
+    await postToSession(page, {
+      protocolVersion,
+      type: 'getArtifact',
+      artifactId,
+      requestId: 'e2e-stl',
+    });
+    await page.waitForFunction(
+      () =>
+        window.__sessionMessages?.some(
+          (m) => m?.type === 'artifact' && m?.requestId === 'e2e-stl' && m?.available === true,
+        ),
+      null,
+      { timeout: 30_000 },
+    );
+    // The bytes arrived as a genuine byte payload with STL content ("solid ..."
+    // ASCII or the binary layout — both start beyond zero length).
+    const byteProbe = await page.evaluate(() => {
+      const reply = window.__sessionMessages?.find(
+        (m) => m?.type === 'artifact' && m?.requestId === 'e2e-stl',
+      );
+      const bytes = reply?.bytes;
+      return bytes instanceof Uint8Array
+        ? { isU8: true, length: bytes.byteLength, head: Array.from(bytes.slice(0, 5)) }
+        : { isU8: false, length: 0, head: [] as number[] };
+    });
+    expect(byteProbe.isU8).toBe(true);
+    expect(byteProbe.length).toBeGreaterThan(0);
   });
 });

--- a/tests/session.spec.ts
+++ b/tests/session.spec.ts
@@ -61,6 +61,13 @@ async function embedSession(page: Page): Promise<void> {
   );
 }
 
+async function postToSession(page: Page, message: object): Promise<void> {
+  await page.evaluate((msg) => {
+    const frame = document.getElementById('session-frame') as HTMLIFrameElement;
+    frame.contentWindow!.postMessage(msg, window.location.origin);
+  }, message);
+}
+
 test.describe('session distributable (#193)', () => {
   test.skip(!sessionServed, 'requires E2E_SERVER_MODE=session (dist-session served)');
 


### PR DESCRIPTION
## Summary

STL/3MF/GLB become reachable from a host: the new **`export { format }`** command (stl/off/glb/3mf/svg/dxf) drives the standard `ExportService` flow; the terminal lands on the push stream as a `kind:'export'` `OperationResult` whose `ArtifactRef` is then fetched via the existing `getArtifact` (#197). Fire-and-observe like the mutation commands — no new bytes path. Still protocol v2 (never shipped since the #197 bump).

- The format is **per-request** — never written to the persisted export settings, so it can't flip subsequent 2D previews' render format.
- Every rejection is a terminal failure result, never silence: `no-output` before a first completed compile, `export-format-mismatch` for the wrong dimensionality.
- An export converts the **last completed output**; its `ArtifactRef` carries that geometry's `sourceRevision` so a host can detect "exported before my edit's preview landed".
- Session entry: the in-page download side effect + completion chime are no-ops (the host owns saving) and `skipMultimaterialPrompt` is set so 3MF can never block on the picker UI.

## Review — 3 real export bugs found and fixed (all pre-existing in the app UI too)

The adversarial pass reproduced: **(1)** pass-through mislabeling — keyed on the format *setting*, a 2D session whose last preview rendered DXF answered an `svg` request with a SUCCESS carrying DXF bytes → pass-through now keys on the output file's *actual* format; **(2)** revision mislabeling — conversions stamped the current edit counter onto older geometry → the ref now carries the consumed output's revision; **(3)** blob-URL aliasing — a pass-through export aliases the live output's URL and a later conversion revoked it, breaking the next conversion's worker fetch → revoke skips the aliased case. Verified clean by the review: GLB's lazy `GLTFExporter` chunk **is** in `dist-session` and gate-walked (the flagged highest risk); the 3MF no-picker path proceeds; the synthetic failure result is shape-identical to real ones; no other `'operation'` consumer can be confused. Deferred with an issue: exports derive from preview-quality geometry (`$preview=true`) — full-render export filed as **#219** and documented as a caveat.

## Testing

- 76 unit files pass; new coverage: transport format allowlist, controller dispatch, capstone export success (STL retrievable by id), `off` pass-through + settings-untouched, revision-provenance under edit-then-export, revoke-aliasing guard, `no-output`, dimensionality mismatch.
- Real-WASM e2e runs the full host loop: compile → `export stl` → export-kind success → `getArtifact` → STL bytes.
- `build:session` green (protocol emit v2, bundle gate, manifest).

Closes #216.