### PR TITLE
feat(session): targeted cancel over the L1 wire (#226)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,15 @@ release (changelog upkeep and tagging had lapsed between `0.1.0` and `0.2.0`).
 
 ## [Unreleased]
 
+### Added
+
+- Targeted cancel over the L1 wire (#226): `cancel { requestId? }` — with an
+  id, only the operation started by the command carrying that id is cancelled
+  (render #219 / export #216), covering the pre-spawn windows too; auto
+  previews and syntax checks survive, so cancelling a slow full render no
+  longer kills a concurrent save's compile. Without an id the pre-existing
+  cancel-everything behavior is unchanged. Additive to protocol v2.
+
 ## [0.3.3] - 2026-07-03
 
 ### Added

--- a/docs/EMBEDDING-VSCODE.md
+++ b/docs/EMBEDDING-VSCODE.md
@@ -323,7 +323,10 @@ before sending. Then **drive a project** rather than push geometry:
   `setProject` it fails with a `no-project` result rather than rendering the
   default model),
   `export { format, requestId? }` (`stl`/`off`/`glb`/`3mf`/`svg`/`dxf` — #216/#223),
-  `getArtifact { artifactId, requestId }`, `cancel`, `dispose`.
+  `getArtifact { artifactId, requestId }`, `cancel { requestId? }` (with an id:
+  cancel ONLY the operation started by the command that carried it — a slow
+  full render can be cancelled without killing a concurrent save's compile;
+  without: everything in flight — #226), `dispose`.
 - **Session → host:** `ready`, `operation-result { result }` (a **push stream** —
   one edit fans out to multiple terminal results; correlate by the nested
   `result.operationId` / `kind` / `sourceRevision`, **not** 1:1 with commands),

--- a/src/protocol/__tests__/session-transport.test.ts
+++ b/src/protocol/__tests__/session-transport.test.ts
@@ -209,6 +209,19 @@ describe('validateSessionInbound', () => {
   it('accepts cancel and dispose', () => {
     expect(ok({ type: 'cancel' })).toEqual({ ok: true, message: { type: 'cancel' } });
     expect(ok({ type: 'dispose' })).toEqual({ ok: true, message: { type: 'dispose' } });
+    // Targeted cancel (#226): optional requestId, validated when present.
+    expect(ok({ type: 'cancel', requestId: 'r-1' })).toEqual({
+      ok: true,
+      message: { type: 'cancel', requestId: 'r-1' },
+    });
+    expect(ok({ type: 'cancel', requestId: 7 })).toMatchObject({
+      ok: false,
+      code: 'invalid-payload',
+    });
+    expect(ok({ type: 'cancel', requestId: 'x'.repeat(SESSION_MAX_ID_LENGTH + 1) })).toMatchObject({
+      ok: false,
+      code: 'too-large',
+    });
   });
 
   it('accepts render with an optional requestId (#219)', () => {

--- a/src/protocol/session-transport.ts
+++ b/src/protocol/session-transport.ts
@@ -71,7 +71,7 @@ export type SessionInbound =
   | { type: 'render'; requestId?: string }
   | { type: 'export'; format: SessionExportFormat; requestId?: string }
   | { type: 'getArtifact'; artifactId: string; requestId: string }
-  | { type: 'cancel' }
+  | { type: 'cancel'; requestId?: string }
   | { type: 'dispose' };
 
 export type SessionValidation =
@@ -236,8 +236,22 @@ export function validateSessionInbound(data: unknown): SessionValidation {
       }
       return { ok: true, message: { type: 'getArtifact', artifactId, requestId } };
     }
-    case 'cancel':
-      return { ok: true, message: { type: 'cancel' } };
+    case 'cancel': {
+      // Optional target (#226): cancel ONLY the operation started by the
+      // command that carried this id (render #219 / export #216); without it,
+      // everything in flight is cancelled (the pre-#226 behavior).
+      const requestId = data.requestId === undefined ? undefined : readString(data.requestId);
+      if (data.requestId !== undefined && requestId === undefined) {
+        return err('invalid-payload', 'requestId must be a string');
+      }
+      if (requestId !== undefined && requestId.length > SESSION_MAX_ID_LENGTH) {
+        return err('too-large', 'an id is too long');
+      }
+      return {
+        ok: true,
+        message: { type: 'cancel', ...(requestId !== undefined ? { requestId } : {}) },
+      };
+    }
     case 'dispose':
       return { ok: true, message: { type: 'dispose' } };
     default:

--- a/src/session-host/__tests__/controller.test.ts
+++ b/src/session-host/__tests__/controller.test.ts
@@ -37,8 +37,8 @@ class FakeSession implements SessionHost {
   exportArtifact(format: string, requestId?: string) {
     this.calls.push(`export:${format}:${requestId ?? ''}`);
   }
-  cancel() {
-    this.calls.push('cancel');
+  cancel(requestId?: string) {
+    this.calls.push(`cancel:${requestId ?? ''}`);
   }
   dispose() {
     this.disposed = true;
@@ -161,7 +161,7 @@ describe('SessionController', () => {
     transport.receive({ protocolVersion: V, type: 'setEntryPoint', path: '/a' });
     transport.receive({ protocolVersion: V, type: 'render', requestId: 'r0' });
     transport.receive({ protocolVersion: V, type: 'export', format: 'stl', requestId: 'r1' });
-    transport.receive({ protocolVersion: V, type: 'cancel' });
+    transport.receive({ protocolVersion: V, type: 'cancel', requestId: 'r2' });
     expect(session.calls).toEqual([
       'setProject:1:',
       'updateFile:/a',
@@ -169,7 +169,7 @@ describe('SessionController', () => {
       'setEntryPoint:/a',
       'render:r0',
       'export:stl:r1',
-      'cancel',
+      'cancel:r2',
     ]);
   });
 

--- a/src/session-host/controller.ts
+++ b/src/session-host/controller.ts
@@ -36,7 +36,8 @@ export interface SessionHost {
    *  ArtifactRef, or a failure — e.g. a dimensionality mismatch), echoing
    *  `requestId` when the command carried one (#223). */
   exportArtifact(format: SessionExportFormat, requestId?: string): void;
-  cancel(): void;
+  /** Cancel everything, or with `requestId` only that command's operation (#226). */
+  cancel(requestId?: string): void;
   dispose(): void;
   /** Subscribe to terminal operation results (the Model's `'operation'` stream);
    *  returns an unsubscribe. */
@@ -107,7 +108,7 @@ export class SessionController {
           void this.sendArtifact(msg.requestId, msg.artifactId);
           break;
         case 'cancel':
-          this.session.cancel();
+          this.session.cancel(msg.requestId);
           break;
         case 'dispose':
           this.dispose();

--- a/src/session-host/session-host.ts
+++ b/src/session-host/session-host.ts
@@ -14,7 +14,7 @@ export function sessionHostOf(session: OpenScadSession): SessionHost {
     setEntryPoint: (path) => session.setEntryPoint(path),
     render: (requestId) => session.render(requestId),
     exportArtifact: (format, requestId) => session.exportArtifact(format, requestId),
-    cancel: () => session.cancel(),
+    cancel: (requestId) => session.cancel(requestId),
     dispose: () => session.dispose(),
     onOperation: (handler) => {
       const listener = (e: Event) => handler((e as CustomEvent<OperationResult>).detail);

--- a/src/state/model.ts
+++ b/src/state/model.ts
@@ -514,9 +514,9 @@ export class Model extends EventTarget {
   /** Cancel in-flight compile and export operations on this session (#123).
    *  Best-effort: each cancelled job surfaces one terminal `cancelled`
    *  OperationResult (via the 'operation' event) and clears its spinner. */
-  cancel(): void {
-    this.compile.cancel();
-    this.exportService.cancel();
+  cancel(requestId?: string): void {
+    this.compile.cancel(requestId);
+    this.exportService.cancel(requestId);
   }
 
   /** Extracts a ZIP archive into /home/ and activates the entry .scad. */

--- a/src/state/services/__tests__/compile-coordinator.test.ts
+++ b/src/state/services/__tests__/compile-coordinator.test.ts
@@ -344,6 +344,62 @@ describe('CompileCoordinator terminal OperationResult (ADR 0008 slice 4)', () =>
     expect(success?.requestId).toBe('rq-new');
   });
 
+  it('targeted cancel kills only the render carrying that requestId (#226)', async () => {
+    const { ctx, results } = makeContext(1);
+    let rejectFn: (e: unknown) => void = () => {};
+    const hang = new Promise((_res, rej) => (rejectFn = rej)) as Promise<unknown> & {
+      kill: () => void;
+    };
+    hang.kill = vi.fn(() => rejectFn(new Error('Cancelled')));
+    renderImpl.mockReturnValueOnce(hang);
+    const coord = new CompileCoordinator(ctx);
+
+    const p = coord.render({ isPreview: false, now: true, requestId: 'rq-target' });
+    await new Promise((r) => setTimeout(r, 0)); // let it reach the spawn
+    coord.cancel('rq-other'); // wrong id → must NOT kill
+    expect(hang.kill).not.toHaveBeenCalled();
+    coord.cancel('rq-target'); // right id → kills
+    expect(hang.kill).toHaveBeenCalledTimes(1);
+    await p;
+
+    expect(results).toHaveLength(1);
+    expect(results[0].status).toBe('cancelled');
+    expect(results[0].requestId).toBe('rq-target');
+  });
+
+  it('a targeted cancel during source materialization cancels pre-spawn (#226)', async () => {
+    const { ctx, results } = makeContext(1);
+    renderImpl.mockResolvedValueOnce(renderOutput(1)); // must never be consumed
+    const coord = new CompileCoordinator(ctx);
+
+    const p = coord.render({ isPreview: false, now: true, requestId: 'rq-early' });
+    coord.cancel('rq-early'); // lands before the job exists
+    await p;
+
+    expect(renderImpl).not.toHaveBeenCalled();
+    expect(results).toHaveLength(1);
+    expect(results[0].status).toBe('cancelled');
+    expect(results[0].requestId).toBe('rq-early');
+  });
+
+  it('targeted cancel spares a render that carries NO requestId (auto previews survive, #226)', async () => {
+    const { ctx, results } = makeContext(1);
+    let resolveFn: (v: unknown) => void = () => {};
+    const hang = new Promise((res) => (resolveFn = res)) as Promise<unknown> & {
+      kill: () => void;
+    };
+    hang.kill = vi.fn();
+    renderImpl.mockReturnValueOnce(hang);
+    const coord = new CompileCoordinator(ctx);
+
+    const p = coord.render({ isPreview: true, now: true }); // an auto preview
+    coord.cancel('rq-whatever'); // targeted → must not touch it
+    expect(hang.kill).not.toHaveBeenCalled();
+    resolveFn(renderOutput(1));
+    await p;
+    expect(results[0].status).toBe('success');
+  });
+
   it('checkSyntax emits one success result with no artifact', async () => {
     const { ctx, results } = makeContext(1);
     checkSyntaxImpl.mockResolvedValue({ revision: 1, markers: [], logText: '' });

--- a/src/state/services/__tests__/export-service.test.ts
+++ b/src/state/services/__tests__/export-service.test.ts
@@ -335,6 +335,35 @@ describe('ExportService', () => {
     expect(success?.requestId).toBe('req-B');
   });
 
+  it('targeted cancel only affects the export carrying that requestId (#226)', async () => {
+    const { ctx, host, getState, results } = makeCtx({
+      is2D: false,
+      exportFormat3D: 'stl',
+      output: fileOutput('m.off'),
+    });
+    const svc = new ExportService(ctx);
+    const inner = vi.fn().mockResolvedValue({
+      outFile: new File(['ok'], 'a.stl'),
+      logText: '',
+      markers: [],
+      elapsedMillis: 1,
+    });
+    mockRenderExport.mockReturnValueOnce(inner);
+
+    const p = svc.export('stl', 'rq-exp'); // suspended at the input read
+    svc.cancel('rq-other'); // wrong id → export must proceed
+    await p;
+    expect(results.at(-1)?.status).toBe('success');
+    expect(host.download).toHaveBeenCalledTimes(1);
+
+    // Matching id cancels pre-spawn, exactly like an untargeted cancel.
+    const p2 = svc.export('stl', 'rq-exp2');
+    svc.cancel('rq-exp2');
+    await p2;
+    expect(results.at(-1)?.status).toBe('cancelled');
+    expect(getState().exporting).toBe(false);
+  });
+
   it('treats a superseded (cancelled) export as supersession, not a user-facing error', async () => {
     const { ctx, host, getState } = makeCtx({
       is2D: false,

--- a/src/state/services/compile-coordinator.ts
+++ b/src/state/services/compile-coordinator.ts
@@ -91,10 +91,28 @@ export class CompileCoordinator {
    * executing `callMain` in the worker finishes there; its result is discarded by
    * id (same as supersession).
    */
-  cancel(): void {
+  cancel(requestId?: string): void {
+    if (requestId !== undefined) {
+      // Targeted (#226): only the render started by the command carrying this
+      // id. Auto syntax checks / previews never carry one, so they survive —
+      // cancelling a slow wire render no longer kills a concurrent save's
+      // compile. The mark also covers the pre-spawn window (source
+      // materialization is async): a render cancelled before its job exists
+      // checks the mark before spawning.
+      this._cancelledRenderRequestId = requestId;
+      if (requestId === this._activeRenderRequestId) this._activeRender?.kill();
+      return;
+    }
     this._activeSyntax?.kill();
     this._activeRender?.kill();
   }
+
+  /** The correlation id of the in-flight render (undefined for auto previews
+   *  or when settled) — the target a `cancel { requestId }` must match. */
+  private _activeRenderRequestId: string | undefined;
+  /** The id a targeted cancel was called with — lets a render that has not yet
+   *  spawned its job observe the cancellation (#226). */
+  private _cancelledRenderRequestId: string | undefined;
 
   /**
    * Convert the typed sources to the flat wire shape, reading each project-local
@@ -425,11 +443,24 @@ export class CompileCoordinator {
         backend: this.ctx.getState().params.backend,
         revision: this.ctx.getSourceRevision(),
       };
+      if (requestId !== undefined && this._cancelledRenderRequestId === requestId) {
+        // A targeted cancel landed during source materialization, before any
+        // job existed: honor it without spawning.
+        this._cancelledRenderRequestId = undefined;
+        this.ctx.mutate((s) => setRendering(s, false));
+        this.emitResult(operationCancelled(base()));
+        return;
+      }
       const renderJob = this._render(renderArgs)({ now });
-      // Retain the handle so cancel() can kill it; clear it once it settles.
+      // Retain the handle (and its correlation id, for targeted cancel #226)
+      // so cancel() can kill it; clear both once it settles.
       this._activeRender = renderJob;
+      this._activeRenderRequestId = requestId;
       const output = await renderJob.finally(() => {
-        if (this._activeRender === renderJob) this._activeRender = null;
+        if (this._activeRender === renderJob) {
+          this._activeRender = null;
+          this._activeRenderRequestId = undefined;
+        }
       });
       if (!isCurrent()) {
         this.emitResult(operationCancelled(base())); // superseded

--- a/src/state/services/export-service.ts
+++ b/src/state/services/export-service.ts
@@ -68,12 +68,17 @@ export class ExportService {
     });
   }
 
-  /** Cancel an in-flight format-conversion render (best-effort, #123). The killed
-   *  job rejects with an expected cancellation, so the existing catch emits one
-   *  terminal `cancelled` result and clears the exporting spinner. The mark also
-   *  covers the pre-spawn window (reading the conversion input is async now):
-   *  an export cancelled before its job exists checks the mark after the read. */
-  cancel(): void {
+  /** Cancel an in-flight export (best-effort, #123). The killed job rejects
+   *  with an expected cancellation, so the existing catch emits one terminal
+   *  `cancelled` result and clears the exporting spinner. The mark also covers
+   *  the pre-spawn window (reading the conversion input is async): an export
+   *  cancelled before its job exists checks the mark after the read.
+   *
+   *  With `requestId` (#226) only the export started by the command carrying
+   *  that id is cancelled — a mismatching id no-ops (that export is already
+   *  superseded or was never ours to kill). */
+  cancel(requestId?: string): void {
+    if (requestId !== undefined && requestId !== this._latestRequestId) return;
     this._cancelledToken = this._exportSeq;
     this._activeRender?.kill();
   }
@@ -81,6 +86,9 @@ export class ExportService {
   /** The export token cancel() was called against (-1 = none) — lets an export
    *  that has not yet spawned its job observe the cancellation. */
   private _cancelledToken = -1;
+  /** The correlation id of the LATEST export invocation (undefined when it
+   *  carried none) — the target a `cancel { requestId }` must match (#226). */
+  private _latestRequestId: string | undefined;
 
   /** Route a terminal result to the optional sink, guarding the commit path: a
    *  throwing sink must never corrupt committed state or double-emit (ADR 0008).
@@ -108,6 +116,7 @@ export class ExportService {
     // `exporting` spinner so a superseded export can neither commit a stale
     // result nor leave the spinner stuck.
     const token = ++this._exportSeq;
+    this._latestRequestId = requestId;
     const isCurrent = () => this._exportSeq === token;
     const operationId = newId(); // one per export() invocation (ADR 0008)
     // The status-independent fields for this export's single terminal result. The

--- a/src/state/session.ts
+++ b/src/state/session.ts
@@ -96,9 +96,10 @@ export class OpenScadSession implements ProjectContract {
     this.model.exportArtifact(format, requestId);
   }
 
-  /** Cancel this session's in-flight compile/export operations (#123). */
-  cancel(): void {
-    this.model.cancel();
+  /** Cancel in-flight operations (#123): all of them, or — with `requestId`
+   *  (#226) — only the operation started by the command carrying that id. */
+  cancel(requestId?: string): void {
+    this.model.cancel(requestId);
   }
 
   /** Tear the session down: stop persistence timers and terminate the worker.


### PR DESCRIPTION
## Summary

**`cancel { requestId? }`** — with an id, only the operation started by the command carrying that id is cancelled (render #219 / export #216), so cancelling a slow full render no longer kills a concurrent save's auto preview or syntax check. Without an id, the pre-existing cancel-everything fan-out is unchanged. Both services honor a targeted cancel landing in their pre-spawn windows (source materialization / input read) via cancellation marks; killed ops already terminate as cancelled results echoing their requestId, so no new result plumbing. Additive to protocol v2 (releases as v0.3.4 together with #227).

## Review

Adversarially reviewed as a pair with #227. Its Medium finding — the coordinator's cancel mark permanently poisoned an id, so a later operation *reusing* it would spuriously self-cancel (repro'd both ways) — is fixed in the follow-up commit on the stacked #227 branch (mark cleared at render entry; regression tests for kill-then-reuse, cancel-after-finish, and the superseded-export no-op), landing minutes after this merges and before the v0.3.4 release. Verified clean: the retry recursion is covered by the mark, dispatch fan-out semantics defensible, export token design immune to reuse.

## Testing

Unit: transport accept/reject/caps, dispatch pass-through, targeted-kill vs spare-the-preview, pre-spawn cancel, export-side matching/no-op. Full verify + browser session e2e green.

Closes #226.