### PR TITLE
feat(fs): runtime user-library plumbing — registry, shadow, replay (#195 Phase A)

### DIFF
--- a/docs/architecture/adr/0010-runtime-user-libraries.md
+++ b/docs/architecture/adr/0010-runtime-user-libraries.md
@@ -157,8 +157,12 @@ itself lives OUTSIDE `params`/the durable slice, see §7) and then drives
 - **Paths**: relative, normalized, no traversal/absolute/control characters
   (the `normalizeProjectPath` posture); bytes at text-suffix paths must be
   valid UTF-8 (#172 semantics).
-- **Duplicates**: duplicate names in one payload, or duplicate paths within
-  one library, reject atomically. Case-variant names/paths are permitted (the
+- **Duplicates and prefix conflicts**: duplicate names in one payload,
+  duplicate paths within one library, and a path that is a DIRECTORY PREFIX of
+  another (`a` next to `a/b.scad` — one must be a file and a directory at
+  once) all reject atomically. The apply layer additionally contains per-library
+  failures (a failing library is cleaned up and reported; the others still
+  apply) as defense in depth. Case-variant names/paths are permitted (the
   VFS is case-sensitive) — a documented divergence from native Windows
   OpenSCAD, where wrong-case directives resolve.
 - **Budgets**: a **separate pool** from the project push, with the same

--- a/src/fs/BrowserFS.d.ts
+++ b/src/fs/BrowserFS.d.ts
@@ -9,6 +9,10 @@ declare interface FS {
    * convert through BrowserFS's own `Buffer` first. See ADR 0006.
    */
   writeBytes(path: string, content: Uint8Array): void;
+  /** Error-VISIBLE sync byte write (writeBytes swallows failures through
+   *  BrowserFS's default no-op callback). Installed by createEditorFS. */
+  writeBytesSync(path: string, content: Uint8Array): void;
+  writeFileSync(path: string, content: any): void;
   readdir(path: string, cb: (err: any, files: string[]) => void): void;
   readdirSync(path: string): string[];
   symlink(target: string, source: string): void;

--- a/src/fs/__tests__/library-mounter.test.ts
+++ b/src/fs/__tests__/library-mounter.test.ts
@@ -21,14 +21,59 @@ vi.mock('../zip-archives.generated.ts', () => ({
   zipArchives: [
     { name: 'demo', zipPath: 'libraries/demo.zip', mountPath: '/libraries/demo' },
     { name: 'extra', zipPath: 'libraries/extra.zip', mountPath: '/libraries/extra' },
+    {
+      name: 'flat',
+      zipPath: 'libraries/flat.zip',
+      mountPath: '/libraries/flat',
+      symlinks: { 'flat.scad': 'flat.scad' },
+    },
   ],
 }));
 
 import { fetchAssetBytes } from '../../runtime/fetch-asset.ts';
-import { LibraryMounter } from '../filesystem.ts';
+import { LibraryMounter, symlinkLibraries } from '../filesystem.ts';
 
 const mockFetch = fetchAssetBytes as ReturnType<typeof vi.fn>;
-const fakeRoot = () => ({ mount: vi.fn() });
+const fakeRoot = () => ({ mount: vi.fn(), umount: vi.fn() });
+
+/** Minimal in-memory Node-compat sync FS for applyRuntimeLibraries. */
+function fakeFs() {
+  const files = new Map<string, string | Uint8Array>();
+  const dirs = new Set<string>(['/libraries']);
+  const fs = {
+    files,
+    mkdirSync: (p: string) => {
+      dirs.add(p);
+    },
+    writeFileSync: (p: string, content: string) => {
+      files.set(p, content);
+    },
+    writeBytes: (p: string, bytes: Uint8Array) => {
+      files.set(p, bytes);
+    },
+    readdirSync: (p: string) => {
+      const prefix = `${p}/`;
+      const entries = new Set<string>();
+      for (const key of [...files.keys(), ...dirs]) {
+        if (key.startsWith(prefix)) entries.add(key.slice(prefix.length).split('/')[0]);
+      }
+      return [...entries];
+    },
+    lstatSync: (p: string) => {
+      const isDir = dirs.has(p) || [...files.keys()].some((k) => k.startsWith(`${p}/`));
+      if (!isDir && !files.has(p)) throw new Error('ENOENT');
+      return { isDirectory: () => isDir && !files.has(p) };
+    },
+    statSync: (p: string) => fs.lstatSync(p),
+    unlinkSync: (p: string) => {
+      files.delete(p);
+    },
+    rmdirSync: (p: string) => {
+      dirs.delete(p);
+    },
+  };
+  return fs;
+}
 
 describe('LibraryMounter (#62 Slice D)', () => {
   beforeEach(() => vi.clearAllMocks());
@@ -72,7 +117,7 @@ describe('LibraryMounter (#62 Slice D)', () => {
   it('preloadAll mounts every registered archive', async () => {
     const root = fakeRoot();
     await new LibraryMounter(root).preloadAll();
-    expect(root.mount).toHaveBeenCalledTimes(2);
+    expect(root.mount).toHaveBeenCalledTimes(3); // demo + extra + flat (mock registry)
   });
 
   it('treats an "already taken" mount (racing thread) as success', async () => {
@@ -94,5 +139,131 @@ describe('LibraryMounter (#62 Slice D)', () => {
     await expect(new LibraryMounter(root).mountDemandLibraries(['use <demo>'])).rejects.toThrow(
       'disk full',
     );
+  });
+});
+
+describe('runtime user libraries (ADR 0010 / #195)', () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it('a runtime library shadows the bundled archive: no fetch, still resolves', async () => {
+    const root = fakeRoot();
+    const m = new LibraryMounter(root);
+    m.applyRuntimeLibraries(fakeFs(), [
+      { name: 'demo', files: [{ path: 'foo.scad', content: '// mine' }] },
+    ]);
+    const mounted = await m.mountDemandLibraries(['use <demo/foo.scad>']);
+    expect(mounted).toContain('demo');
+    expect(mockFetch).not.toHaveBeenCalled();
+    expect(root.mount).not.toHaveBeenCalled();
+  });
+
+  it('shadowing an ALREADY-MOUNTED bundled archive unmounts it; unshadow restores demand-mounting', async () => {
+    const root = fakeRoot();
+    const m = new LibraryMounter(root);
+    await m.mountDemandLibraries(['use <demo/x.scad>']); // bundled demo mounts
+    expect(root.mount).toHaveBeenCalledTimes(1);
+
+    m.applyRuntimeLibraries(fakeFs(), [{ name: 'demo', files: [] }]);
+    expect(root.umount).toHaveBeenCalledWith('/libraries/demo');
+
+    // Unshadow: an empty set removes the runtime copy; the bundled archive is
+    // demand-mountable again (a fresh fetch + mount).
+    m.applyRuntimeLibraries(fakeFs(), []);
+    await m.mountDemandLibraries(['use <demo/x.scad>']);
+    expect(mockFetch).toHaveBeenCalledTimes(2);
+    expect(root.mount).toHaveBeenCalledTimes(2);
+  });
+
+  it('replacing the set deletes previously-owned files (no stale leftovers)', () => {
+    const root = fakeRoot();
+    const m = new LibraryMounter(root);
+    const fs = fakeFs();
+    m.applyRuntimeLibraries(fs, [
+      {
+        name: 'MyLib',
+        files: [
+          { path: 'a.scad', content: 'a' },
+          { path: 'sub/extra.scad', content: 'x' },
+        ],
+      },
+    ]);
+    expect(fs.files.has('/libraries/MyLib/sub/extra.scad')).toBe(true);
+
+    m.applyRuntimeLibraries(fs, [{ name: 'MyLib', files: [{ path: 'a.scad', content: 'a2' }] }]);
+    expect(fs.files.get('/libraries/MyLib/a.scad')).toBe('a2');
+    expect(fs.files.has('/libraries/MyLib/sub/extra.scad')).toBe(false);
+  });
+
+  it('shadowing a custom-symlink-map bundled name is reported as a diagnostic', () => {
+    const m = new LibraryMounter(fakeRoot());
+    const { customSymlinkShadows } = m.applyRuntimeLibraries(fakeFs(), [
+      { name: 'flat', files: [{ path: 'flat.scad', content: '//' }] },
+      { name: 'MyLib', files: [] },
+    ]);
+    expect(customSymlinkShadows).toEqual(['flat']);
+  });
+
+  it('runtime libraries are included in every demand result, even unreferenced (sibling deps)', async () => {
+    const m = new LibraryMounter(fakeRoot());
+    m.applyRuntimeLibraries(fakeFs(), [{ name: 'SiblingDep', files: [] }]);
+    const mounted = await m.mountDemandLibraries(['cube(1);']); // no directives at all
+    expect(mounted).toContain('SiblingDep');
+  });
+
+  it("a runtime library's own directives demand-mount BUNDLED libraries", async () => {
+    const root = fakeRoot();
+    const m = new LibraryMounter(root);
+    m.applyRuntimeLibraries(fakeFs(), [
+      { name: 'MyLib', files: [{ path: 'util.scad', content: 'use <demo/std.scad>' }] },
+    ]);
+    const mounted = await m.mountDemandLibraries(['use <MyLib/util.scad>']);
+    expect(mounted).toEqual(expect.arrayContaining(['MyLib', 'demo']));
+    expect(root.mount).toHaveBeenCalledWith('/libraries/demo', expect.anything());
+  });
+
+  it('bytes files write via writeBytes; text files feed the dep scan', () => {
+    const m = new LibraryMounter(fakeRoot());
+    const fs = fakeFs();
+    const bytes = Uint8Array.from([1, 2]);
+    m.applyRuntimeLibraries(fs, [{ name: 'MyLib', files: [{ path: 'part.stl', bytes }] }]);
+    expect(fs.files.get('/libraries/MyLib/part.stl')).toBe(bytes);
+  });
+});
+
+describe('symlinkLibraries with runtime names (ADR 0010)', () => {
+  it('a runtime name gets the default /<name> symlink and never consults the registry', async () => {
+    const symlink = vi.fn(async () => {});
+    // 'TotallyUnknown' is not in zipArchives — would THROW without runtime awareness.
+    const failures = await symlinkLibraries(
+      ['TotallyUnknown'],
+      { symlink },
+      '/libraries',
+      '/',
+      new Set(['TotallyUnknown']),
+    );
+    expect(symlink).toHaveBeenCalledWith('/libraries/TotallyUnknown', '/TotallyUnknown');
+    expect(failures).toEqual([]);
+  });
+
+  it('a runtime name shadowing a custom-map bundled name still gets ONLY the default symlink', async () => {
+    const symlink = vi.fn(async () => {});
+    await symlinkLibraries(['flat'], { symlink }, '/libraries', '/', new Set(['flat']));
+    expect(symlink).toHaveBeenCalledTimes(1);
+    expect(symlink).toHaveBeenCalledWith('/libraries/flat', '/flat');
+  });
+
+  it('symlink failures are collected, not just console-swallowed', async () => {
+    const symlink = vi.fn(async () => {
+      throw new Error('EEXIST');
+    });
+    const failures = await symlinkLibraries(
+      ['MyLib'],
+      { symlink },
+      '/libraries',
+      '/',
+      new Set(['MyLib']),
+    );
+    expect(failures).toHaveLength(1);
+    expect(failures[0]).toMatch(/MyLib/);
   });
 });

--- a/src/fs/__tests__/library-mounter.test.ts
+++ b/src/fs/__tests__/library-mounter.test.ts
@@ -267,3 +267,78 @@ describe('symlinkLibraries with runtime names (ADR 0010)', () => {
     expect(failures[0]).toMatch(/MyLib/);
   });
 });
+
+describe('applyRuntimeLibraries failure containment (#195 Phase A review)', () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it('one failing library is skipped + cleaned up; the others still apply', () => {
+    const m = new LibraryMounter(fakeRoot());
+    const fs = fakeFs();
+    const goodBefore = { name: 'Good', files: [{ path: 'g.scad', content: '//' }] };
+    const bad = {
+      name: 'Bad',
+      files: [
+        { path: 'ok.scad', content: '//' },
+        { path: 'boom.scad', content: 'x' },
+      ],
+    };
+    const origWrite = fs.writeFileSync;
+    fs.writeFileSync = (p: string, c: string) => {
+      if (p.endsWith('boom.scad')) throw new Error('ENOTDIR');
+      origWrite(p, c);
+    };
+
+    const { failures } = m.applyRuntimeLibraries(fs, [goodBefore, bad]);
+
+    expect(failures).toEqual([{ name: 'Bad', reason: 'ENOTDIR' }]);
+    // The failing library's PARTIAL files were removed; it is not registered.
+    expect(fs.files.has('/libraries/Bad/ok.scad')).toBe(false);
+    expect([...m.runtimeNames()]).toEqual(['Good']);
+    expect(fs.files.has('/libraries/Good/g.scad')).toBe(true);
+  });
+
+  it('a failed umount aborts THAT library without touching the mount bookkeeping', async () => {
+    const root = {
+      mount: vi.fn(),
+      umount: vi.fn(() => {
+        throw new Error('umount failed');
+      }),
+    };
+    const m = new LibraryMounter(root);
+    await m.mountDemandLibraries(['use <demo/x.scad>']); // bundled demo mounted
+    const { failures } = m.applyRuntimeLibraries(fakeFs(), [{ name: 'demo', files: [] }]);
+    expect(failures[0]).toMatchObject({ name: 'demo' });
+    // Bookkeeping intact: demo still counts as mounted (the ZipFS still owns
+    // the path), and it is NOT registered as a runtime library.
+    expect([...m.runtimeNames()]).toEqual([]);
+    const mounted = await m.mountDemandLibraries(['use <demo/x.scad>']);
+    expect(mounted).toEqual(['demo']); // still served by the bundled mount
+    expect(root.mount).toHaveBeenCalledTimes(1); // no re-mount attempted
+  });
+
+  it('text-suffix BYTES files feed the dep scan (ADR 0010 §5)', async () => {
+    const root = fakeRoot();
+    const m = new LibraryMounter(root);
+    const scad = 'use <demo/std.scad>';
+    m.applyRuntimeLibraries(fakeFs(), [
+      {
+        name: 'MyLib',
+        files: [{ path: 'util.scad', bytes: Uint8Array.from(scad, (c) => c.charCodeAt(0)) }],
+      },
+    ]);
+    const mounted = await m.mountDemandLibraries([]);
+    expect(mounted).toEqual(expect.arrayContaining(['MyLib', 'demo']));
+  });
+
+  it('runtimeDeps reset between applies (a replaced lib stops demanding its old deps)', async () => {
+    const root = fakeRoot();
+    const m = new LibraryMounter(root);
+    m.applyRuntimeLibraries(fakeFs(), [
+      { name: 'A', files: [{ path: 'a.scad', content: 'use <demo/x.scad>' }] },
+    ]);
+    m.applyRuntimeLibraries(fakeFs(), [{ name: 'A', files: [{ path: 'a.scad', content: '//' }] }]);
+    const mounted = await m.mountDemandLibraries([]);
+    expect(mounted).toEqual(['A']); // demo no longer demanded
+    expect(mockFetch).not.toHaveBeenCalled();
+  });
+});

--- a/src/fs/filesystem.ts
+++ b/src/fs/filesystem.ts
@@ -4,6 +4,7 @@ import { getBrowserFS } from '../runtime/browserfs-runtime.ts';
 import { resolveRuntimeAssetUrl } from '../runtime/asset-urls.ts';
 import { fetchAssetBytes } from '../runtime/fetch-asset.ts';
 import { zipArchives, ZipArchive } from './zip-archives.generated.ts';
+import type { WorkerLibrary } from '../runner/worker-protocol.ts';
 import { isProbablyTextPath } from '../state/project-source.ts';
 
 // Re-export for consumers that need the type
@@ -141,6 +142,33 @@ export async function createEditorFS({
 // Demand-loaded library mounting
 // ---------------------------------------------------------------------------
 
+/** mkdir -p via the Node-compat sync API (BrowserFS InMemory supports sync). */
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+function mkdirpSync(fs: any, dir: string): void {
+  const parts = dir.split('/').filter(Boolean);
+  let cur = '';
+  for (const part of parts) {
+    cur += `/${part}`;
+    try {
+      fs.mkdirSync(cur);
+    } catch {
+      /* exists */
+    }
+  }
+}
+
+/** Recursive delete that tolerates an absent path (a removed runtime library
+ *  may never have been written in THIS worker's lifetime). */
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+function removeTreeIfPresentSync(fs: any, path: string): void {
+  try {
+    fs.lstatSync(path);
+  } catch {
+    return; // absent
+  }
+  removeTreeSync(fs, path);
+}
+
 /** Parses `use <...>` and `include <...>` directives; returns the top-level library names. */
 const LIBRARY_DIRECTIVE_RE = /(?:use|include)\s*<([^>]+)>/g;
 
@@ -163,15 +191,79 @@ export function extractLibraryNames(source: string): string[] {
 export class LibraryMounter {
   private readonly mounted = new Set<string>();
   private readonly mounting = new Map<string, Promise<void>>();
+  /** Runtime user libraries (ADR 0010): names applied via applyRuntimeLibraries.
+   *  A runtime name SHADOWS the bundled archive of the same name entirely. */
+  private readonly runtime = new Set<string>();
+  /** Bundled library names referenced by the runtime libraries' own text files
+   *  (`use <BOSL2/…>` inside a user lib) — joined into every demand scan. */
+  private runtimeDeps = new Set<string>();
 
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   constructor(private readonly rootMFS: any) {}
 
+  /** The currently applied runtime library names (for per-job symlinking). */
+  runtimeNames(): ReadonlySet<string> {
+    return this.runtime;
+  }
+
+  /**
+   * Replace the FULL runtime user-library set (ADR 0010): delete every
+   * previously runtime-owned `/libraries/<name>` subtree, unmount any bundled
+   * ZipFS a new name shadows (restoring demand-mount eligibility when the
+   * shadow is later removed), then write the new files into the /libraries
+   * partition. Runs at job boundaries only (the worker guarantees that), so
+   * the multi-step replace is never observed torn. Returns the names that
+   * shadow a bundled archive with a CUSTOM symlink map — those libraries'
+   * include style changes under the shadow (runtime libs always get the
+   * default `/<name>` symlink) and the host should surface it.
+   */
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  applyRuntimeLibraries(fs: any, libraries: WorkerLibrary[]): { customSymlinkShadows: string[] } {
+    for (const name of this.runtime) {
+      removeTreeIfPresentSync(fs, `/libraries/${name}`);
+    }
+    this.runtime.clear();
+    this.runtimeDeps = new Set<string>();
+    const customSymlinkShadows: string[] = [];
+    for (const lib of libraries) {
+      const bundled = zipArchives.find((a) => a.name === lib.name);
+      if (bundled && this.mounted.has(lib.name)) {
+        // The bundled archive is ALREADY mounted at this path — the shadow
+        // requires unmounting it, or the ZipFS keeps owning the subtree and
+        // the runtime files are unreachable.
+        try {
+          this.rootMFS.umount(bundled.mountPath);
+        } catch (e) {
+          console.error(`umount(${bundled.mountPath}) failed:`, e);
+        }
+        this.mounted.delete(lib.name);
+      }
+      if (bundled?.symlinks) customSymlinkShadows.push(lib.name);
+      for (const file of lib.files) {
+        const full = `/libraries/${lib.name}/${file.path}`;
+        mkdirpSync(fs, full.slice(0, full.lastIndexOf('/')));
+        if (file.bytes !== undefined) {
+          fs.writeBytes(full, file.bytes);
+        } else {
+          fs.writeFileSync(full, file.content ?? '');
+        }
+        if (typeof file.content === 'string') {
+          for (const dep of extractLibraryNames(file.content)) this.runtimeDeps.add(dep);
+        }
+      }
+      this.runtime.add(lib.name);
+    }
+    return { customSymlinkShadows };
+  }
+
   /**
    * Fetches and mounts a single library ZIP into the /libraries partition.
    * No-op if already mounted (session cache); concurrent calls share one mount.
+   * A runtime user library SHADOWS the bundled archive of the same name — the
+   * bundled zip is never fetched while the shadow is in place (ADR 0010).
    */
   private async fetchAndMount(name: string): Promise<void> {
+    if (this.runtime.has(name)) return;
     if (this.mounted.has(name)) return;
     const inFlight = this.mounting.get(name);
     if (inFlight) return inFlight;
@@ -211,9 +303,21 @@ export class LibraryMounter {
    * resolved set of mounted library names.
    */
   async mountDemandLibraries(sourceTexts: string[], extraNames: string[] = []): Promise<string[]> {
-    const needed = [...new Set([...sourceTexts.flatMap(extractLibraryNames), ...extraNames])];
+    // Every runtime library is included UNCONDITIONALLY (ADR 0010): symlinks
+    // are per-job and cheap, and sibling-dependency payloads (project uses A,
+    // A uses B) only work if unreferenced runtime names still resolve. The
+    // runtime libraries' own directive deps join the scan so a user lib that
+    // includes a BUNDLED library still demand-mounts it.
+    const needed = [
+      ...new Set([
+        ...sourceTexts.flatMap(extractLibraryNames),
+        ...extraNames,
+        ...this.runtime,
+        ...this.runtimeDeps,
+      ]),
+    ];
     await Promise.all(needed.map((n) => this.fetchAndMount(n)));
-    return needed.filter((n) => this.mounted.has(n));
+    return needed.filter((n) => this.mounted.has(n) || this.runtime.has(n));
   }
 
   /**
@@ -236,18 +340,30 @@ export async function symlinkLibraries(
   fs: any,
   prefix = '/libraries',
   cwd = '/',
-): Promise<void> {
+  runtimeNames: ReadonlySet<string> = new Set(),
+): Promise<string[]> {
+  const failures: string[] = [];
   const createSymlink = async (target: string, source: string) => {
     try {
       await fs.symlink(target, source);
     } catch (e) {
+      // Collected AND logged: for a runtime library the user explicitly
+      // pushed, a silently failed symlink is a silently dead library.
       console.error(`symlink(${target}, ${source}) failed: `, e);
+      failures.push(`symlink ${source} -> ${target} failed`);
     }
   };
 
   await Promise.all(
     archiveNames.map((n) =>
       (async () => {
+        // Runtime user libraries ALWAYS get the default `/<name>` directory
+        // symlink (ADR 0010) — a shadowed bundled archive's custom symlink map
+        // is never applied to runtime files.
+        if (runtimeNames.has(n)) {
+          await createSymlink(`${prefix}/${n}`, `${cwd === '/' ? '' : cwd}/${n}`);
+          return;
+        }
         const archive = zipArchives.find((a) => a.name === n);
         if (!archive) throw new Error(`Archive named ${n} not found in registry`);
         const { symlinks } = archive;
@@ -263,6 +379,7 @@ export async function symlinkLibraries(
       })(),
     ),
   );
+  return failures;
 }
 
 // ---------------------------------------------------------------------------

--- a/src/fs/filesystem.ts
+++ b/src/fs/filesystem.ts
@@ -135,12 +135,27 @@ export async function createEditorFS({
   fs.writeBytes = (path: string, content: Uint8Array): void => {
     fs.writeFile(path, BfsBuffer.from(content));
   };
+  // Error-VISIBLE variant for callers that must observe write failures (the
+  // async form swallows them via BrowserFS's default no-op callback).
+  fs.writeBytesSync = (path: string, content: Uint8Array): void => {
+    fs.writeFileSync(path, BfsBuffer.from(content));
+  };
   return { fs, libraries: new LibraryMounter(rootMFS) };
 }
 
 // ---------------------------------------------------------------------------
 // Demand-loaded library mounting
 // ---------------------------------------------------------------------------
+
+/** Best-effort UTF-8 decode for directive scanning; undefined when invalid
+ *  (Phase B's wire validation already rejects invalid text-suffix bytes). */
+function safeDecodeUtf8(bytes: Uint8Array): string | undefined {
+  try {
+    return new TextDecoder('utf-8', { fatal: true }).decode(bytes);
+  } catch {
+    return undefined;
+  }
+}
 
 /** mkdir -p via the Node-compat sync API (BrowserFS InMemory supports sync). */
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
@@ -218,42 +233,65 @@ export class LibraryMounter {
    * default `/<name>` symlink) and the host should surface it.
    */
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  applyRuntimeLibraries(fs: any, libraries: WorkerLibrary[]): { customSymlinkShadows: string[] } {
+  applyRuntimeLibraries(
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    fs: any,
+    libraries: WorkerLibrary[],
+  ): { customSymlinkShadows: string[]; failures: { name: string; reason: string }[] } {
     for (const name of this.runtime) {
       removeTreeIfPresentSync(fs, `/libraries/${name}`);
     }
     this.runtime.clear();
     this.runtimeDeps = new Set<string>();
     const customSymlinkShadows: string[] = [];
+    const failures: { name: string; reason: string }[] = [];
     for (const lib of libraries) {
-      const bundled = zipArchives.find((a) => a.name === lib.name);
-      if (bundled && this.mounted.has(lib.name)) {
-        // The bundled archive is ALREADY mounted at this path — the shadow
-        // requires unmounting it, or the ZipFS keeps owning the subtree and
-        // the runtime files are unreachable.
-        try {
+      // Exception-contained PER LIBRARY: one bad library (e.g. an FS-level
+      // path collision the wire validation cannot fully preclude) must fail
+      // alone — its partial subtree is removed, the failure is reported, and
+      // the other libraries still apply. A throw escaping here used to poison
+      // every subsequent compile (the worker retried the same set forever).
+      try {
+        const bundled = zipArchives.find((a) => a.name === lib.name);
+        if (bundled && this.mounted.has(lib.name)) {
+          // The bundled archive is ALREADY mounted at this path — the shadow
+          // requires unmounting it, or the read-only ZipFS keeps owning the
+          // subtree and every write below fails. An umount failure aborts
+          // THIS library (writing into the ZipFS would be worse).
           this.rootMFS.umount(bundled.mountPath);
-        } catch (e) {
-          console.error(`umount(${bundled.mountPath}) failed:`, e);
+          this.mounted.delete(lib.name);
         }
-        this.mounted.delete(lib.name);
+        if (bundled?.symlinks) customSymlinkShadows.push(lib.name);
+        for (const file of lib.files) {
+          const full = `/libraries/${lib.name}/${file.path}`;
+          mkdirpSync(fs, full.slice(0, full.lastIndexOf('/')));
+          if (file.bytes !== undefined) {
+            // Prefer the sync write (error-visible); the async writeBytes
+            // swallows failures via BrowserFS's default no-op callback.
+            if (fs.writeBytesSync) fs.writeBytesSync(full, file.bytes);
+            else fs.writeBytes(full, file.bytes);
+          } else {
+            fs.writeFileSync(full, file.content ?? '');
+          }
+          // Directive scan: text CONTENT, or bytes at a text-suffix path
+          // (ADR 0010 §5 — a .scad pushed as UTF-8 bytes still declares deps).
+          const text =
+            typeof file.content === 'string'
+              ? file.content
+              : file.bytes !== undefined && isProbablyTextPath(file.path)
+                ? safeDecodeUtf8(file.bytes)
+                : undefined;
+          if (text !== undefined) {
+            for (const dep of extractLibraryNames(text)) this.runtimeDeps.add(dep);
+          }
+        }
+        this.runtime.add(lib.name);
+      } catch (e) {
+        removeTreeIfPresentSync(fs, `/libraries/${lib.name}`);
+        failures.push({ name: lib.name, reason: e instanceof Error ? e.message : String(e) });
       }
-      if (bundled?.symlinks) customSymlinkShadows.push(lib.name);
-      for (const file of lib.files) {
-        const full = `/libraries/${lib.name}/${file.path}`;
-        mkdirpSync(fs, full.slice(0, full.lastIndexOf('/')));
-        if (file.bytes !== undefined) {
-          fs.writeBytes(full, file.bytes);
-        } else {
-          fs.writeFileSync(full, file.content ?? '');
-        }
-        if (typeof file.content === 'string') {
-          for (const dep of extractLibraryNames(file.content)) this.runtimeDeps.add(dep);
-        }
-      }
-      this.runtime.add(lib.name);
     }
-    return { customSymlinkShadows };
+    return { customSymlinkShadows, failures };
   }
 
   /**

--- a/src/fs/project-filesystem.ts
+++ b/src/fs/project-filesystem.ts
@@ -18,6 +18,8 @@ export interface ProjectFileSystem {
    * as zeros). See ADR 0006.
    */
   writeBytes?(path: string, content: Uint8Array): void;
+  /** Error-visible sync byte write (the async form swallows failures). */
+  writeBytesSync?(path: string, content: Uint8Array): void;
   /**
    * Create a single directory. Optional because most consumers never need it;
    * the real BrowserFS-backed `FS` provides it. Callers create parents in order

--- a/src/runner/openscad-runner.ts
+++ b/src/runner/openscad-runner.ts
@@ -14,6 +14,8 @@ import {
   CompileStdout,
   CompileStderr,
   MergedOutput,
+  type SetLibrariesRequest,
+  type WorkerLibrary,
 } from './worker-protocol.ts';
 
 export type MergedOutputs = MergedOutput[];
@@ -119,6 +121,10 @@ export interface CompileBackend {
   ): AbortablePromise<OpenSCADInvocationResults>;
   cancel(id: string, reason?: string): void;
   dispose(): void;
+  /** Replace the runtime user-library set (ADR 0010 / #195). The backend
+   *  retains it and replays it to the worker across recycles; applied at the
+   *  worker's next job boundary. Optional so fake/test backends keep working. */
+  setLibraries?(libraries: WorkerLibrary[]): void;
 }
 
 /**
@@ -166,6 +172,18 @@ export class WasmWorkerBackend implements CompileBackend {
     this.recycleWorker('Worker recycled after timeout');
   }
 
+  /** The retained runtime user-library set (ADR 0010), replayed to every
+   *  worker (re)creation — worker recycle wipes worker state, so the backend
+   *  is the durable owner. */
+  private librarySet: WorkerLibrary[] | undefined;
+
+  /** Replace the runtime user-library set; reaches the current worker now (if
+   *  any) and every future worker via the getWorker replay. */
+  setLibraries(libraries: WorkerLibrary[]): void {
+    this.librarySet = libraries;
+    this.worker?.postMessage({ type: 'setLibraries', libraries } satisfies SetLibrariesRequest);
+  }
+
   private getWorker(): Worker {
     if (!this.worker) {
       const generation = this.generation; // snapshot: pins this worker's identity
@@ -173,8 +191,15 @@ export class WasmWorkerBackend implements CompileBackend {
       this.worker.onmessage = (e: MessageEvent<WorkerResponse>) =>
         this.handleWorkerMessage(e, generation);
       this.worker.onerror = (e: ErrorEvent) => this.handleWorkerError(e);
-      // Inject the host-resolved asset base + wasm URL before any compile (#196).
+      // Inject the host-resolved asset base + wasm URL before any compile (#196),
+      // then replay the retained library set (recycle-transparent, ADR 0010).
       this.worker.postMessage(workerConfigPayload());
+      if (this.librarySet !== undefined) {
+        this.worker.postMessage({
+          type: 'setLibraries',
+          libraries: this.librarySet,
+        } satisfies SetLibrariesRequest);
+      }
     }
     return this.worker;
   }

--- a/src/runner/openscad-worker.ts
+++ b/src/runner/openscad-worker.ts
@@ -175,16 +175,25 @@ async function runCompile(msg: CompileRequest): Promise<void> {
       // Job boundary: apply the latest runtime library set BEFORE the demand
       // scan, so this job sees a complete, consistent set (ADR 0010).
       if (pendingLibraries !== undefined) {
-        const { customSymlinkShadows } = editorFs.libraries.applyRuntimeLibraries(
-          editorFs.fs,
-          pendingLibraries,
-        );
+        // ONE attempt per set: clear the pending slot before applying, or a
+        // deterministic apply failure would re-run (and re-fail) at every
+        // future job boundary — permanently poisoning the engine.
+        const toApply = pendingLibraries;
         pendingLibraries = undefined;
+        const { customSymlinkShadows, failures } = editorFs.libraries.applyRuntimeLibraries(
+          editorFs.fs,
+          toApply,
+        );
         for (const name of customSymlinkShadows) {
           mergedOutputs.push({
             stderr:
               `[openscad-web] runtime library '${name}' shadows a bundled library that ` +
               `used custom root symlinks; the runtime copy resolves as '${name}/...' only.`,
+          });
+        }
+        for (const failure of failures) {
+          mergedOutputs.push({
+            stderr: `[openscad-web] runtime library '${failure.name}' failed to apply and was skipped: ${failure.reason}`,
           });
         }
       }

--- a/src/runner/openscad-worker.ts
+++ b/src/runner/openscad-worker.ts
@@ -22,6 +22,7 @@ import {
   CompileStdout,
   CompileStderr,
   MergedOutput,
+  WorkerLibrary,
   WorkerRequest,
 } from './worker-protocol.ts';
 import { fetchSource } from '../utils.ts';
@@ -69,7 +70,11 @@ let editorFs: EditorFs | null = null;
  *   - /fonts      → BrowserFS /fonts     (ZipFS from fonts.zip, pre-loaded at init)
  * Then creates WASM FS symlinks so OpenSCAD can resolve `use <LibName/...>` from CWD.
  */
-async function ensureArchivesMounted(rt: OpenSCADRuntime, libraryNames: string[]): Promise<void> {
+async function ensureArchivesMounted(
+  rt: OpenSCADRuntime,
+  libraryNames: string[],
+  runtimeNames: ReadonlySet<string> = new Set(),
+): Promise<string[]> {
   const browserFS = await ensureWorkerBrowserFSLoaded();
   const BFS = new browserFS.EmscriptenFS(
     rt.FS,
@@ -90,8 +95,9 @@ async function ensureArchivesMounted(rt: OpenSCADRuntime, libraryNames: string[]
 
   // Create WASM FS symlinks so `use <MCAD/shapes.scad>` resolves from CWD /
   if (libraryNames.length > 0) {
-    await symlinkLibraries(libraryNames, rt.FS, '/libraries', '/');
+    return symlinkLibraries(libraryNames, rt.FS, '/libraries', '/', runtimeNames);
   }
+  return [];
 }
 
 // Compile jobs are serialized: the worker runs exactly one at a time. The async
@@ -101,8 +107,17 @@ async function ensureArchivesMounted(rt: OpenSCADRuntime, libraryNames: string[]
 // synchronous callMain cannot be interrupted (the host discards its result by id).
 const compileQueue = createSerialQueue<CompileRequest>((request) => runCompile(request));
 
+// The latest runtime user-library set, applied at the NEXT job boundary (ADR
+// 0010): applying mid-job would hand that job a torn, half-replaced set. The
+// host retains + re-sends the set after configure on every worker creation.
+let pendingLibraries: WorkerLibrary[] | undefined;
+
 self.addEventListener('message', (e: MessageEvent<WorkerRequest>) => {
   const msg = e.data;
+  if (msg.type === 'setLibraries') {
+    pendingLibraries = msg.libraries;
+    return;
+  }
   if (msg.type === 'configure') {
     appBaseUrl = msg.assetBase;
     wasmUrl = msg.wasmUrl;
@@ -157,6 +172,22 @@ async function runCompile(msg: CompileRequest): Promise<void> {
         .filter((p) => p.startsWith('/libraries/'))
         .map((p) => p.split('/')[2])
         .filter(Boolean);
+      // Job boundary: apply the latest runtime library set BEFORE the demand
+      // scan, so this job sees a complete, consistent set (ADR 0010).
+      if (pendingLibraries !== undefined) {
+        const { customSymlinkShadows } = editorFs.libraries.applyRuntimeLibraries(
+          editorFs.fs,
+          pendingLibraries,
+        );
+        pendingLibraries = undefined;
+        for (const name of customSymlinkShadows) {
+          mergedOutputs.push({
+            stderr:
+              `[openscad-web] runtime library '${name}' shadows a bundled library that ` +
+              `used custom root symlinks; the runtime copy resolves as '${name}/...' only.`,
+          });
+        }
+      }
       const libraryMountStart = performance.now();
       libraryNames = await editorFs.libraries.mountDemandLibraries(sourceTexts, extraNames);
       perf.workerLibraryMountMillis = performance.now() - libraryMountStart;
@@ -170,7 +201,14 @@ async function runCompile(msg: CompileRequest): Promise<void> {
     measurePerf('osc:wasm-init', 'osc:wasm-init-start', 'osc:wasm-init-end');
 
     if (mountArchives) {
-      await ensureArchivesMounted(rt, libraryNames);
+      const linkFailures = await ensureArchivesMounted(
+        rt,
+        libraryNames,
+        editorFs!.libraries.runtimeNames(),
+      );
+      for (const failure of linkFailures) {
+        mergedOutputs.push({ stderr: `[openscad-web] ${failure}` });
+      }
     }
 
     // Fonts resolved from cwd/fonts (via /fonts mount point)

--- a/src/runner/worker-protocol.ts
+++ b/src/runner/worker-protocol.ts
@@ -42,7 +42,21 @@ export type ConfigureRequest = {
   assetUrls?: Record<string, string>;
 };
 
-export type WorkerRequest = CompileRequest | CancelRequest | ConfigureRequest;
+/** One runtime user-library file (ADR 0010): a path RELATIVE to the library
+ *  root, as text or bytes. Validation happens host-side before this crosses. */
+export type WorkerLibraryFile = { path: string; content?: string; bytes?: Uint8Array };
+/** One runtime user library, keyed by its `use <Name/…>` token. */
+export type WorkerLibrary = { name: string; files: WorkerLibraryFile[] };
+
+/**
+ * Replace the FULL runtime user-library set (ADR 0010 / #195). Applied at the
+ * next job boundary (never mid-job); the host retains the set and re-sends it
+ * after `configure` whenever the worker is (re)created, so recycle is
+ * transparent.
+ */
+export type SetLibrariesRequest = { type: 'setLibraries'; libraries: WorkerLibrary[] };
+
+export type WorkerRequest = CompileRequest | CancelRequest | ConfigureRequest | SetLibrariesRequest;
 
 // Worker response types (worker → host)
 export type CompileStarted = { type: 'started'; id: string };


### PR DESCRIPTION
## Summary

**Phase A of #195** (per ADR 0010): the FS/worker/runner half of runtime user libraries — inert until Phase B's wire command lands.

- **`LibraryMounter` runtime registry**: `applyRuntimeLibraries(set)` deletes every previously runtime-owned `/libraries/<name>` subtree, unmounts an already-demand-mounted bundled ZipFS a new name shadows (restoring demand-mount eligibility on unshadow), writes the new files, and reports custom-symlink-map shadows. Shadowed bundled zips are never fetched; demand results include every runtime name unconditionally (sibling-dep payloads) plus the runtime libraries' own directive deps.
- **`symlinkLibraries`**: runtime names always get the default `/<name>` symlink (never a bundled custom map); failures are collected and surfaced as job-log stderr lines instead of console-swallowed.
- **Worker**: new `setLibraries` message, applied at the **next job boundary only** (a mid-job apply would hand that job a torn set).
- **Runner**: `WasmWorkerBackend.setLibraries` retains the set and replays it after `configure` on every worker (re)creation — recycle-transparent (the load-bearing constraint from the scoping: worker recycle wipes worker state).

## Review

Adversarially reviewed pre-PR. Its HIGH — a deterministic mid-apply throw from a wire-valid payload (file/dir path-prefix collision) permanently poisoned the engine via infinite `pendingLibraries` retry plus a torn registry — is fixed: one attempt per set, per-library exception containment with partial-subtree cleanup and surfaced failure diagnostics, and a failed umount now aborts that library instead of corrupting the mount bookkeeping (the old swallow left a read-only ZipFS owning a path the registry claimed was free). Also fixed per review: text-suffix **bytes** library files now feed the dep scan (an ADR §5 gap), and bytes writes use a new error-visible `writeBytesSync`. ADR §6 amended with path-prefix-conflict rejection for Phase B. Verified clean: worker job-boundary semantics, runner FIFO replay ordering, no memory accumulation.

## Testing

656 unit tests (11 new: shadow-no-fetch, unmount-on-shadow + unshadow re-eligibility, replace-removes-stale, custom-map diagnostic, sibling-dep inclusion, runtime-dep + bytes-dep scanning, runtimeDeps reset, failure containment + cleanup, umount-failure bookkeeping, runtime-name symlinking + failure collection) + 25 e2e; browser session e2e green.

Part of #195 (ADR 0010). Phase B (wire command + contract + `libraries-ack`) follows.