### PR TITLE
feat(session): setProject ack with the assigned sourceRevision (#227, v0.3.4)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,8 +6,16 @@ release (changelog upkeep and tagging had lapsed between `0.1.0` and `0.2.0`).
 
 ## [Unreleased]
 
+## [0.3.4] - 2026-07-03
+
 ### Added
 
+- `setProject` ack (#227): `setProject { …, requestId? }` is answered with
+  `project-ack { requestId, sourceRevision }` — the engine's assigned revision
+  for that push. A host can then accept exactly that push's results instead of
+  the monotonic-revision heuristic (closing the last stale-settle window), and
+  a REJECTED push becomes detectable on the wire: the acked revision equals
+  the previous one. Additive to protocol v2.
 - Targeted cancel over the L1 wire (#226): `cancel { requestId? }` — with an
   id, only the operation started by the command carrying that id is cancelled
   (render #219 / export #216), covering the pre-spawn windows too; auto

--- a/docs/EMBEDDING-VSCODE.md
+++ b/docs/EMBEDDING-VSCODE.md
@@ -312,7 +312,7 @@ The handshake is the same shape as §4: wait for `ready` (its `capabilities` are
 inbound command names) and assert `protocolVersion === SESSION_PROTOCOL_VERSION`
 before sending. Then **drive a project** rather than push geometry:
 
-- **Host → session:** `setProject { files, entryPoint? }` where each file is
+- **Host → session:** `setProject { files, entryPoint?, requestId? }` where each file is
   `{path, content}` (editable text) **or** `{path, bytes}` (a binary asset's
   exact bytes as a `Uint8Array` — #172; e.g. an `.stl` referenced via
   `import()`; a binary entry point renders via the engine's `import()` wrapper;
@@ -331,7 +331,10 @@ before sending. Then **drive a project** rather than push geometry:
   one edit fans out to multiple terminal results; correlate by the nested
   `result.operationId` / `kind` / `sourceRevision`, **not** 1:1 with commands),
   `artifact { requestId, available, artifact?, bytes? }` (the correlated reply to
-  `getArtifact`), and `error { code, reason }`.
+  `getArtifact`), `project-ack { requestId, sourceRevision }` (the reply to a
+  `setProject` that carried a `requestId` — #227: the engine's ASSIGNED revision
+  for that push; accept exactly the results carrying it, and detect a rejected
+  push by an unchanged revision), and `error { code, reason }`.
 
 Geometry is **not** sent over the wire: the session renders it **in-process** into
 its embedded viewer. The `operation-result` carries an `artifact` _reference_

--- a/docs/EMBEDDING-VSCODE.md
+++ b/docs/EMBEDDING-VSCODE.md
@@ -376,6 +376,16 @@ when the consuming extension declares `engines.vscode >= 1.57` (VS Code gates
 buffer serialization per extension); older declarations silently mangle the
 bytes.
 
+**Version pairing:** additive protocol-v2 features (`requestId` echoes, the
+`project-ack`, targeted cancel) degrade SILENTLY against an older session
+bundle — a `requestId`'d `setProject` never acks (indistinguishable from a slow
+session) and a targeted `cancel` becomes cancel-everything. Always pair the
+vendored bundle with the manifest it shipped with (the extension's atomic
+re-vendor does this); never mix a new host with a cached older bundle. Also
+note the rejected-push detection needs a PRIOR ack as baseline: a rejected
+FIRST push acks the boot revision and is detectable only by the absence of any
+results at a new revision.
+
 > Compiling arbitrary `.scad` runs the full OpenSCAD engine on host-supplied input.
 > Push only files the user opened/trusts; the protocol caps file count/size, but
 > the compiler itself is the trust boundary.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "openscad-web",
-  "version": "0.3.3",
+  "version": "0.3.4",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "openscad-web",
-      "version": "0.3.3",
+      "version": "0.3.4",
       "dependencies": {
         "@monaco-editor/loader": "^1.4.0",
         "blurhash": "^2.0.5",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "openscad-web",
-  "version": "0.3.3",
+  "version": "0.3.4",
   "private": true,
   "type": "module",
   "homepage": "https://cameronbrooks11.github.io/openscad-web/",

--- a/src/protocol/__tests__/session-transport.test.ts
+++ b/src/protocol/__tests__/session-transport.test.ts
@@ -10,6 +10,7 @@ import {
   sessionArtifact,
   sessionError,
   sessionOperationResult,
+  sessionProjectAck,
   sessionReady,
   validateSessionInbound,
 } from '../session-transport.ts';
@@ -61,6 +62,18 @@ describe('validateSessionInbound', () => {
     });
     // entryPoint omitted is fine.
     expect(ok({ type: 'setProject', files: [] })).toMatchObject({ ok: true });
+    // Optional correlation id (#227): forwarded when present, validated when given.
+    expect(ok({ type: 'setProject', files: [], requestId: 'p-1' })).toEqual({
+      ok: true,
+      message: { type: 'setProject', files: [], requestId: 'p-1' },
+    });
+    expect(ok({ type: 'setProject', files: [], requestId: 9 })).toMatchObject({
+      ok: false,
+      code: 'invalid-payload',
+    });
+    expect(
+      ok({ type: 'setProject', files: [], requestId: 'x'.repeat(SESSION_MAX_ID_LENGTH + 1) }),
+    ).toMatchObject({ ok: false, code: 'too-large' });
   });
 
   it('accepts binary project files (bytes as Uint8Array) and enforces one-of content|bytes (#172)', () => {
@@ -372,6 +385,15 @@ describe('outbound builders', () => {
       type: 'artifact',
       requestId: 'r-2',
       available: false,
+    });
+  });
+
+  it('sessionProjectAck echoes the id with the assigned revision (#227)', () => {
+    expect(sessionProjectAck('p-1', 7)).toEqual({
+      protocolVersion: v,
+      type: 'project-ack',
+      requestId: 'p-1',
+      sourceRevision: 7,
     });
   });
 

--- a/src/protocol/session-transport.ts
+++ b/src/protocol/session-transport.ts
@@ -64,7 +64,7 @@ export type SessionExportFormat = (typeof SESSION_EXPORT_FORMATS)[number];
  *  plus `export` (#216), `getArtifact` (bytes-by-id, #197), and `dispose` for
  *  worker teardown. */
 export type SessionInbound =
-  | { type: 'setProject'; files: ProjectFile[]; entryPoint?: string }
+  | { type: 'setProject'; files: ProjectFile[]; entryPoint?: string; requestId?: string }
   | { type: 'updateFile'; path: string; content: string }
   | { type: 'removeFile'; path: string }
   | { type: 'setEntryPoint'; path: string }
@@ -153,12 +153,23 @@ export function validateSessionInbound(data: unknown): SessionValidation {
       if (data.entryPoint !== undefined && entryPoint === undefined) {
         return err('invalid-payload', 'entryPoint must be a string');
       }
+      // Optional correlation id (#227): when present, the session replies with
+      // project-ack { requestId, sourceRevision } so the host can correlate
+      // this push's results EXACTLY (by revision) instead of heuristically.
+      const requestId = data.requestId === undefined ? undefined : readString(data.requestId);
+      if (data.requestId !== undefined && requestId === undefined) {
+        return err('invalid-payload', 'requestId must be a string');
+      }
+      if (requestId !== undefined && requestId.length > SESSION_MAX_ID_LENGTH) {
+        return err('too-large', 'an id is too long');
+      }
       return {
         ok: true,
         message: {
           type: 'setProject',
           files: result.files,
           ...(entryPoint !== undefined ? { entryPoint } : {}),
+          ...(requestId !== undefined ? { requestId } : {}),
         },
       };
     }
@@ -311,6 +322,26 @@ export function sessionArtifact(
         bytes: resolved.bytes,
       }
     : { protocolVersion: SESSION_PROTOCOL_VERSION, type: 'artifact', requestId, available: false };
+}
+
+/** The reply to a `setProject` that carried a `requestId` (#227): echoes the id
+ *  with the engine's ASSIGNED source revision, so the host can accept exactly
+ *  the results of this push (each `setProject` bumps the revision once). A
+ *  rejected push is detectable: the acked revision equals the previous one. */
+export type SessionProjectAck = {
+  protocolVersion: number;
+  type: 'project-ack';
+  requestId: string;
+  sourceRevision: number;
+};
+
+export function sessionProjectAck(requestId: string, sourceRevision: number): SessionProjectAck {
+  return {
+    protocolVersion: SESSION_PROTOCOL_VERSION,
+    type: 'project-ack',
+    requestId,
+    sourceRevision,
+  };
 }
 
 /** A protocol-level rejection of an inbound message (validation failure). */

--- a/src/session-host/__tests__/controller.test.ts
+++ b/src/session-host/__tests__/controller.test.ts
@@ -11,6 +11,8 @@ const flush = () => new Promise((r) => setTimeout(r));
 class FakeSession implements SessionHost {
   calls: string[] = [];
   disposed = false;
+  /** Mirrors the engine: each setProject bumps the revision exactly once. */
+  revision = 0;
   throwOnUpdate = false;
   throwOnRead = false;
   useDeferredReads = false;
@@ -19,7 +21,11 @@ class FakeSession implements SessionHost {
   private readDeferreds = new Map<string, (text: string | undefined) => void>();
 
   setProject(files: { path: string }[], entryPoint?: string) {
+    this.revision++;
     this.calls.push(`setProject:${files.length}:${entryPoint ?? ''}`);
+  }
+  currentSourceRevision() {
+    return this.revision;
   }
   updateFile(path: string) {
     if (this.throwOnUpdate) throw new Error('ProjectPathError: unsafe path');
@@ -262,6 +268,63 @@ describe('SessionController', () => {
     session.emit(result({ kind: 'render', sourceRevision: 3, artifactId: 'a1' }));
     await flush();
     expect(viewer.offText).toBeNull();
+  });
+
+  it('setProject with a requestId is acked with the ASSIGNED revision (#227)', () => {
+    const { session, transport } = setup();
+    transport.receive({
+      protocolVersion: V,
+      type: 'setProject',
+      files: [{ path: '/a', content: 'x' }],
+      requestId: 'push-1',
+    });
+    expect(transport.sent.at(-1)).toEqual({
+      protocolVersion: V,
+      type: 'project-ack',
+      requestId: 'push-1',
+      sourceRevision: 1,
+    });
+    // A second push acks the bumped revision.
+    transport.receive({
+      protocolVersion: V,
+      type: 'setProject',
+      files: [{ path: '/a', content: 'y' }],
+      requestId: 'push-2',
+    });
+    expect(transport.sent.at(-1)).toMatchObject({ requestId: 'push-2', sourceRevision: 2 });
+    expect(session.calls.filter((c) => c.startsWith('setProject'))).toHaveLength(2);
+  });
+
+  it('setProject without a requestId sends no ack (pre-#227 behavior)', () => {
+    const { transport } = setup();
+    transport.receive({
+      protocolVersion: V,
+      type: 'setProject',
+      files: [{ path: '/a', content: 'x' }],
+    });
+    expect(sentTypes(transport)).toEqual(['ready']);
+  });
+
+  it('a REJECTED push acks the UNCHANGED revision (host-detectable, #227)', () => {
+    const { session, transport } = setup();
+    transport.receive({
+      protocolVersion: V,
+      type: 'setProject',
+      files: [{ path: '/a', content: 'x' }],
+      requestId: 'push-1',
+    });
+    // Model swallows contract errors internally without bumping the revision;
+    // simulate by making setProject a no-op on the revision.
+    session.setProject = (files: { path: string }[]) => {
+      session.calls.push(`setProject-rejected:${files.length}`);
+    };
+    transport.receive({
+      protocolVersion: V,
+      type: 'setProject',
+      files: [{ path: '/a', content: 'y' }],
+      requestId: 'push-2',
+    });
+    expect(transport.sent.at(-1)).toMatchObject({ requestId: 'push-2', sourceRevision: 1 });
   });
 
   it('getArtifact: replies with the ref + exact bytes, correlated by requestId', async () => {

--- a/src/session-host/controller.ts
+++ b/src/session-host/controller.ts
@@ -14,6 +14,7 @@ import {
   sessionArtifact,
   sessionError,
   sessionOperationResult,
+  sessionProjectAck,
   sessionReady,
   validateSessionInbound,
 } from '../protocol/session-transport.ts';
@@ -42,6 +43,9 @@ export interface SessionHost {
   /** Subscribe to terminal operation results (the Model's `'operation'` stream);
    *  returns an unsubscribe. */
   onOperation(handler: (result: OperationResult) => void): () => void;
+  /** The engine's current monotonic source revision — read right after a
+   *  `setProject` dispatch to ack the assigned revision (#227). */
+  currentSourceRevision(): number;
   /** The exact OFF text of a produced artifact (race-free, by id), or undefined. */
   readArtifactText(artifactId: string): Promise<string | undefined>;
   /** A produced artifact's immutable identity + exact bytes (by id), for the
@@ -88,6 +92,15 @@ export class SessionController {
       switch (msg.type) {
         case 'setProject':
           this.session.setProject(msg.files, msg.entryPoint);
+          // Ack with the ASSIGNED revision (#227): setProject is synchronous
+          // (including its internal error handling), so the revision read here
+          // is exactly this push's — or, for a REJECTED push, the unchanged
+          // previous one, which is how a host detects the rejection.
+          if (msg.requestId !== undefined) {
+            this.transport.send(
+              sessionProjectAck(msg.requestId, this.session.currentSourceRevision()),
+            );
+          }
           break;
         case 'updateFile':
           this.session.updateFile(msg.path, msg.content);

--- a/src/session-host/session-host.ts
+++ b/src/session-host/session-host.ts
@@ -21,6 +21,7 @@ export function sessionHostOf(session: OpenScadSession): SessionHost {
       session.model.addEventListener('operation', listener);
       return () => session.model.removeEventListener('operation', listener);
     },
+    currentSourceRevision: () => session.model.getSourceRevision(),
     readArtifactText: async (artifactId) => {
       const stored = session.artifacts.get(artifactId);
       return stored ? stored.bytes.text() : undefined;

--- a/src/state/model.ts
+++ b/src/state/model.ts
@@ -139,6 +139,12 @@ export class Model extends EventTarget {
     return this.artifacts.get(artifactId);
   }
 
+  /** The current monotonic source revision (#56) — read by the session host to
+   *  ack a `setProject` with its assigned revision (#227). */
+  getSourceRevision(): number {
+    return this._sourceRevision;
+  }
+
   private setState(state: State) {
     // bubbleUpDeepMutations gives params.sources a fresh identity exactly when
     // its contents change (and not on view/var-only edits), so a reference

--- a/src/state/services/__tests__/compile-coordinator.test.ts
+++ b/src/state/services/__tests__/compile-coordinator.test.ts
@@ -400,6 +400,41 @@ describe('CompileCoordinator terminal OperationResult (ADR 0008 slice 4)', () =>
     expect(results[0].status).toBe('success');
   });
 
+  it('a killed render does not poison its id — a later render reusing it runs (#226 review)', async () => {
+    const { ctx, results } = makeContext(1);
+    let rejectFn: (e: unknown) => void = () => {};
+    const hang = new Promise((_res, rej) => (rejectFn = rej)) as Promise<unknown> & {
+      kill: () => void;
+    };
+    hang.kill = vi.fn(() => rejectFn(new Error('Cancelled')));
+    renderImpl.mockReturnValueOnce(hang);
+    renderImpl.mockResolvedValueOnce(renderOutput(1));
+    const coord = new CompileCoordinator(ctx);
+
+    const p1 = coord.render({ isPreview: false, now: true, requestId: 'rq-reuse' });
+    await new Promise((r) => setTimeout(r, 0));
+    coord.cancel('rq-reuse'); // kills post-spawn; the mark must not linger
+    await p1;
+
+    const p2 = coord.render({ isPreview: false, now: true, requestId: 'rq-reuse' });
+    await p2;
+    expect(renderImpl).toHaveBeenCalledTimes(2); // the reuse actually spawned
+    expect(results.map((r) => r.status)).toEqual(['cancelled', 'success']);
+  });
+
+  it('a targeted cancel AFTER an op finished does not cancel a future op with the same id (#226 review)', async () => {
+    const { ctx, results } = makeContext(1);
+    renderImpl.mockResolvedValueOnce(renderOutput(1));
+    renderImpl.mockResolvedValueOnce(renderOutput(1));
+    const coord = new CompileCoordinator(ctx);
+
+    await coord.render({ isPreview: false, now: true, requestId: 'rq-late' });
+    coord.cancel('rq-late'); // late no-op — nothing in flight
+    await coord.render({ isPreview: false, now: true, requestId: 'rq-late' });
+
+    expect(results.map((r) => r.status)).toEqual(['success', 'success']);
+  });
+
   it('checkSyntax emits one success result with no artifact', async () => {
     const { ctx, results } = makeContext(1);
     checkSyntaxImpl.mockResolvedValue({ revision: 1, markers: [], logText: '' });

--- a/src/state/services/__tests__/export-service.test.ts
+++ b/src/state/services/__tests__/export-service.test.ts
@@ -364,6 +364,30 @@ describe('ExportService', () => {
     expect(getState().exporting).toBe(false);
   });
 
+  it('a targeted cancel for a SUPERSEDED export id no-ops (the newer export survives, #226)', async () => {
+    const { ctx, host, results } = makeCtx({
+      is2D: false,
+      exportFormat3D: 'stl',
+      output: fileOutput('m.off'),
+    });
+    const svc = new ExportService(ctx);
+    const secondInner = vi.fn().mockResolvedValue({
+      outFile: new File(['second'], 'second.stl'),
+      logText: '',
+      markers: [],
+      elapsedMillis: 1,
+    });
+    mockRenderExport.mockReturnValueOnce(secondInner);
+
+    const p1 = svc.export('stl', 'rq-old'); // superseded during its input read
+    const p2 = svc.export('stl', 'rq-new');
+    svc.cancel('rq-old'); // targets the superseded one → must not touch rq-new
+    await Promise.all([p1, p2]);
+
+    expect(host.download.mock.calls.map((c) => c[1])).toEqual(['second.stl']);
+    expect(results.find((r) => r.requestId === 'rq-new')?.status).toBe('success');
+  });
+
   it('treats a superseded (cancelled) export as supersession, not a user-facing error', async () => {
     const { ctx, host, getState } = makeCtx({
       is2D: false,

--- a/src/state/services/compile-coordinator.ts
+++ b/src/state/services/compile-coordinator.ts
@@ -367,6 +367,13 @@ export class CompileCoordinator {
     retryInOtherDim ??= true;
     // A render and a preview own separate UI flags; track the latest of each so a
     // superseded call cannot turn off the spinner a newer call is still driving.
+    // A mark equal to THIS render's id at entry is necessarily stale (wire
+    // dispatch is synchronous, so a cancel for this command can only be
+    // processed after entry): clear it, or a reused id would self-cancel
+    // pre-spawn (#226 review — every targeted cancel used to poison its id).
+    if (requestId !== undefined && this._cancelledRenderRequestId === requestId) {
+      this._cancelledRenderRequestId = undefined;
+    }
     const token = isPreview ? ++this._previewSeq : ++this._renderSeq;
     const isCurrent = () => (isPreview ? this._previewSeq : this._renderSeq) === token;
     // One operation id per scheduler invocation (ADR 0008). The dimension retry

--- a/tests/session.spec.ts
+++ b/tests/session.spec.ts
@@ -27,6 +27,7 @@ declare global {
         artifact?: { format?: string; artifactId?: string };
       };
       requestId?: string;
+      sourceRevision?: number;
       available?: boolean;
       artifact?: { format?: string };
       bytes?: Uint8Array;
@@ -97,10 +98,24 @@ test.describe('session distributable (#193)', () => {
             { path: 'assets/blob.bin', bytes: new Uint8Array([0xde, 0xad, 0xbe, 0xef]) },
           ],
           entryPoint: 'main.scad',
+          requestId: 'e2e-push-1',
         },
         window.location.origin,
       );
     }, protocolVersion);
+
+    // The push is acked with its assigned revision (#227) before any results.
+    await page.waitForFunction(
+      () =>
+        window.__sessionMessages?.some(
+          (m) =>
+            m?.type === 'project-ack' &&
+            m?.requestId === 'e2e-push-1' &&
+            typeof m?.sourceRevision === 'number',
+        ),
+      null,
+      { timeout: 30_000 },
+    );
 
     // A genuine WASM compile fans out to a success operation-result carrying an
     // OFF artifact (the render bridge also sets it on the embedded viewer, but the


### PR DESCRIPTION
## Summary

**`setProject { …, requestId? }` → `project-ack { requestId, sourceRevision }`** — the engine's ASSIGNED revision for that push, read synchronously after dispatch (each push bumps the revision exactly once; no result can precede the ack — verified through the full dispatch chain). A host can then accept exactly that push's results by revision, replacing the monotonic-floor heuristic and its reload special-cases and closing the last stale-settle window. Bonus: a REJECTED push (swallowed into `state.error`, previously invisible on the wire) is now detectable — the acked revision doesn't advance. Additive to protocol v2; ships as **v0.3.4** (bump + CHANGELOG included; #226 merged just before).

Also carries the pair review's fix commit: the #226 cancel-mark poisoning (a killed/finished operation's id spuriously self-cancelled a later op reusing it — repro'd) is fixed with an entry-time stale-mark clear + regression tests, and the docs gain the version-pairing warning (additive v2 features degrade silently against an older bundle) and the first-push rejection-baseline caveat.

## Review

Adversarially reviewed as a pair with #226: ack ordering verified un-raceable (no emit exists in the dispatch's synchronous prefix), rejected-push ack semantics verified against Model's internal error handling, dispose interleaving impossible. Findings (1 Medium mark-poisoning, 2 doc Lows) all addressed in this PR.

## Testing

642 unit tests (new: ack with assigned/bumped revision, no-ack-without-id, rejected-push unchanged-revision, mark-reuse regressions, superseded-export targeted no-op) + 25 e2e; the real-WASM session e2e asserts the ack (id + revision) precedes its push's results.

Closes #227.