### PR TITLE
feat(session): echo an export correlation requestId (#223, v0.3.2)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,16 @@ release (changelog upkeep and tagging had lapsed between `0.1.0` and `0.2.0`).
 
 ## [Unreleased]
 
+## [0.3.2] - 2026-07-03
+
+### Added
+
+- Export correlation (#223): `export { format, requestId? }` — the optional id
+  is echoed on every terminal of that export operation (success, failure,
+  cancelled; the `OperationResult` base gains an optional `requestId`).
+  Additive to protocol v2; hosts should always send one, since a superseded
+  export's late terminal is otherwise indistinguishable from the current one's.
+
 ## [0.3.1] - 2026-07-03
 
 ### Fixed

--- a/docs/EMBEDDING-VSCODE.md
+++ b/docs/EMBEDDING-VSCODE.md
@@ -319,7 +319,7 @@ before sending. Then **drive a project** rather than push geometry:
   `bytes` at a text-suffix path must be valid UTF-8 and are treated as text),
   `updateFile { path, content }` (text-only — re-push binary
   changes via `setProject`), `removeFile { path }`, `setEntryPoint { path }`,
-  `export { format }` (`stl`/`off`/`glb`/`3mf`/`svg`/`dxf` — #216),
+  `export { format, requestId? }` (`stl`/`off`/`glb`/`3mf`/`svg`/`dxf` — #216/#223),
   `getArtifact { artifactId, requestId }`, `cancel`, `dispose`.
 - **Session → host:** `ready`, `operation-result { result }` (a **push stream** —
   one edit fans out to multiple terminal results; correlate by the nested
@@ -336,9 +336,11 @@ as a **`Uint8Array`** via structured clone (never base64), or `available: false`
 if the id is unknown, was evicted from the small per-session LRU (fetch promptly
 after the result you want), or its blob read failed.
 
-**Exporting STL/3MF/GLB** (#216): send `export { format }` — the terminal arrives
-on the push stream as a `kind: 'export'` result (fire-and-observe, like the
-mutation commands). On success it carries the converted artifact's `ArtifactRef`;
+**Exporting STL/3MF/GLB** (#216): send `export { format, requestId? }` — the
+terminal arrives on the push stream as a `kind: 'export'` result
+(fire-and-observe, like the mutation commands) **echoing your `requestId`**
+(#223). Always send one and correlate by it: without it, a superseded export's
+late terminal is indistinguishable from the current one's. On success it carries the converted artifact's `ArtifactRef`;
 fetch the bytes with `getArtifact` and save them. Semantics a host should know:
 
 - An export converts the **last completed output**; its

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "openscad-web",
-  "version": "0.3.1",
+  "version": "0.3.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "openscad-web",
-      "version": "0.3.1",
+      "version": "0.3.2",
       "dependencies": {
         "@monaco-editor/loader": "^1.4.0",
         "blurhash": "^2.0.5",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "openscad-web",
-  "version": "0.3.1",
+  "version": "0.3.2",
   "private": true,
   "type": "module",
   "homepage": "https://cameronbrooks11.github.io/openscad-web/",

--- a/src/protocol/__tests__/session-transport.test.ts
+++ b/src/protocol/__tests__/session-transport.test.ts
@@ -227,6 +227,18 @@ describe('validateSessionInbound', () => {
       ok: false,
       code: 'invalid-payload',
     });
+    // Optional correlation id (#223): forwarded when present, validated when given.
+    expect(ok({ type: 'export', format: 'stl', requestId: 'r-9' })).toEqual({
+      ok: true,
+      message: { type: 'export', format: 'stl', requestId: 'r-9' },
+    });
+    expect(ok({ type: 'export', format: 'stl', requestId: 7 })).toMatchObject({
+      ok: false,
+      code: 'invalid-payload',
+    });
+    expect(
+      ok({ type: 'export', format: 'stl', requestId: 'x'.repeat(SESSION_MAX_ID_LENGTH + 1) }),
+    ).toMatchObject({ ok: false, code: 'too-large' });
   });
 
   it('accepts getArtifact and requires string artifactId + requestId', () => {

--- a/src/protocol/session-contract.ts
+++ b/src/protocol/session-contract.ts
@@ -75,6 +75,14 @@ interface OperationResultBase {
   /** Host-neutral markers (ADR 0001). */
   diagnostics: Diagnostic[];
   logText: string;
+  /**
+   * Echo of the initiating command's `requestId`, on every terminal of the
+   * operation it started (#223). Today only `export { requestId? }` threads
+   * one through; absent for operations the session started itself (auto
+   * previews/syntax checks) or when the command carried none. Additive —
+   * optional, so the L1 payload version is unchanged.
+   */
+  requestId?: string;
 }
 
 export interface OperationSuccess extends OperationResultBase {

--- a/src/protocol/session-transport.ts
+++ b/src/protocol/session-transport.ts
@@ -67,7 +67,7 @@ export type SessionInbound =
   | { type: 'updateFile'; path: string; content: string }
   | { type: 'removeFile'; path: string }
   | { type: 'setEntryPoint'; path: string }
-  | { type: 'export'; format: SessionExportFormat }
+  | { type: 'export'; format: SessionExportFormat; requestId?: string }
   | { type: 'getArtifact'; artifactId: string; requestId: string }
   | { type: 'cancel' }
   | { type: 'dispose' };
@@ -180,12 +180,28 @@ export function validateSessionInbound(data: unknown): SessionValidation {
     case 'export': {
       // Fire-and-observe like the mutation commands: the terminal arrives on the
       // push stream as a `kind: 'export'` OperationResult (success with an
-      // ArtifactRef to then fetch via getArtifact, or a failure).
+      // ArtifactRef to then fetch via getArtifact, or a failure). The optional
+      // `requestId` is echoed on that terminal (#223) so a host can correlate a
+      // specific export with its result under supersession — recommended.
       const format = readString(data.format);
       if (format === undefined || !(SESSION_EXPORT_FORMATS as readonly string[]).includes(format)) {
         return err('invalid-payload', `format must be one of ${SESSION_EXPORT_FORMATS.join(', ')}`);
       }
-      return { ok: true, message: { type: 'export', format: format as SessionExportFormat } };
+      const requestId = data.requestId === undefined ? undefined : readString(data.requestId);
+      if (data.requestId !== undefined && requestId === undefined) {
+        return err('invalid-payload', 'requestId must be a string');
+      }
+      if (requestId !== undefined && requestId.length > SESSION_MAX_ID_LENGTH) {
+        return err('too-large', 'an id is too long');
+      }
+      return {
+        ok: true,
+        message: {
+          type: 'export',
+          format: format as SessionExportFormat,
+          ...(requestId !== undefined ? { requestId } : {}),
+        },
+      };
     }
     case 'getArtifact': {
       // Unlike the push-stream commands, this is a correlated request/response:

--- a/src/session-host/__tests__/controller.test.ts
+++ b/src/session-host/__tests__/controller.test.ts
@@ -31,8 +31,8 @@ class FakeSession implements SessionHost {
   setEntryPoint(path: string) {
     this.calls.push(`setEntryPoint:${path}`);
   }
-  exportArtifact(format: string) {
-    this.calls.push(`export:${format}`);
+  exportArtifact(format: string, requestId?: string) {
+    this.calls.push(`export:${format}:${requestId ?? ''}`);
   }
   cancel() {
     this.calls.push('cancel');
@@ -155,14 +155,14 @@ describe('SessionController', () => {
     transport.receive({ protocolVersion: V, type: 'updateFile', path: '/a', content: 'y' });
     transport.receive({ protocolVersion: V, type: 'removeFile', path: '/a' });
     transport.receive({ protocolVersion: V, type: 'setEntryPoint', path: '/a' });
-    transport.receive({ protocolVersion: V, type: 'export', format: 'stl' });
+    transport.receive({ protocolVersion: V, type: 'export', format: 'stl', requestId: 'r1' });
     transport.receive({ protocolVersion: V, type: 'cancel' });
     expect(session.calls).toEqual([
       'setProject:1:',
       'updateFile:/a',
       'removeFile:/a',
       'setEntryPoint:/a',
-      'export:stl',
+      'export:stl:r1',
       'cancel',
     ]);
   });

--- a/src/session-host/controller.ts
+++ b/src/session-host/controller.ts
@@ -29,8 +29,9 @@ export interface SessionHost {
   setEntryPoint(path: string): void;
   /** Export the current model as `format` (#216). Fire-and-observe: the terminal
    *  lands on the operation stream as a `kind: 'export'` result (success with an
-   *  ArtifactRef, or a failure — e.g. a dimensionality mismatch). */
-  exportArtifact(format: SessionExportFormat): void;
+   *  ArtifactRef, or a failure — e.g. a dimensionality mismatch), echoing
+   *  `requestId` when the command carried one (#223). */
+  exportArtifact(format: SessionExportFormat, requestId?: string): void;
   cancel(): void;
   dispose(): void;
   /** Subscribe to terminal operation results (the Model's `'operation'` stream);
@@ -93,7 +94,7 @@ export class SessionController {
           this.session.setEntryPoint(msg.path);
           break;
         case 'export':
-          this.session.exportArtifact(msg.format);
+          this.session.exportArtifact(msg.format, msg.requestId);
           break;
         case 'getArtifact':
           void this.sendArtifact(msg.requestId, msg.artifactId);

--- a/src/session-host/session-host.ts
+++ b/src/session-host/session-host.ts
@@ -12,7 +12,7 @@ export function sessionHostOf(session: OpenScadSession): SessionHost {
     updateFile: (path, content) => session.updateFile(path, content),
     removeFile: (path) => session.removeFile(path),
     setEntryPoint: (path) => session.setEntryPoint(path),
-    exportArtifact: (format) => session.exportArtifact(format),
+    exportArtifact: (format, requestId) => session.exportArtifact(format, requestId),
     cancel: () => session.cancel(),
     dispose: () => session.dispose(),
     onOperation: (handler) => {

--- a/src/state/__tests__/project-contract.test.ts
+++ b/src/state/__tests__/project-contract.test.ts
@@ -278,11 +278,15 @@ describe('#123 multi-file project contract — headless end to end', () => {
     await settle();
     expect(ops.find((o) => o.status === 'success' && o.artifact)).toBeDefined();
 
-    model.exportArtifact('stl');
+    model.exportArtifact('stl', 'req-42');
     await settle();
 
     const exported = ops.find((o) => o.kind === 'export');
     expect(exported).toBeDefined();
+    // The initiating command's correlation id is echoed on the terminal (#223);
+    // session-initiated results (the preview) carry none.
+    expect(exported!.requestId).toBe('req-42');
+    expect(ops.find((o) => o.kind === 'preview')?.requestId).toBeUndefined();
     expect(exported!.status).toBe('success');
     if (exported!.status === 'success') {
       expect(exported!.artifact?.format).toBe('stl');
@@ -364,11 +368,12 @@ describe('#123 multi-file project contract — headless end to end', () => {
     model.setProject([{ path: 'main.scad', content: 'cube(1);' }], 'main.scad');
     await settle();
 
-    model.exportArtifact('svg'); // 2D format, 3D model
+    model.exportArtifact('svg', 'req-7'); // 2D format, 3D model
     await settle();
 
     const exported = ops.find((o) => o.kind === 'export');
     expect(exported).toBeDefined();
+    expect(exported!.requestId).toBe('req-7'); // synthetic failures echo it too (#223)
     expect(exported!.status).toBe('error');
     if (exported!.status === 'error') {
       expect(exported!.code).toBe('export-format-mismatch');

--- a/src/state/model.ts
+++ b/src/state/model.ts
@@ -346,7 +346,7 @@ export class Model extends EventTarget {
    * (exports convert the LAST completed output), `export-format-mismatch` for
    * the wrong dimensionality.
    */
-  exportArtifact(format: ExportFormat): void {
+  exportArtifact(format: ExportFormat, requestId?: string): void {
     const fail = (code: string, reason: string) =>
       this.dispatchEvent(
         new CustomEvent('operation', {
@@ -359,6 +359,7 @@ export class Model extends EventTarget {
               elapsedMillis: 0,
               diagnostics: [],
               logText: '',
+              ...(requestId !== undefined ? { requestId } : {}),
             },
             code,
             reason,
@@ -381,7 +382,7 @@ export class Model extends EventTarget {
       );
       return;
     }
-    void this.exportService.export(format);
+    void this.exportService.export(format, requestId);
   }
 
   /** Creates a new empty .scad file in /home/ and activates it. */

--- a/src/state/services/__tests__/export-service.test.ts
+++ b/src/state/services/__tests__/export-service.test.ts
@@ -310,6 +310,31 @@ describe('ExportService', () => {
     expect(results[0].status).toBe('cancelled');
   });
 
+  it("a superseded export's cancelled terminal echoes the SUPERSEDED request's id (#223)", async () => {
+    const { ctx, results } = makeCtx({
+      is2D: false,
+      exportFormat3D: 'stl',
+      output: fileOutput('m.off'),
+    });
+    const svc = new ExportService(ctx);
+    const secondInner = vi.fn().mockResolvedValue({
+      outFile: new File(['second'], 'second.stl'),
+      logText: '',
+      markers: [],
+      elapsedMillis: 1,
+    });
+    mockRenderExport.mockReturnValueOnce(secondInner);
+
+    const p1 = svc.export('stl', 'req-A'); // superseded during its input read
+    const p2 = svc.export('stl', 'req-B');
+    await Promise.all([p1, p2]);
+
+    const cancelled = results.find((r) => r.status === 'cancelled');
+    const success = results.find((r) => r.status === 'success');
+    expect(cancelled?.requestId).toBe('req-A'); // the exact #223 scenario
+    expect(success?.requestId).toBe('req-B');
+  });
+
   it('treats a superseded (cancelled) export as supersession, not a user-facing error', async () => {
     const { ctx, host, getState } = makeCtx({
       is2D: false,

--- a/src/state/services/export-service.ts
+++ b/src/state/services/export-service.ts
@@ -100,7 +100,7 @@ export class ExportService {
    * mutates persistent state (which would silently flip subsequent 2D previews'
    * render format — and via the pass-through, could even mislabel the result).
    */
-  async export(requested?: ExportFormat) {
+  async export(requested?: ExportFormat, requestId?: string) {
     const { mutate, host } = this.ctx;
     // Claim the export token at entry — before any early return — so that EVERY
     // export (pass-through, picker, or async conversion) supersedes an in-flight
@@ -123,6 +123,9 @@ export class ExportService {
       elapsedMillis: 0,
       diagnostics: [],
       logText: '',
+      // Echo the initiating command's correlation id on EVERY terminal of this
+      // op — success, failure, cancelled, pass-through, picker (#223).
+      ...(requestId !== undefined ? { requestId } : {}),
       ...over,
     });
     // Cancel any in-flight conversion render so a superseding export — including

--- a/src/state/session.ts
+++ b/src/state/session.ts
@@ -66,8 +66,8 @@ export class OpenScadSession implements ProjectContract {
 
   /** Export the current model as `format` (#216); the terminal lands on the
    *  operation stream as a `kind: 'export'` result. */
-  exportArtifact(format: ExportFormat): void {
-    this.model.exportArtifact(format);
+  exportArtifact(format: ExportFormat, requestId?: string): void {
+    this.model.exportArtifact(format, requestId);
   }
 
   /** Cancel this session's in-flight compile/export operations (#123). */

--- a/tests/session.spec.ts
+++ b/tests/session.spec.ts
@@ -23,6 +23,7 @@ declare global {
       result?: {
         status?: string;
         kind?: string;
+        requestId?: string;
         artifact?: { format?: string; artifactId?: string };
       };
       requestId?: string;
@@ -126,7 +127,12 @@ test.describe('session distributable (#193)', () => {
     // Export round-trip (#216 + #197): trigger a real STL export over the wire,
     // then fetch the produced artifact's exact bytes by id. This is the flow a
     // VS Code host uses to save STL/3MF to disk.
-    await postToSession(page, { protocolVersion, type: 'export', format: 'stl' });
+    await postToSession(page, {
+      protocolVersion,
+      type: 'export',
+      format: 'stl',
+      requestId: 'e2e-export-1',
+    });
     await page.waitForFunction(
       () =>
         window.__sessionMessages?.some(
@@ -134,6 +140,7 @@ test.describe('session distributable (#193)', () => {
             m?.type === 'operation-result' &&
             m?.result?.kind === 'export' &&
             m?.result?.status === 'success' &&
+            m?.result?.requestId === 'e2e-export-1' &&
             m?.result?.artifact?.format === 'stl',
         ),
       null,


### PR DESCRIPTION
## Summary

`export { format, requestId? }` — the optional id threads through Model/ExportService into the `OperationResult` base, so **every terminal of that export operation echoes it**: success, failure, cancelled (incl. supersession), pass-through, picker, and the synthetic `no-output`/`export-format-mismatch` failures. Additive to protocol v2 (optional inbound field + optional result field; L1 payload version unchanged — old hosts unaffected, verified both directions).

**Why**: exports were fire-and-observe with no correlation — a host superseding export A with export B couldn't tell whose terminal arrived first, and same-format supersession was unresolvable (the extension carried an artifact-format belt as a partial workaround, now retired in its follow-up PR). Docs (§6) now tell hosts to always send one.

Ships as **v0.3.2** (bump + CHANGELOG included); the extension re-vendors after the tag.

## Review

Adversarially reviewed pre-PR: **clean** — no leak/misattribution across ops (per-invocation closure; the pass-through result/ref identity split matches the existing `sourceRevision` pattern), both supersession token paths echo the right id, validation is prototype-safe, and the additive/no-bump claim was verified for old-host and old-session directions. Its one suggestion — a test pinning the superseded terminal's echo, the exact #223 scenario — is included.

## Testing

627 unit tests (new: validation accept/reject/caps, dispatch pass-through, capstone echo on success + synthetic failure + absence on session-initiated previews, superseded-terminal echo) + 25 e2e; the real-WASM session e2e asserts the echo on the wire.

Closes #223.