### PR TITLE
chore(release): v0.3.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,15 @@ release (changelog upkeep and tagging had lapsed between `0.1.0` and `0.2.0`).
 
 ## [Unreleased]
 
+## [0.3.0] - 2026-07-03
+
+The live-session release: the compile-capable `dist-session` distributable is
+now fully host-drivable over the Layer-1 wire (protocol **v2**) — push a
+multi-file project (text + binary assets), observe the result stream, trigger
+exports, and fetch artifact bytes by id. This is the upstream half of the VS
+Code extension's live `.scad` preview + export (epic #179; consumer epic
+openscad-web-vscode#8).
+
 ### Fixed
 
 - Export (found by #216's adversarial review; all three pre-existing in the app

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "openscad-web",
-  "version": "0.2.0",
+  "version": "0.3.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "openscad-web",
-      "version": "0.2.0",
+      "version": "0.3.0",
       "dependencies": {
         "@monaco-editor/loader": "^1.4.0",
         "blurhash": "^2.0.5",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "openscad-web",
-  "version": "0.2.0",
+  "version": "0.3.0",
   "private": true,
   "type": "module",
   "homepage": "https://cameronbrooks11.github.io/openscad-web/",


### PR DESCRIPTION
Version bump + CHANGELOG cut for **v0.3.0** — the live-session release (L1 protocol v2: getArtifact #197, binary assets #172, export #216, export correctness fixes). Tag + GitHub release follow the merge.