### PR TITLE
feat(session): full render over the L1 wire (#219, v0.3.3)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,17 @@ release (changelog upkeep and tagging had lapsed between `0.1.0` and `0.2.0`).
 
 ## [Unreleased]
 
+## [0.3.3] - 2026-07-03
+
+### Added
+
+- Full render over the L1 wire (#219): new `render { requestId? }` command
+  drives the app's `$preview = false` render path; the terminal is the
+  existing `kind: 'render'` result (echoing `requestId`, #223 convention), its
+  render-quality OFF commits as the session output — so a following `export`
+  converts render-quality geometry and the embedded viewer displays it.
+  Additive to protocol v2.
+
 ## [0.3.2] - 2026-07-03
 
 ### Added

--- a/docs/EMBEDDING-VSCODE.md
+++ b/docs/EMBEDDING-VSCODE.md
@@ -319,7 +319,9 @@ before sending. Then **drive a project** rather than push geometry:
   `bytes` at a text-suffix path must be valid UTF-8 and are treated as text),
   `updateFile { path, content }` (text-only — re-push binary
   changes via `setProject`), `removeFile { path }`, `setEntryPoint { path }`,
-  `render { requestId? }` (a FULL `$preview = false` render — #219),
+  `render { requestId? }` (a FULL `$preview = false` render — #219; before any
+  `setProject` it fails with a `no-project` result rather than rendering the
+  default model),
   `export { format, requestId? }` (`stl`/`off`/`glb`/`3mf`/`svg`/`dxf` — #216/#223),
   `getArtifact { artifactId, requestId }`, `cancel`, `dispose`.
 - **Session → host:** `ready`, `operation-result { result }` (a **push stream** —

--- a/docs/EMBEDDING-VSCODE.md
+++ b/docs/EMBEDDING-VSCODE.md
@@ -319,6 +319,7 @@ before sending. Then **drive a project** rather than push geometry:
   `bytes` at a text-suffix path must be valid UTF-8 and are treated as text),
   `updateFile { path, content }` (text-only — re-push binary
   changes via `setProject`), `removeFile { path }`, `setEntryPoint { path }`,
+  `render { requestId? }` (a FULL `$preview = false` render — #219),
   `export { format, requestId? }` (`stl`/`off`/`glb`/`3mf`/`svg`/`dxf` — #216/#223),
   `getArtifact { artifactId, requestId }`, `cancel`, `dispose`.
 - **Session → host:** `ready`, `operation-result { result }` (a **push stream** —
@@ -352,9 +353,12 @@ fetch the bytes with `getArtifact` and save them. Semantics a host should know:
   export-kind **failure** (`export-format-mismatch`), never silence. The
   request's format is per-request only — it does not alter the session's
   preview settings.
-- Exports derive from **preview-quality** geometry (`$preview = true`): a model
-  that gates detail on `$preview` exports its preview variant. A wire command
-  for full-render exports is a tracked follow-up in epic #179.
+- By default exports derive from the last completed output — usually a
+  **preview** (`$preview = true`). For render-quality exports, send
+  `render { requestId? }` first (#219): its `kind: 'render'` terminal commits
+  render-quality geometry as the output (the embedded viewer shows it too),
+  and the following `export` converts THAT. Full renders can take much longer
+  than previews — budget the timeout accordingly.
 - The in-page download side effect and the 3MF multimaterial picker are
   disabled in the session artifact (the host owns saving; default colors
   apply).

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "openscad-web",
-  "version": "0.3.2",
+  "version": "0.3.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "openscad-web",
-      "version": "0.3.2",
+      "version": "0.3.3",
       "dependencies": {
         "@monaco-editor/loader": "^1.4.0",
         "blurhash": "^2.0.5",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "openscad-web",
-  "version": "0.3.2",
+  "version": "0.3.3",
   "private": true,
   "type": "module",
   "homepage": "https://cameronbrooks11.github.io/openscad-web/",

--- a/src/protocol/__tests__/session-transport.test.ts
+++ b/src/protocol/__tests__/session-transport.test.ts
@@ -211,6 +211,22 @@ describe('validateSessionInbound', () => {
     expect(ok({ type: 'dispose' })).toEqual({ ok: true, message: { type: 'dispose' } });
   });
 
+  it('accepts render with an optional requestId (#219)', () => {
+    expect(ok({ type: 'render' })).toEqual({ ok: true, message: { type: 'render' } });
+    expect(ok({ type: 'render', requestId: 'r-1' })).toEqual({
+      ok: true,
+      message: { type: 'render', requestId: 'r-1' },
+    });
+    expect(ok({ type: 'render', requestId: 7 })).toMatchObject({
+      ok: false,
+      code: 'invalid-payload',
+    });
+    expect(ok({ type: 'render', requestId: 'x'.repeat(SESSION_MAX_ID_LENGTH + 1) })).toMatchObject({
+      ok: false,
+      code: 'too-large',
+    });
+  });
+
   it('accepts export with a known format and rejects unknown/missing ones (#216)', () => {
     for (const format of ['stl', 'off', 'glb', '3mf', 'svg', 'dxf']) {
       expect(ok({ type: 'export', format })).toEqual({
@@ -276,6 +292,7 @@ describe('validateSessionInbound', () => {
       updateFile: { path: '/a', content: 'x' },
       removeFile: { path: '/a' },
       setEntryPoint: { path: '/a' },
+      render: {},
       export: { format: 'stl' },
       getArtifact: { artifactId: 'a', requestId: 'r' },
       cancel: {},

--- a/src/protocol/session-contract.ts
+++ b/src/protocol/session-contract.ts
@@ -77,10 +77,10 @@ interface OperationResultBase {
   logText: string;
   /**
    * Echo of the initiating command's `requestId`, on every terminal of the
-   * operation it started (#223). Today only `export { requestId? }` threads
-   * one through; absent for operations the session started itself (auto
-   * previews/syntax checks) or when the command carried none. Additive —
-   * optional, so the L1 payload version is unchanged.
+   * operation it started (#223). The `export` (#216) and `render` (#219)
+   * commands thread one through; absent for operations the session started
+   * itself (auto previews/syntax checks) or when the command carried none.
+   * Additive — optional, so the L1 payload version is unchanged.
    */
   requestId?: string;
 }

--- a/src/protocol/session-transport.ts
+++ b/src/protocol/session-transport.ts
@@ -46,6 +46,7 @@ export const SESSION_COMMANDS = [
   'updateFile',
   'removeFile',
   'setEntryPoint',
+  'render',
   'export',
   'getArtifact',
   'cancel',
@@ -67,6 +68,7 @@ export type SessionInbound =
   | { type: 'updateFile'; path: string; content: string }
   | { type: 'removeFile'; path: string }
   | { type: 'setEntryPoint'; path: string }
+  | { type: 'render'; requestId?: string }
   | { type: 'export'; format: SessionExportFormat; requestId?: string }
   | { type: 'getArtifact'; artifactId: string; requestId: string }
   | { type: 'cancel' }
@@ -176,6 +178,23 @@ export function validateSessionInbound(data: unknown): SessionValidation {
       if (path === undefined) return err('invalid-payload', 'path must be a string');
       if (path.length > SESSION_MAX_PATH_LENGTH) return err('too-large', 'path is too long');
       return { ok: true, message: { type: data.type, path } };
+    }
+    case 'render': {
+      // Full render (#219): $preview = false, render-quality geometry. The
+      // terminal is the existing kind:'render' result (echoing requestId); its
+      // OFF commits as the output, so a following `export` converts
+      // render-quality geometry.
+      const requestId = data.requestId === undefined ? undefined : readString(data.requestId);
+      if (data.requestId !== undefined && requestId === undefined) {
+        return err('invalid-payload', 'requestId must be a string');
+      }
+      if (requestId !== undefined && requestId.length > SESSION_MAX_ID_LENGTH) {
+        return err('too-large', 'an id is too long');
+      }
+      return {
+        ok: true,
+        message: { type: 'render', ...(requestId !== undefined ? { requestId } : {}) },
+      };
     }
     case 'export': {
       // Fire-and-observe like the mutation commands: the terminal arrives on the

--- a/src/session-host/__tests__/controller.test.ts
+++ b/src/session-host/__tests__/controller.test.ts
@@ -31,6 +31,9 @@ class FakeSession implements SessionHost {
   setEntryPoint(path: string) {
     this.calls.push(`setEntryPoint:${path}`);
   }
+  render(requestId?: string) {
+    this.calls.push(`render:${requestId ?? ''}`);
+  }
   exportArtifact(format: string, requestId?: string) {
     this.calls.push(`export:${format}:${requestId ?? ''}`);
   }
@@ -137,6 +140,7 @@ describe('SessionController', () => {
         'updateFile',
         'removeFile',
         'setEntryPoint',
+        'render',
         'export',
         'getArtifact',
         'cancel',
@@ -155,6 +159,7 @@ describe('SessionController', () => {
     transport.receive({ protocolVersion: V, type: 'updateFile', path: '/a', content: 'y' });
     transport.receive({ protocolVersion: V, type: 'removeFile', path: '/a' });
     transport.receive({ protocolVersion: V, type: 'setEntryPoint', path: '/a' });
+    transport.receive({ protocolVersion: V, type: 'render', requestId: 'r0' });
     transport.receive({ protocolVersion: V, type: 'export', format: 'stl', requestId: 'r1' });
     transport.receive({ protocolVersion: V, type: 'cancel' });
     expect(session.calls).toEqual([
@@ -162,6 +167,7 @@ describe('SessionController', () => {
       'updateFile:/a',
       'removeFile:/a',
       'setEntryPoint:/a',
+      'render:r0',
       'export:stl:r1',
       'cancel',
     ]);

--- a/src/session-host/controller.ts
+++ b/src/session-host/controller.ts
@@ -27,6 +27,10 @@ export interface SessionHost {
   updateFile(path: string, content: string): void;
   removeFile(path: string): void;
   setEntryPoint(path: string): void;
+  /** Run a FULL render (#219) — render-quality geometry; the terminal is a
+   *  `kind: 'render'` result echoing `requestId`, and its output becomes what a
+   *  subsequent export converts. */
+  render(requestId?: string): void;
   /** Export the current model as `format` (#216). Fire-and-observe: the terminal
    *  lands on the operation stream as a `kind: 'export'` result (success with an
    *  ArtifactRef, or a failure — e.g. a dimensionality mismatch), echoing
@@ -92,6 +96,9 @@ export class SessionController {
           break;
         case 'setEntryPoint':
           this.session.setEntryPoint(msg.path);
+          break;
+        case 'render':
+          this.session.render(msg.requestId);
           break;
         case 'export':
           this.session.exportArtifact(msg.format, msg.requestId);

--- a/src/session-host/session-host.ts
+++ b/src/session-host/session-host.ts
@@ -12,6 +12,7 @@ export function sessionHostOf(session: OpenScadSession): SessionHost {
     updateFile: (path, content) => session.updateFile(path, content),
     removeFile: (path) => session.removeFile(path),
     setEntryPoint: (path) => session.setEntryPoint(path),
+    render: (requestId) => session.render(requestId),
     exportArtifact: (format, requestId) => session.exportArtifact(format, requestId),
     cancel: () => session.cancel(),
     dispose: () => session.dispose(),

--- a/src/state/__tests__/project-contract.test.ts
+++ b/src/state/__tests__/project-contract.test.ts
@@ -295,6 +295,31 @@ describe('#123 multi-file project contract — headless end to end', () => {
     }
   });
 
+  it('a full render terminates as kind:render echoing its requestId; export then converts it (#219)', async () => {
+    const { model, ops } = makeModel(new FakeBackend());
+    model.setProject([{ path: 'main.scad', content: 'cube(1);' }], 'main.scad');
+    await settle();
+
+    void model.render({ isPreview: false, now: true, requestId: 'rq-render' });
+    await settle();
+
+    const render = ops.find((o) => o.kind === 'render');
+    expect(render).toBeDefined();
+    expect(render!.status).toBe('success');
+    expect(render!.requestId).toBe('rq-render');
+    if (render!.status === 'success') {
+      expect(render!.artifact?.format).toBe('off');
+    }
+
+    // The render committed as the session output, so an export now converts
+    // render-quality geometry — the #219 flow: render -> export -> getArtifact.
+    model.exportArtifact('stl', 'rq-exp');
+    await settle();
+    const exported = ops.find((o) => o.kind === 'export');
+    expect(exported?.status).toBe('success');
+    expect(exported?.requestId).toBe('rq-exp');
+  });
+
   it('exportArtifact does not mutate the persisted format settings, and off pass-through works (#216 review)', async () => {
     const { model, ops } = makeModel(new FakeBackend());
     model.setProject([{ path: 'main.scad', content: 'cube(1);' }], 'main.scad');

--- a/src/state/model.ts
+++ b/src/state/model.ts
@@ -346,26 +346,37 @@ export class Model extends EventTarget {
    * (exports convert the LAST completed output), `export-format-mismatch` for
    * the wrong dimensionality.
    */
+  /** Emit a synthetic terminal failure on the operation stream — for wire
+   *  commands that must never end in silence (export #216, render #219). */
+  emitOperationFailure(
+    kind: 'export' | 'render',
+    code: string,
+    reason: string,
+    requestId?: string,
+  ): void {
+    this.dispatchEvent(
+      new CustomEvent('operation', {
+        detail: operationFailure(
+          {
+            sessionId: this.sessionId,
+            operationId: newId(),
+            sourceRevision: this._sourceRevision,
+            kind,
+            elapsedMillis: 0,
+            diagnostics: [],
+            logText: '',
+            ...(requestId !== undefined ? { requestId } : {}),
+          },
+          code,
+          reason,
+        ),
+      }),
+    );
+  }
+
   exportArtifact(format: ExportFormat, requestId?: string): void {
     const fail = (code: string, reason: string) =>
-      this.dispatchEvent(
-        new CustomEvent('operation', {
-          detail: operationFailure(
-            {
-              sessionId: this.sessionId,
-              operationId: newId(),
-              sourceRevision: this._sourceRevision,
-              kind: 'export',
-              elapsedMillis: 0,
-              diagnostics: [],
-              logText: '',
-              ...(requestId !== undefined ? { requestId } : {}),
-            },
-            code,
-            reason,
-          ),
-        }),
-      );
+      this.emitOperationFailure('export', code, reason, requestId);
     if (!this.state.output) {
       fail(
         'no-output',

--- a/src/state/model.ts
+++ b/src/state/model.ts
@@ -600,6 +600,7 @@ export class Model extends EventTarget {
     mountArchives?: boolean;
     now: boolean;
     retryInOtherDim?: boolean;
+    requestId?: string;
   }) {
     return this.compile.render(args);
   }

--- a/src/state/services/__tests__/compile-coordinator.test.ts
+++ b/src/state/services/__tests__/compile-coordinator.test.ts
@@ -1,6 +1,7 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
 import { CompileCoordinator } from '../compile-coordinator.ts';
+import { UserFacingOperationError } from '../../../user-facing-errors.ts';
 import type { ServiceContext } from '../service-context.ts';
 import { ArtifactStore } from '../../artifact-store.ts';
 import type { OperationResult } from '../../../runner/compile-contract.ts';
@@ -286,24 +287,61 @@ describe('CompileCoordinator terminal OperationResult (ADR 0008 slice 4)', () =>
     expect(results[0].operationId).not.toBe(results[1].operationId);
   });
 
-  it('the 2D/3D dimension retry is a distinct second operation (two results, two ids)', async () => {
+  it('the 2D/3D dimension retry emits ONE terminal — the retry owns the request (#219)', async () => {
     const { ctx, results } = makeContext(1);
-    // The first render logs a dimension mismatch via the streams callback, which
-    // triggers exactly one retry (a recursive render with its own operationId).
+    // The first render logs a dimension mismatch via the streams callback; the
+    // wrong-dimension attempt must emit and commit NOTHING (a correlated host
+    // would otherwise see a spurious first terminal for its requestId).
     renderImpl.mockImplementationOnce((renderArgs: { streamsCallback: (p: unknown) => void }) => {
       renderArgs.streamsCallback({ stderr: 'Current top level object is not a 3D object.' });
       return Promise.resolve(renderOutput(1));
     });
     renderImpl.mockResolvedValueOnce(renderOutput(1));
 
-    await new CompileCoordinator(ctx).render({ isPreview: false, now: true });
+    await new CompileCoordinator(ctx).render({ isPreview: false, now: true, requestId: 'rq-dim' });
     // The retry is dispatched without await (fire-and-return), so let its own
     // async commit settle before asserting.
     await new Promise((r) => setTimeout(r, 0));
 
-    expect(results).toHaveLength(2);
-    expect(results.every((r) => r.status === 'success')).toBe(true);
-    expect(results[0].operationId).not.toBe(results[1].operationId);
+    expect(results).toHaveLength(1);
+    expect(results[0].status).toBe('success');
+    expect(results[0].requestId).toBe('rq-dim');
+  });
+
+  it('a mismatch FAILURE also retries without a spurious terminal, reading the job-local log (#219)', async () => {
+    const { ctx, results } = makeContext(1);
+    renderImpl.mockRejectedValueOnce(
+      new UserFacingOperationError({
+        message: 'render failed',
+        logText: 'Current top level object is not a 3D object.',
+      }),
+    );
+    renderImpl.mockResolvedValueOnce(renderOutput(1));
+
+    await new CompileCoordinator(ctx).render({ isPreview: false, now: true, requestId: 'rq-f' });
+    await new Promise((r) => setTimeout(r, 0));
+
+    expect(results).toHaveLength(1);
+    expect(results[0].status).toBe('success');
+    expect(results[0].requestId).toBe('rq-f');
+  });
+
+  it('a superseded render terminates as cancelled carrying its requestId (#219/#223)', async () => {
+    const { ctx, results } = makeContext(1);
+    let resolveFirst: (v: unknown) => void = () => {};
+    renderImpl.mockReturnValueOnce(new Promise((r) => (resolveFirst = r)));
+    renderImpl.mockResolvedValueOnce(renderOutput(1));
+    const coord = new CompileCoordinator(ctx);
+
+    const first = coord.render({ isPreview: false, now: true, requestId: 'rq-old' });
+    const second = coord.render({ isPreview: false, now: true, requestId: 'rq-new' });
+    resolveFirst(renderOutput(1));
+    await Promise.all([first, second]);
+
+    const cancelled = results.find((r) => r.status === 'cancelled');
+    const success = results.find((r) => r.status === 'success');
+    expect(cancelled?.requestId).toBe('rq-old');
+    expect(success?.requestId).toBe('rq-new');
   });
 
   it('checkSyntax emits one success result with no artifact', async () => {

--- a/src/state/services/compile-coordinator.ts
+++ b/src/state/services/compile-coordinator.ts
@@ -304,6 +304,32 @@ export class CompileCoordinator {
     });
   }
 
+  /** The corrected `is2D` for a 2D/3D dimension-mismatch retry, or undefined
+   *  when the log shows no mismatch. Reads the JOB'S OWN log first; the shared
+   *  currentRunLogs only as a fallback — a concurrent render() resets those,
+   *  so they can misattribute lines under interleaving (#219 review). */
+  private static dimensionRetryTarget(
+    jobLogText: string | undefined,
+    sharedLogs: ['stderr' | 'stdout', string][] | undefined,
+  ): boolean | undefined {
+    const lines = jobLogText ? jobLogText.split('\n') : (sharedLogs ?? []).map(([, l]) => l);
+    let is2D: boolean | undefined;
+    let is3D: boolean | undefined;
+    for (const line of lines) {
+      if (line == 'Current top level object is not a 3D object.') {
+        is3D = false;
+      } else if (line == 'Top level object is a 3D object:') {
+        is3D = true;
+      } else if (line == 'Current top level object is not a 2D object.') {
+        is2D = false;
+      } else if (line == 'Top level object is a 2D object:') {
+        is2D = true;
+      }
+    }
+    if (is2D === false || is3D === false) return !(is2D === false);
+    return undefined;
+  }
+
   async render({
     isPreview,
     mountArchives,
@@ -418,6 +444,25 @@ export class CompileCoordinator {
         this.emitResult(operationCancelled(base())); // revision stale-drop
         return;
       }
+      if (retryInOtherDim) {
+        const retry2D = CompileCoordinator.dimensionRetryTarget(
+          output.logText,
+          this.ctx.getState().currentRunLogs,
+        );
+        if (retry2D !== undefined) {
+          // A wrong-dimension "success" (the engine exits zero with an empty
+          // output and a mismatch log line). The retry produces this REQUEST's
+          // actual terminal — same requestId (#223 convention) — so this
+          // attempt emits nothing and commits nothing (no flash of empty
+          // geometry, no spurious terminal for a correlated host).
+          this.ctx.mutate((s) => {
+            setRendering(s, false);
+            s.is2D = retry2D;
+          });
+          this.render({ isPreview, now: true, retryInOtherDim: false, requestId });
+          return;
+        }
+      }
       is2D = output.outFile.name.endsWith('.svg') || output.outFile.name.endsWith('.dxf');
       // Everything from the staleness checks above to the commit below is
       // synchronous (the viewer reads the OFF File directly and uses outFileURL
@@ -483,6 +528,22 @@ export class CompileCoordinator {
         this.emitResult(operationCancelled(base())); // superseded
         return; // superseded — the newer call owns the spinner state
       }
+      if (retryInOtherDim && !isExpectedJobCancellation(err)) {
+        const retry2D = CompileCoordinator.dimensionRetryTarget(
+          isUserFacingOperationError(err) ? err.userFacingError.logText : undefined,
+          this.ctx.getState().currentRunLogs,
+        );
+        if (retry2D !== undefined) {
+          // Same as the success-path retry: the mismatch failure must not emit
+          // a spurious first terminal — one terminal per request (#219 review).
+          this.ctx.mutate((s) => {
+            setRendering(s, false);
+            s.is2D = retry2D;
+          });
+          this.render({ isPreview, now: true, retryInOtherDim: false, requestId });
+          return;
+        }
+      }
       this.ctx.mutate((s) => {
         setRendering(s, false);
         if (!isExpectedJobCancellation(err)) {
@@ -503,27 +564,6 @@ export class CompileCoordinator {
               normalizeOperationFailure(err, isPreview ? 'preview' : 'render').message,
             ),
       );
-    }
-    if (retryInOtherDim) {
-      let is2D: boolean | undefined;
-      let is3D: boolean | undefined;
-      for (const [, line] of this.ctx.getState().currentRunLogs ?? []) {
-        if (line == 'Current top level object is not a 3D object.') {
-          is3D = false;
-        } else if (line == 'Top level object is a 3D object:') {
-          is3D = true;
-        } else if (line == 'Current top level object is not a 2D object.') {
-          is2D = false;
-        } else if (line == 'Top level object is a 2D object:') {
-          is2D = true;
-        }
-      }
-      if (is2D === false || is3D === false) {
-        this.ctx.mutate((s) => (s.is2D = !(is2D === false)));
-        // The retry produces the ACTUAL terminal for the request — keep its id.
-        this.render({ isPreview, now: true, retryInOtherDim: false, requestId });
-        return;
-      }
     }
   }
 }

--- a/src/state/services/compile-coordinator.ts
+++ b/src/state/services/compile-coordinator.ts
@@ -309,11 +309,15 @@ export class CompileCoordinator {
     mountArchives,
     now,
     retryInOtherDim,
+    requestId,
   }: {
     isPreview: boolean;
     mountArchives?: boolean;
     now: boolean;
     retryInOtherDim?: boolean;
+    /** Correlation id echoed on this operation's terminal (#219/#223) — set by
+     *  the wire's `render` command; absent for app/auto-triggered renders. */
+    requestId?: string;
   }) {
     mountArchives ??= true;
     retryInOtherDim ??= true;
@@ -338,6 +342,8 @@ export class CompileCoordinator {
       elapsedMillis: 0,
       diagnostics: [],
       logText: '',
+      // Echo the initiating command's correlation id on the terminal (#219).
+      ...(requestId !== undefined ? { requestId } : {}),
       ...over,
     });
     const setRendering = (s: State, value: boolean) => {
@@ -514,7 +520,8 @@ export class CompileCoordinator {
       }
       if (is2D === false || is3D === false) {
         this.ctx.mutate((s) => (s.is2D = !(is2D === false)));
-        this.render({ isPreview, now: true, retryInOtherDim: false });
+        // The retry produces the ACTUAL terminal for the request — keep its id.
+        this.render({ isPreview, now: true, retryInOtherDim: false, requestId });
         return;
       }
     }

--- a/src/state/session.ts
+++ b/src/state/session.ts
@@ -50,8 +50,14 @@ export class OpenScadSession implements ProjectContract {
     this.model.init();
   }
 
+  /** Whether the host has pushed a project yet — a wire render before that
+   *  would silently full-render the DEFAULT playground model (the session
+   *  entry never init()s precisely to avoid showing it). */
+  private hostProjectSet = false;
+
   // --- ProjectContract (#123): host-drivable project ops, delegated to Model ---
   setProject(files: ProjectFile[], entryPoint?: string): void {
+    this.hostProjectSet = true;
     this.model.setProject(files, entryPoint);
   }
   updateFile(path: string, content: string): void {
@@ -70,6 +76,17 @@ export class OpenScadSession implements ProjectContract {
    *  session output, so a subsequent export converts render-quality geometry
    *  (and the embedded viewer shows it). */
   render(requestId?: string): void {
+    if (!this.hostProjectSet) {
+      // Never render (and display!) the default playground model on a host
+      // bug — fail the request loudly instead (#219 review).
+      this.model.emitOperationFailure(
+        'render',
+        'no-project',
+        'no project has been pushed — send setProject before render',
+        requestId,
+      );
+      return;
+    }
     void this.model.render({ isPreview: false, now: true, requestId });
   }
 

--- a/src/state/session.ts
+++ b/src/state/session.ts
@@ -64,6 +64,15 @@ export class OpenScadSession implements ProjectContract {
     this.model.setEntryPoint(path);
   }
 
+  /** Run a FULL render of the current model (#219) — `$preview = false`,
+   *  render-quality geometry. The terminal lands on the operation stream as a
+   *  `kind: 'render'` result echoing `requestId`; its OFF commits as the
+   *  session output, so a subsequent export converts render-quality geometry
+   *  (and the embedded viewer shows it). */
+  render(requestId?: string): void {
+    void this.model.render({ isPreview: false, now: true, requestId });
+  }
+
   /** Export the current model as `format` (#216); the terminal lands on the
    *  operation stream as a `kind: 'export'` result. */
   exportArtifact(format: ExportFormat, requestId?: string): void {

--- a/tests/session.spec.ts
+++ b/tests/session.spec.ts
@@ -124,6 +124,23 @@ test.describe('session distributable (#193)', () => {
     );
     expect(hadError).toBeFalsy();
 
+    // Full render (#219): trigger a render-quality compile over the wire and
+    // await its kind:'render' terminal (echoing our requestId). Its output is
+    // what the export below converts — render-quality, not preview-quality.
+    await postToSession(page, { protocolVersion, type: 'render', requestId: 'e2e-render-1' });
+    await page.waitForFunction(
+      () =>
+        window.__sessionMessages?.some(
+          (m) =>
+            m?.type === 'operation-result' &&
+            m?.result?.kind === 'render' &&
+            m?.result?.status === 'success' &&
+            m?.result?.requestId === 'e2e-render-1',
+        ),
+      null,
+      { timeout: 60_000 },
+    );
+
     // Export round-trip (#216 + #197): trigger a real STL export over the wire,
     // then fetch the produced artifact's exact bytes by id. This is the flow a
     // VS Code host uses to save STL/3MF to disk.


### PR DESCRIPTION
## Summary

New **`render { requestId? }`** command drives the app's `$preview = false` render path (the same `Model.render` the Render button uses). The terminal is the existing `kind:'render'` result echoing the `requestId` (#223 convention); the render-quality OFF commits as the session output — so a following `export` converts **render-quality geometry** (and the embedded viewer shows it), closing the preview-quality-only export caveat. Additive to protocol v2; ships as **v0.3.3**.

## Review — one real defect found and fixed

The adversarial pass verified the headline race is sound (a superseded wire render terminates as `cancelled` with its id — empirically reproduced, no silence), but caught the **dimension-retry double terminal**: a 2D model rendered as 3D emitted a spurious failure (or committed a wrong-dimension empty "success") carrying the requestId before the retry's real terminal — breaking the one-terminal-per-request contract hosts key on. Fixed by deciding the retry **before any emit on both paths**, reading the job's own log (the shared `currentRunLogs` fallback was also racy — a concurrent render resets them). Also per review: `render` before any `setProject` now fails loudly with `no-project` instead of silently full-rendering the default playground model; stale contract comment fixed. Verified clean: state flags/chime/picker inert in the session artifact, viewer bridge displays the render (rank render > preview), full command parity.

## Testing

631 unit tests (new: validation, dispatch, capstone render→export chain with echoes, single-terminal retry on both paths, superseded-render cancelled echo) + 25 e2e; the real-WASM session e2e now runs **preview → full render (echo asserted) → export STL → getArtifact**.

Closes #219.