### PR TITLE
fix(export): ship the conversion input as content, not a blob URL (v0.3.1)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,20 @@ release (changelog upkeep and tagging had lapsed between `0.1.0` and `0.2.0`).
 
 ## [Unreleased]
 
+## [0.3.1] - 2026-07-03
+
+### Fixed
+
+- Export conversion (STL/DXF/…) failed inside a VS Code webview: the worker
+  received the rendered output as a blob URL, whose origin can never match the
+  webview's asset-base origin under the external-source policy (blob URLs mint
+  under the webview's own opaque origin). The conversion input now ships as
+  plain content, which works on every host. Found by the extension's EDH
+  export test the moment v0.3.0 was vendored. Side effects: the accidental
+  2 MiB cap on conversion inputs (the URL fetch path's external-source limit)
+  is gone — conversions of large outputs now work — and `cancel()` during the
+  input read now cancels the export instead of silently no-op'ing.
+
 ## [0.3.0] - 2026-07-03
 
 The live-session release: the compile-capable `dist-session` distributable is

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "openscad-web",
-  "version": "0.3.0",
+  "version": "0.3.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "openscad-web",
-      "version": "0.3.0",
+      "version": "0.3.1",
       "dependencies": {
         "@monaco-editor/loader": "^1.4.0",
         "blurhash": "^2.0.5",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "openscad-web",
-  "version": "0.3.0",
+  "version": "0.3.1",
   "private": true,
   "type": "module",
   "homepage": "https://cameronbrooks11.github.io/openscad-web/",

--- a/src/state/services/__tests__/export-service.test.ts
+++ b/src/state/services/__tests__/export-service.test.ts
@@ -38,6 +38,11 @@ import type { OperationResult } from '../../../runner/compile-contract.ts';
  * own and kill the in-flight render. The promise stays pending until `resolve`
  * (or `reject`) is called by the test.
  */
+/** Flush the conversion branch's `await outFile.text()` so the export reaches
+ *  its renderExport spawn before the test's next action (the input is shipped
+ *  as content now — the spawn is no longer synchronous). */
+const tick = () => new Promise((r) => setTimeout(r, 0));
+
 function hangingRender() {
   let resolve!: (v: RenderOutput) => void;
   let reject!: (e: unknown) => void;
@@ -198,6 +203,13 @@ describe('ExportService', () => {
     expect(mockRenderExport).toHaveBeenCalledTimes(1);
     // Export runs on its own scheduling priority (preempts background compiles).
     expect(mockRenderExport.mock.calls[0][0].priority).toBe('export');
+    // The conversion input ships as CONTENT, never a blob URL: a webview blob
+    // URL's origin can never satisfy the worker's external-source policy
+    // (v0.3.1 regression guard).
+    const inputSource = mockRenderExport.mock.calls[0][0].sources[1];
+    expect(inputSource.path).toBe('m.off');
+    expect(inputSource.content).toBe('x');
+    expect(inputSource.url).toBeUndefined();
     expect(host.download).toHaveBeenCalledWith('blob:new', 'model.stl');
     // The committed export's artifactId resolves in the store to the exact File
     // (shared id, byte-identical write-through — ADR 0008).
@@ -230,6 +242,7 @@ describe('ExportService', () => {
     mockRenderExport.mockReturnValueOnce(first.inner).mockReturnValueOnce(secondInner);
 
     const p1 = svc.export(); // token 1 — awaits the hanging conversion
+    await tick(); // let it reach the (hanging) renderExport spawn
     const p2 = svc.export(); // token 2 — resolves and commits
     await p2;
     // The superseding export killed the first render job.
@@ -248,6 +261,53 @@ describe('ExportService', () => {
     expect(getState().exporting).toBe(false);
     // Two terminal results: the superseded op is cancelled, the newer succeeds.
     expect(results.map((r) => r.status).sort()).toEqual(['cancelled', 'success']);
+  });
+
+  it('an export superseded during the input read cancels without spawning its render', async () => {
+    const { ctx, host, getState, results } = makeCtx({
+      is2D: false,
+      exportFormat3D: 'stl',
+      output: fileOutput('m.off'),
+    });
+    const svc = new ExportService(ctx);
+    const secondInner = vi.fn().mockResolvedValue({
+      outFile: new File(['second'], 'second.stl'),
+      logText: '',
+      markers: [],
+      elapsedMillis: 1,
+    });
+    mockRenderExport.mockReturnValueOnce(secondInner);
+
+    // NO tick between them: export 1 is still awaiting outFile.text() when
+    // export 2 supersedes it, so export 1 must cancel pre-spawn — consuming NO
+    // mocked render (the single mock belongs to export 2).
+    const p1 = svc.export();
+    const p2 = svc.export();
+    await Promise.all([p1, p2]);
+
+    expect(mockRenderExport).toHaveBeenCalledTimes(1);
+    expect(host.download.mock.calls.map((c) => c[1])).toEqual(['second.stl']);
+    expect(results.map((r) => r.status).sort()).toEqual(['cancelled', 'success']);
+    expect(getState().exporting).toBe(false);
+  });
+
+  it('cancel() during the input read cancels pre-spawn and clears the spinner', async () => {
+    const { ctx, host, getState, results } = makeCtx({
+      is2D: false,
+      exportFormat3D: 'stl',
+      output: fileOutput('m.off'),
+    });
+    const svc = new ExportService(ctx);
+
+    const p = svc.export(); // suspended at the outFile.text() read
+    svc.cancel(); // no job exists yet — the mark must still take effect
+    await p;
+
+    expect(mockRenderExport).not.toHaveBeenCalled();
+    expect(host.download).not.toHaveBeenCalled();
+    expect(getState().exporting).toBe(false); // still-current → clears its own spinner
+    expect(results).toHaveLength(1);
+    expect(results[0].status).toBe('cancelled');
   });
 
   it('treats a superseded (cancelled) export as supersession, not a user-facing error', async () => {
@@ -279,6 +339,7 @@ describe('ExportService', () => {
     mockRenderExport.mockReturnValueOnce(first.inner);
 
     const p1 = svc.export(); // token 1 — STL conversion hangs, exporting=true
+    await tick(); // let it reach the (hanging) renderExport spawn
     // User switches to a pass-through format (OFF) and exports again.
     ctx.mutate((s) => {
       s.params.exportFormat3D = 'off';
@@ -314,6 +375,7 @@ describe('ExportService', () => {
     mockRenderExport.mockReturnValueOnce(first.inner);
 
     const p1 = svc.export(); // token 1 — exporting=true
+    await tick(); // let it reach the (hanging) renderExport spawn
     // User switches to 3MF (no extruder colors) and exports → the picker shows.
     ctx.mutate((s) => {
       s.params.exportFormat3D = '3mf';
@@ -355,6 +417,7 @@ describe('ExportService', () => {
     mockRenderExport.mockReturnValueOnce(first.inner).mockReturnValueOnce(secondInner);
 
     const p1 = svc.export(); // token 1 — hangs
+    await tick(); // let it reach the (hanging) renderExport spawn
     const p2 = svc.export(); // token 2 — resolves and commits
     await p2;
     // The stale first export now fails with a non-cancellation error.
@@ -393,7 +456,7 @@ describe('ExportService', () => {
     const svc = new ExportService(ctx);
 
     const p = svc.export(); // worker-conversion branch; sets _activeRender, awaits
-    await Promise.resolve();
+    await tick();
     expect(getState().exporting).toBe(true);
 
     svc.cancel();

--- a/src/state/services/export-service.ts
+++ b/src/state/services/export-service.ts
@@ -70,10 +70,17 @@ export class ExportService {
 
   /** Cancel an in-flight format-conversion render (best-effort, #123). The killed
    *  job rejects with an expected cancellation, so the existing catch emits one
-   *  terminal `cancelled` result and clears the exporting spinner. */
+   *  terminal `cancelled` result and clears the exporting spinner. The mark also
+   *  covers the pre-spawn window (reading the conversion input is async now):
+   *  an export cancelled before its job exists checks the mark after the read. */
   cancel(): void {
+    this._cancelledToken = this._exportSeq;
     this._activeRender?.kill();
   }
+
+  /** The export token cancel() was called against (-1 = none) — lets an export
+   *  that has not yet spawned its job observe the cancellation. */
+  private _cancelledToken = -1;
 
   /** Route a terminal result to the optional sink, guarding the commit path: a
    *  throwing sink must never corrupt committed state or double-emit (ADR 0008).
@@ -220,17 +227,40 @@ export class ExportService {
           markers: [],
         };
       } else {
+        // Ship the rendered output's CONTENT, not its blob URL: the worker's
+        // external-source policy requires a blob URL's origin to match the base
+        // origin, which holds on a normal page but not in a VS Code webview
+        // (blob URLs mint under the webview's own opaque origin while the asset
+        // base is the vscode-resource origin) — the fetch was rejected outright
+        // and every conversion export failed there. The output is OFF/SVG text,
+        // so the plain content source works everywhere.
+        const inputName = state.output.outFile.name;
+        const inputText = await state.output.outFile.text();
+        if (!isCurrent()) {
+          // Superseded during the read: the newer export owns the spinner.
+          this.emitResult(operationCancelled(base()));
+          return;
+        }
+        if (this._cancelledToken === token) {
+          // cancel() landed during the read, before any job existed: still
+          // current, so clear our own spinner (nothing newer owns it).
+          mutate((s) => {
+            s.exporting = false;
+          });
+          this.emitResult(operationCancelled(base()));
+          return;
+        }
         const job = this._renderExport({
           mountArchives: false,
           scadPath: '/export.scad',
           sources: [
             {
               path: '/export.scad',
-              content: `import("${state.output?.outFile.name}");`,
+              content: `import("${inputName}");`,
             },
             {
-              path: state.output?.outFile.name,
-              url: state.output?.outFileURL,
+              path: inputName,
+              content: inputText,
             },
           ],
           extraArgs: [],
@@ -279,8 +309,9 @@ export class ExportService {
       mutate((s) => {
         s.exporting = false;
         // A prior pass-through export ALIASES the live output's URL
-        // (s.export = s.output); revoking it would break the next conversion's
-        // worker fetch of state.output.outFileURL (review of #216).
+        // (s.export = s.output); that URL is the viewer/download URL of the
+        // LIVE output, so revoking it here would break it for everyone still
+        // holding it (review of #216).
         if (
           (s.export?.outFileURL?.startsWith('blob:') ?? false) &&
           s.export!.outFileURL !== s.output?.outFileURL


### PR DESCRIPTION
## Summary

**Every STL/DXF conversion export failed inside a VS Code webview**: the worker received the rendered output as a blob URL, and the external-source policy requires a blob URL's origin to match the asset-base origin — which can never hold in a webview (blob URLs mint under the webview's opaque origin; the asset base is the `vscode-resource` origin). On a normal page the origins coincide, which is why the browser e2e passed. Found by openscad-web-vscode's new EDH export test the moment v0.3.0 was vendored — the first consumer to run this path in a real webview.

**Fix**: ship the OFF/SVG text as a plain `content` source — origin-independent everywhere. Side effects (both improvements, changelogged): the URL path's accidental **2 MiB cap** on conversion inputs is gone, and a latent race is closed (the coordinator's commit revokes the previous output's blob URL, which could kill an in-flight conversion fetch).

Per this PR's adversarial review (no correctness defects found): `cancel()` during the now-async input read cancels the export pre-spawn instead of silently no-op'ing; regression tests pin content-not-URL sources, the pre-spawn supersession branch, and the pre-spawn cancel; a stale comment fixed.

Includes the **v0.3.1** version bump + CHANGELOG (tag + release follow the merge, then the extension re-vendors).

## Testing

- 626 unit tests (4 new: content-source regression guard, no-tick supersession, pre-spawn cancel, plus the input-source assertions) + 25 e2e; browser session e2e green.
- **Proven against the real webview**: dist-session built from this branch, synced into openscad-web-vscode — all 5 EDH tests pass including `exports the compiled model as STL and receives the bytes` (previously failing).