### PR TITLE
feat(session): runtime user libraries over the L1 wire (#195 Phase B, v0.4.0)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,26 @@ release (changelog upkeep and tagging had lapsed between `0.1.0` and `0.2.0`).
 
 ## [Unreleased]
 
+## [0.4.0] - 2026-07-04
+
+### Added
+
+- **Runtime user libraries over the L1 wire** (#195, ADR 0010): the new
+  `setLibraries { libraries, requestId? }` command pushes the declarative FULL
+  set of user libraries — `{name, files, meta?}`, where name is the
+  `use <Name/…>` token, files are individually validated relative paths
+  (content or bytes; no archives, no zip tooling anywhere), and `meta` is
+  opaque passthrough for a future library manager. A runtime name SHADOWS the
+  bundled library of the same name (whole-library; the bundled ZipFS is
+  unmounted and demand-eligibility restored on unshadow); every runtime name
+  is symlinked per job so sibling-dependency payloads work; the set is
+  retained host-side and replayed across worker recycles, applied only at job
+  boundaries with per-library failure containment. The mutation bumps the
+  source revision, so a project that failed on the missing library recompiles
+  when the set arrives, stale results drop, and `libraries-ack
+{ requestId, sourceRevision }` gives exact correlation (#227 pattern).
+  Additive to protocol v2; hosts feature-detect via `ready.capabilities`.
+
 ## [0.3.4] - 2026-07-03
 
 ### Added

--- a/docs/EMBEDDING-VSCODE.md
+++ b/docs/EMBEDDING-VSCODE.md
@@ -319,6 +319,13 @@ before sending. Then **drive a project** rather than push geometry:
   `bytes` at a text-suffix path must be valid UTF-8 and are treated as text),
   `updateFile { path, content }` (text-only — re-push binary
   changes via `setProject`), `removeFile { path }`, `setEntryPoint { path }`,
+  `setLibraries { libraries, requestId? }` (runtime USER libraries, ADR 0010:
+  the declarative FULL set of `{name, files, meta?}` entries — name is the
+  `use <Name/…>` token, files are relative paths as content/bytes; a runtime
+  name SHADOWS the bundled library of the same name whole; answered with
+  `libraries-ack { requestId, sourceRevision }` and the already-pushed project
+  recompiles automatically; feature-detect via `ready.capabilities` — an older
+  session rejects the command as `unknown-type`),
   `render { requestId? }` (a FULL `$preview = false` render — #219; before any
   `setProject` it fails with a `no-project` result rather than rendering the
   default model),
@@ -334,7 +341,8 @@ before sending. Then **drive a project** rather than push geometry:
   `getArtifact`), `project-ack { requestId, sourceRevision }` (the reply to a
   `setProject` that carried a `requestId` — #227: the engine's ASSIGNED revision
   for that push; accept exactly the results carrying it, and detect a rejected
-  push by an unchanged revision), and `error { code, reason }`.
+  push by an unchanged revision), `libraries-ack { requestId, sourceRevision }`
+  (the same pattern for `setLibraries`), and `error { code, reason }`.
 
 Geometry is **not** sent over the wire: the session renders it **in-process** into
 its embedded viewer. The `operation-result` carries an `artifact` _reference_

--- a/docs/architecture/adr/0010-runtime-user-libraries.md
+++ b/docs/architecture/adr/0010-runtime-user-libraries.md
@@ -122,9 +122,13 @@ itself lives OUTSIDE `params`/the durable slice, see §7) and then drives
 - **Stale-drop**: an in-flight compile against the OLD set terminates via the
   standard revision-stale-drop; its result cannot masquerade as the new set's.
 - **Ack**: the optional `requestId` is answered with the #227 ack pattern
-  (`libraries-ack { requestId, sourceRevision }`, same semantics as
-  `project-ack` including rejected-push detection by non-advancing revision).
-- Validation failures reject the whole command atomically (nothing mounted).
+  (`libraries-ack { requestId, sourceRevision }`). Unlike `setProject`, there
+  is no engine-internal rejection path — a validated set always applies — so
+  an ack always carries a freshly advanced revision; validation failures
+  reject the whole command atomically at the wire and surface as an
+  uncorrelated `error` (no ack). Hosts should treat a missing ack within a
+  short window as a rejected payload (a host bug), not poll for a
+  non-advancing revision.
 
 ### 5. Worker application: job boundaries, subtree replace, unconditional symlinks
 

--- a/docs/architecture/adr/0010-runtime-user-libraries.md
+++ b/docs/architecture/adr/0010-runtime-user-libraries.md
@@ -1,6 +1,6 @@
 # ADR 0010 — Runtime user libraries over the session wire
 
-**Status:** Proposed — the design for #195 (runtime user libraries /
+**Status:** Accepted — the design for #195 (runtime user libraries /
 OPENSCADPATH beyond the bundled zips). Adversarially design-reviewed
 2026-07-03; the review's findings are folded in below.
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "openscad-web",
-  "version": "0.3.4",
+  "version": "0.4.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "openscad-web",
-      "version": "0.3.4",
+      "version": "0.4.0",
       "dependencies": {
         "@monaco-editor/loader": "^1.4.0",
         "blurhash": "^2.0.5",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "openscad-web",
-  "version": "0.3.4",
+  "version": "0.4.0",
   "private": true,
   "type": "module",
   "homepage": "https://cameronbrooks11.github.io/openscad-web/",

--- a/src/protocol/__tests__/session-transport.test.ts
+++ b/src/protocol/__tests__/session-transport.test.ts
@@ -9,6 +9,7 @@ import {
   SESSION_PROTOCOL_VERSION,
   sessionArtifact,
   sessionError,
+  sessionLibrariesAck,
   sessionOperationResult,
   sessionProjectAck,
   sessionReady,
@@ -237,6 +238,94 @@ describe('validateSessionInbound', () => {
     });
   });
 
+  it('accepts setLibraries and validates names, paths, one-of, meta (ADR 0010)', () => {
+    const lib = {
+      name: 'MyLib',
+      files: [{ path: 'util.scad', content: 'module u() cube(1);' }],
+      meta: { version: '1.2.3', source: 'local', junk: 'dropped' },
+    };
+    expect(ok({ type: 'setLibraries', libraries: [lib], requestId: 'L1' })).toEqual({
+      ok: true,
+      message: {
+        type: 'setLibraries',
+        libraries: [
+          {
+            name: 'MyLib',
+            files: [{ path: 'util.scad', content: 'module u() cube(1);' }],
+            meta: { version: '1.2.3', source: 'local' }, // unknown meta keys dropped
+          },
+        ],
+        requestId: 'L1',
+      },
+    });
+    // Names: traversal, reserved, multi-segment, bad charset.
+    for (const name of ['..', '.', 'fonts', 'home', 'a/b', 'a b', '']) {
+      expect(ok({ type: 'setLibraries', libraries: [{ name, files: [] }] })).toMatchObject({
+        ok: false,
+        code: 'invalid-payload',
+      });
+    }
+    // Paths: absolute, traversal, empty segment.
+    for (const path of ['/abs.scad', '../out.scad', 'a//b.scad', 'a/./b.scad']) {
+      expect(
+        ok({ type: 'setLibraries', libraries: [{ name: 'L', files: [{ path, content: '' }] }] }),
+      ).toMatchObject({ ok: false, code: 'invalid-payload' });
+    }
+    // Duplicate names / paths and path-prefix conflicts reject atomically.
+    expect(
+      ok({
+        type: 'setLibraries',
+        libraries: [
+          { name: 'L', files: [] },
+          { name: 'L', files: [] },
+        ],
+      }),
+    ).toMatchObject({ ok: false, code: 'invalid-payload' });
+    expect(
+      ok({
+        type: 'setLibraries',
+        libraries: [
+          {
+            name: 'L',
+            files: [
+              { path: 'a', content: '' },
+              { path: 'a/b.scad', content: '' },
+            ],
+          },
+        ],
+      }),
+    ).toMatchObject({ ok: false, code: 'invalid-payload' });
+    // exactly-one-of + invalid UTF-8 at a text suffix.
+    expect(
+      ok({ type: 'setLibraries', libraries: [{ name: 'L', files: [{ path: 'x.scad' }] }] }),
+    ).toMatchObject({ ok: false, code: 'invalid-payload' });
+    expect(
+      ok({
+        type: 'setLibraries',
+        libraries: [
+          { name: 'L', files: [{ path: 'x.scad', bytes: Uint8Array.from([0xff, 0xfe]) }] },
+        ],
+      }),
+    ).toMatchObject({ ok: false, code: 'invalid-payload' });
+    // Binary assets at non-text suffixes are fine.
+    expect(
+      ok({
+        type: 'setLibraries',
+        libraries: [{ name: 'L', files: [{ path: 'part.stl', bytes: Uint8Array.from([1]) }] }],
+      }),
+    ).toMatchObject({ ok: true });
+  });
+
+  it('setLibraries enforces its own (separate) size pool', () => {
+    const big = 'x'.repeat(SESSION_MAX_FILE_LENGTH + 1);
+    expect(
+      ok({
+        type: 'setLibraries',
+        libraries: [{ name: 'L', files: [{ path: 'a.scad', content: big }] }],
+      }),
+    ).toMatchObject({ ok: false, code: 'too-large' });
+  });
+
   it('accepts render with an optional requestId (#219)', () => {
     expect(ok({ type: 'render' })).toEqual({ ok: true, message: { type: 'render' } });
     expect(ok({ type: 'render', requestId: 'r-1' })).toEqual({
@@ -318,6 +407,7 @@ describe('validateSessionInbound', () => {
       updateFile: { path: '/a', content: 'x' },
       removeFile: { path: '/a' },
       setEntryPoint: { path: '/a' },
+      setLibraries: { libraries: [] },
       render: {},
       export: { format: 'stl' },
       getArtifact: { artifactId: 'a', requestId: 'r' },
@@ -385,6 +475,15 @@ describe('outbound builders', () => {
       type: 'artifact',
       requestId: 'r-2',
       available: false,
+    });
+  });
+
+  it('sessionLibrariesAck echoes the id with the assigned revision (ADR 0010)', () => {
+    expect(sessionLibrariesAck('L1', 9)).toEqual({
+      protocolVersion: v,
+      type: 'libraries-ack',
+      requestId: 'L1',
+      sourceRevision: 9,
     });
   });
 

--- a/src/protocol/__tests__/session-transport.test.ts
+++ b/src/protocol/__tests__/session-transport.test.ts
@@ -316,6 +316,30 @@ describe('validateSessionInbound', () => {
     ).toMatchObject({ ok: true });
   });
 
+  it('setLibraries caps names and library COUNT (budget bypass guard)', () => {
+    expect(
+      ok({
+        type: 'setLibraries',
+        libraries: [{ name: 'x'.repeat(SESSION_MAX_PATH_LENGTH + 1), files: [] }],
+      }),
+    ).toMatchObject({ ok: false, code: 'too-large' });
+    const many = Array.from({ length: SESSION_MAX_FILES + 1 }, (_, i) => ({
+      name: `L${i}`,
+      files: [],
+    }));
+    expect(ok({ type: 'setLibraries', libraries: many })).toMatchObject({
+      ok: false,
+      code: 'too-large',
+    });
+    // DEL char in a path (normalizeProjectPath parity).
+    expect(
+      ok({
+        type: 'setLibraries',
+        libraries: [{ name: 'L', files: [{ path: 'a\u007fb.scad', content: '' }] }],
+      }),
+    ).toMatchObject({ ok: false, code: 'invalid-payload' });
+  });
+
   it('setLibraries enforces its own (separate) size pool', () => {
     const big = 'x'.repeat(SESSION_MAX_FILE_LENGTH + 1);
     expect(

--- a/src/protocol/session-transport.ts
+++ b/src/protocol/session-transport.ts
@@ -40,12 +40,28 @@ export const SESSION_MAX_PATH_LENGTH = 4096;
 /** Cap for opaque ids (`artifactId` is a v4 UUID, `requestId` host-chosen). */
 export const SESSION_MAX_ID_LENGTH = 256;
 
+/** Library-name rule (ADR 0010): the name becomes a ROOT SYMLINK verbatim, so
+ *  it must be a single safe segment — and never `.`/`..` or a reserved mount. */
+export const SESSION_LIBRARY_NAME_RE = /^[A-Za-z0-9._-]+$/;
+export const SESSION_RESERVED_LIBRARY_NAMES = new Set([
+  'fonts',
+  'home',
+  'tmp',
+  'libraries',
+  'locale',
+  'dev',
+  'proc',
+  '.',
+  '..',
+]);
+
 /** The inbound command types, advertised in `ready` so a host can feature-detect. */
 export const SESSION_COMMANDS = [
   'setProject',
   'updateFile',
   'removeFile',
   'setEntryPoint',
+  'setLibraries',
   'render',
   'export',
   'getArtifact',
@@ -68,11 +84,24 @@ export type SessionInbound =
   | { type: 'updateFile'; path: string; content: string }
   | { type: 'removeFile'; path: string }
   | { type: 'setEntryPoint'; path: string }
+  | { type: 'setLibraries'; libraries: SessionLibrary[]; requestId?: string }
   | { type: 'render'; requestId?: string }
   | { type: 'export'; format: SessionExportFormat; requestId?: string }
   | { type: 'getArtifact'; artifactId: string; requestId: string }
   | { type: 'cancel'; requestId?: string }
   | { type: 'dispose' };
+
+/** One runtime user library (ADR 0010 / #195): identity is the `use <Name/…>`
+ *  token; files are RELATIVE paths inside the library; `meta` is opaque
+ *  passthrough (a future library manager's version/source — no semantics). */
+export type SessionLibraryFile =
+  | { path: string; content: string; bytes?: never }
+  | { path: string; bytes: Uint8Array; content?: never };
+export type SessionLibrary = {
+  name: string;
+  files: SessionLibraryFile[];
+  meta?: { version?: string; source?: string };
+};
 
 export type SessionValidation =
   { ok: true; message: SessionInbound } | { ok: false; code: ProtocolErrorCode; reason: string };
@@ -132,6 +161,150 @@ function readProjectFiles(value: unknown): SessionValidation | { files: ProjectF
   return { files };
 }
 
+/** Text-suffix mirror of the engine's classification (project-source.ts) —
+ *  duplicated here because the protocol layer is import-fenced. Bytes at these
+ *  paths must be valid UTF-8 (they are treated as text downstream). */
+const LIBRARY_TEXT_EXTENSIONS = new Set([
+  'scad',
+  'txt',
+  'text',
+  'csv',
+  'json',
+  'svg',
+  'md',
+  'xml',
+  'yaml',
+  'yml',
+  'ini',
+  'cfg',
+  'log',
+]);
+
+function isSafeLibraryRelPath(path: string): boolean {
+  if (path.length === 0 || path.length > SESSION_MAX_PATH_LENGTH) return false;
+  if (path.startsWith('/') || path.includes('\\')) return false;
+  // eslint-disable-next-line no-control-regex
+  if (/[\u0000-\u001f]/.test(path)) return false;
+  const segments = path.split('/');
+  return segments.every((s) => s.length > 0 && s !== '.' && s !== '..');
+}
+
+/** Validate a `SessionLibrary[]` payload per ADR 0010 §6: safe single-segment
+ *  names (reserved list excluded), safe relative paths, exactly-one-of
+ *  content|bytes, valid UTF-8 for bytes at text-suffix paths, no duplicate
+ *  names/paths, no path-prefix conflicts (a path that is both a file and a
+ *  directory), and a SEPARATE size pool with the shared constants. */
+function readSessionLibraries(value: unknown): SessionValidation | { libraries: SessionLibrary[] } {
+  if (!Array.isArray(value)) return err('invalid-payload', 'libraries must be an array');
+  const libraries: SessionLibrary[] = [];
+  const names = new Set<string>();
+  let total = 0;
+  let fileCount = 0;
+  for (const entry of value) {
+    if (!isRecord(entry)) return err('invalid-payload', 'each library must be an object');
+    const name = readString(entry.name);
+    if (
+      name === undefined ||
+      !SESSION_LIBRARY_NAME_RE.test(name) ||
+      SESSION_RESERVED_LIBRARY_NAMES.has(name)
+    ) {
+      return err('invalid-payload', 'library name must be a safe, non-reserved single segment');
+    }
+    if (names.has(name)) return err('invalid-payload', `duplicate library name: ${name}`);
+    names.add(name);
+    if (!Array.isArray(entry.files)) {
+      return err('invalid-payload', 'library files must be an array');
+    }
+    const files: SessionLibraryFile[] = [];
+    const paths = new Set<string>();
+    const dirPrefixes = new Set<string>();
+    for (const file of entry.files) {
+      fileCount += 1;
+      if (fileCount > SESSION_MAX_FILES) return err('too-large', 'too many library files');
+      if (!isRecord(file)) return err('invalid-payload', 'each library file must be an object');
+      const path = readString(file.path);
+      if (path === undefined || !isSafeLibraryRelPath(path)) {
+        return err('invalid-payload', 'library file paths must be safe relative paths');
+      }
+      if (paths.has(path) || dirPrefixes.has(path)) {
+        return err('invalid-payload', `conflicting library path: ${path}`);
+      }
+      const segments = path.split('/');
+      let prefix = '';
+      for (const segment of segments.slice(0, -1)) {
+        prefix = prefix ? `${prefix}/${segment}` : segment;
+        if (paths.has(prefix)) return err('invalid-payload', `conflicting library path: ${prefix}`);
+        dirPrefixes.add(prefix);
+      }
+      paths.add(path);
+      const hasContent = file.content !== undefined;
+      const hasBytes = file.bytes !== undefined;
+      if (hasContent === hasBytes) {
+        return err(
+          'invalid-payload',
+          'each library file must have exactly one of content or bytes',
+        );
+      }
+      if (hasBytes) {
+        const bytes = file.bytes;
+        if (!(bytes instanceof Uint8Array)) {
+          return err('invalid-payload', 'library file bytes must be a Uint8Array');
+        }
+        if (bytes.byteLength > SESSION_MAX_FILE_LENGTH) {
+          return err('too-large', 'a library file is too large');
+        }
+        total += bytes.byteLength + path.length;
+        if (total > SESSION_MAX_TOTAL_LENGTH) {
+          return err('too-large', 'libraries exceed the size limit');
+        }
+        const dot = path.lastIndexOf('.');
+        const ext = dot >= 0 ? path.slice(dot + 1).toLowerCase() : '';
+        if (LIBRARY_TEXT_EXTENSIONS.has(ext)) {
+          try {
+            new TextDecoder('utf-8', { fatal: true }).decode(bytes);
+          } catch {
+            return err('invalid-payload', `${path} has a text extension but is not valid UTF-8`);
+          }
+        }
+        files.push({ path, bytes });
+        continue;
+      }
+      const content = readString(file.content);
+      if (content === undefined) {
+        return err('invalid-payload', 'library file content must be a string');
+      }
+      if (content.length > SESSION_MAX_FILE_LENGTH) {
+        return err('too-large', 'a library file is too large');
+      }
+      total += content.length + path.length;
+      if (total > SESSION_MAX_TOTAL_LENGTH)
+        return err('too-large', 'libraries exceed the size limit');
+      files.push({ path, content });
+    }
+    // meta: opaque passthrough — only known, capped string fields survive.
+    let meta: SessionLibrary['meta'];
+    if (entry.meta !== undefined) {
+      if (!isRecord(entry.meta)) return err('invalid-payload', 'library meta must be an object');
+      const version = readString(entry.meta.version);
+      const source = readString(entry.meta.source);
+      if (
+        (version !== undefined && version.length > SESSION_MAX_ID_LENGTH) ||
+        (source !== undefined && source.length > SESSION_MAX_ID_LENGTH)
+      ) {
+        return err('too-large', 'library meta is too long');
+      }
+      if (version !== undefined || source !== undefined) {
+        meta = {
+          ...(version !== undefined ? { version } : {}),
+          ...(source !== undefined ? { source } : {}),
+        };
+      }
+    }
+    libraries.push({ name, files, ...(meta !== undefined ? { meta } : {}) });
+  }
+  return { libraries };
+}
+
 /**
  * Validate an untrusted inbound session message against the L1 protocol. Returns
  * the narrowed message or a structured rejection the host can be told about. Shape
@@ -189,6 +362,27 @@ export function validateSessionInbound(data: unknown): SessionValidation {
       if (path === undefined) return err('invalid-payload', 'path must be a string');
       if (path.length > SESSION_MAX_PATH_LENGTH) return err('too-large', 'path is too long');
       return { ok: true, message: { type: data.type, path } };
+    }
+    case 'setLibraries': {
+      // Declarative FULL-set replace (ADR 0010): validated atomically; the
+      // optional requestId is answered with libraries-ack (the #227 pattern).
+      const result = readSessionLibraries(data.libraries);
+      if ('ok' in result) return result;
+      const requestId = data.requestId === undefined ? undefined : readString(data.requestId);
+      if (data.requestId !== undefined && requestId === undefined) {
+        return err('invalid-payload', 'requestId must be a string');
+      }
+      if (requestId !== undefined && requestId.length > SESSION_MAX_ID_LENGTH) {
+        return err('too-large', 'an id is too long');
+      }
+      return {
+        ok: true,
+        message: {
+          type: 'setLibraries',
+          libraries: result.libraries,
+          ...(requestId !== undefined ? { requestId } : {}),
+        },
+      };
     }
     case 'render': {
       // Full render (#219): $preview = false, render-quality geometry. The
@@ -334,6 +528,28 @@ export type SessionProjectAck = {
   requestId: string;
   sourceRevision: number;
 };
+
+/** The reply to a `setLibraries` that carried a `requestId` (ADR 0010): echoes
+ *  the id with the revision the set applied at — same semantics as
+ *  `project-ack`, so hosts correlate the resulting recompile exactly. */
+export type SessionLibrariesAck = {
+  protocolVersion: number;
+  type: 'libraries-ack';
+  requestId: string;
+  sourceRevision: number;
+};
+
+export function sessionLibrariesAck(
+  requestId: string,
+  sourceRevision: number,
+): SessionLibrariesAck {
+  return {
+    protocolVersion: SESSION_PROTOCOL_VERSION,
+    type: 'libraries-ack',
+    requestId,
+    sourceRevision,
+  };
+}
 
 export function sessionProjectAck(requestId: string, sourceRevision: number): SessionProjectAck {
   return {

--- a/src/protocol/session-transport.ts
+++ b/src/protocol/session-transport.ts
@@ -184,7 +184,7 @@ function isSafeLibraryRelPath(path: string): boolean {
   if (path.length === 0 || path.length > SESSION_MAX_PATH_LENGTH) return false;
   if (path.startsWith('/') || path.includes('\\')) return false;
   // eslint-disable-next-line no-control-regex
-  if (/[\u0000-\u001f]/.test(path)) return false;
+  if (/[\u0000-\u001f\u007f]/.test(path)) return false;
   const segments = path.split('/');
   return segments.every((s) => s.length > 0 && s !== '.' && s !== '..');
 }
@@ -196,6 +196,7 @@ function isSafeLibraryRelPath(path: string): boolean {
  *  directory), and a SEPARATE size pool with the shared constants. */
 function readSessionLibraries(value: unknown): SessionValidation | { libraries: SessionLibrary[] } {
   if (!Array.isArray(value)) return err('invalid-payload', 'libraries must be an array');
+  if (value.length > SESSION_MAX_FILES) return err('too-large', 'too many libraries');
   const libraries: SessionLibrary[] = [];
   const names = new Set<string>();
   let total = 0;
@@ -210,8 +211,13 @@ function readSessionLibraries(value: unknown): SessionValidation | { libraries: 
     ) {
       return err('invalid-payload', 'library name must be a safe, non-reserved single segment');
     }
+    if (name.length > SESSION_MAX_PATH_LENGTH)
+      return err('too-large', 'a library name is too long');
     if (names.has(name)) return err('invalid-payload', `duplicate library name: ${name}`);
     names.add(name);
+    total += name.length;
+    if (total > SESSION_MAX_TOTAL_LENGTH)
+      return err('too-large', 'libraries exceed the size limit');
     if (!Array.isArray(entry.files)) {
       return err('invalid-payload', 'library files must be an array');
     }

--- a/src/session-host/__tests__/controller.test.ts
+++ b/src/session-host/__tests__/controller.test.ts
@@ -37,6 +37,10 @@ class FakeSession implements SessionHost {
   setEntryPoint(path: string) {
     this.calls.push(`setEntryPoint:${path}`);
   }
+  setLibraries(libraries: { name: string }[]) {
+    this.revision++;
+    this.calls.push(`setLibraries:${libraries.map((l) => l.name).join(',')}`);
+  }
   render(requestId?: string) {
     this.calls.push(`render:${requestId ?? ''}`);
   }
@@ -146,6 +150,7 @@ describe('SessionController', () => {
         'updateFile',
         'removeFile',
         'setEntryPoint',
+        'setLibraries',
         'render',
         'export',
         'getArtifact',
@@ -268,6 +273,28 @@ describe('SessionController', () => {
     session.emit(result({ kind: 'render', sourceRevision: 3, artifactId: 'a1' }));
     await flush();
     expect(viewer.offText).toBeNull();
+  });
+
+  it('setLibraries dispatches and acks the assigned revision (ADR 0010)', () => {
+    const { session, transport } = setup();
+    transport.receive({
+      protocolVersion: V,
+      type: 'setLibraries',
+      libraries: [{ name: 'MyLib', files: [{ path: 'u.scad', content: '//' }] }],
+      requestId: 'L1',
+    });
+    expect(session.calls).toEqual(['setLibraries:MyLib']);
+    expect(transport.sent.at(-1)).toEqual({
+      protocolVersion: V,
+      type: 'libraries-ack',
+      requestId: 'L1',
+      sourceRevision: 1,
+    });
+    // No requestId → no ack.
+    transport.receive({ protocolVersion: V, type: 'setLibraries', libraries: [] });
+    expect(
+      transport.sent.filter((m) => (m as { type: string }).type === 'libraries-ack'),
+    ).toHaveLength(1);
   });
 
   it('setProject with a requestId is acked with the ASSIGNED revision (#227)', () => {

--- a/src/session-host/controller.ts
+++ b/src/session-host/controller.ts
@@ -14,11 +14,12 @@ import {
   sessionArtifact,
   sessionError,
   sessionOperationResult,
+  sessionLibrariesAck,
   sessionProjectAck,
   sessionReady,
   validateSessionInbound,
 } from '../protocol/session-transport.ts';
-import type { SessionExportFormat } from '../protocol/session-transport.ts';
+import type { SessionExportFormat, SessionLibrary } from '../protocol/session-transport.ts';
 import type { ArtifactRef, OperationResult, ProjectFile } from '../protocol/session-contract.ts';
 import type { Transport } from '../viewer-host/transport.ts';
 
@@ -28,6 +29,9 @@ export interface SessionHost {
   updateFile(path: string, content: string): void;
   removeFile(path: string): void;
   setEntryPoint(path: string): void;
+  /** Replace the runtime user-library set (ADR 0010): declarative full set;
+   *  the revision-bumping mutation drives the recompile + ack correlation. */
+  setLibraries(libraries: SessionLibrary[]): void;
   /** Run a FULL render (#219) — render-quality geometry; the terminal is a
    *  `kind: 'render'` result echoing `requestId`, and its output becomes what a
    *  subsequent export converts. */
@@ -110,6 +114,16 @@ export class SessionController {
           break;
         case 'setEntryPoint':
           this.session.setEntryPoint(msg.path);
+          break;
+        case 'setLibraries':
+          this.session.setLibraries(msg.libraries);
+          // Ack with the assigned revision (ADR 0010, #227 pattern): the
+          // mutation is synchronous, so the read here is exactly this set's.
+          if (msg.requestId !== undefined) {
+            this.transport.send(
+              sessionLibrariesAck(msg.requestId, this.session.currentSourceRevision()),
+            );
+          }
           break;
         case 'render':
           this.session.render(msg.requestId);

--- a/src/session-host/session-host.ts
+++ b/src/session-host/session-host.ts
@@ -12,6 +12,7 @@ export function sessionHostOf(session: OpenScadSession): SessionHost {
     updateFile: (path, content) => session.updateFile(path, content),
     removeFile: (path) => session.removeFile(path),
     setEntryPoint: (path) => session.setEntryPoint(path),
+    setLibraries: (libraries) => session.setLibraries(libraries),
     render: (requestId) => session.render(requestId),
     exportArtifact: (format, requestId) => session.exportArtifact(format, requestId),
     cancel: (requestId) => session.cancel(requestId),

--- a/src/state/__tests__/project-contract.test.ts
+++ b/src/state/__tests__/project-contract.test.ts
@@ -301,6 +301,15 @@ describe('#123 multi-file project contract — headless end to end', () => {
     ]);
   });
 
+  it('setLibraries with recompile=false applies without compiling (the pre-project guard)', async () => {
+    const backend = new FakeBackend();
+    const { model, ops } = makeModel(backend);
+    model.setLibraries([{ name: 'MyLib', files: [] }], false);
+    await settle();
+    expect(backend.libraries?.[0]?.name).toBe('MyLib');
+    expect(ops).toEqual([]); // nothing compiled — the default model stays dark
+  });
+
   it('setLibraries-then-setProject also compiles (order independence, ADR 0010)', async () => {
     const backend = new FakeBackend();
     const { model, ops } = makeModel(backend);

--- a/src/state/__tests__/project-contract.test.ts
+++ b/src/state/__tests__/project-contract.test.ts
@@ -27,6 +27,11 @@ class FakeBackend implements CompileBackend {
   mode: 'ok' | 'hang' = 'ok';
   /** Every invocation received, so tests can assert what crossed to the worker. */
   invocations: OpenSCADInvocation[] = [];
+  /** The runtime library set the Model handed over (ADR 0010). */
+  libraries: { name: string }[] | undefined;
+  setLibraries(libraries: { name: string }[]) {
+    this.libraries = libraries;
+  }
 
   spawn(invocation: OpenSCADInvocation): AbortablePromise<OpenSCADInvocationResults> {
     this.invocations.push(invocation);
@@ -269,6 +274,43 @@ describe('#123 multi-file project contract — headless end to end', () => {
     await settle();
     expect(model.state.params.sources.map((s) => s.path)).toEqual(['/home/main.scad']);
     expect(model.state.params.activePath).toBe('/home/main.scad');
+  });
+
+  it('setLibraries reaches the backend, bumps the revision, and recompiles (ADR 0010)', async () => {
+    const backend = new FakeBackend();
+    const { model, ops } = makeModel(backend);
+    model.setProject([{ path: 'main.scad', content: 'use <MyLib/util.scad>\nu();' }], 'main.scad');
+    await settle();
+    const before = ops.filter((o) => o.kind === 'preview').length;
+    const revBefore = model.getSourceRevision();
+
+    model.setLibraries([
+      { name: 'MyLib', files: [{ path: 'util.scad', content: 'module u(){}' }] },
+    ]);
+    await settle();
+
+    expect(backend.libraries).toEqual([
+      { name: 'MyLib', files: [{ path: 'util.scad', content: 'module u(){}' }] },
+    ]);
+    expect(model.getSourceRevision()).toBeGreaterThan(revBefore); // ack correlation basis
+    // The declarative contract recompiled the already-pushed project.
+    expect(ops.filter((o) => o.kind === 'preview').length).toBeGreaterThan(before);
+    // Libraries are HOST state: sources content unchanged, nothing persisted.
+    expect(model.state.params.sources).toEqual([
+      { kind: 'text', path: '/home/main.scad', content: 'use <MyLib/util.scad>\nu();' },
+    ]);
+  });
+
+  it('setLibraries-then-setProject also compiles (order independence, ADR 0010)', async () => {
+    const backend = new FakeBackend();
+    const { model, ops } = makeModel(backend);
+    model.setLibraries([
+      { name: 'MyLib', files: [{ path: 'util.scad', content: 'module u(){}' }] },
+    ]);
+    model.setProject([{ path: 'main.scad', content: 'use <MyLib/util.scad>\nu();' }], 'main.scad');
+    await settle();
+    expect(backend.libraries?.[0]?.name).toBe('MyLib');
+    expect(ops.find((o) => o.status === 'success' && o.artifact)).toBeDefined();
   });
 
   it('exportArtifact drives a kind:export success carrying the requested format (#216)', async () => {

--- a/src/state/model.ts
+++ b/src/state/model.ts
@@ -363,17 +363,21 @@ export class Model extends EventTarget {
    * the standard machinery provides the recompile, the stale-drop of results
    * compiled against the OLD set, and the ack correlation (#227 pattern).
    */
-  setLibraries(libraries: WorkerLibrary[]): void {
+  setLibraries(libraries: WorkerLibrary[], recompile = true): void {
     this.backend.setLibraries?.(libraries);
     this.mutate((s) => {
-      // Fresh identity, same content: the revision bump + recompile signal
+      // Fresh identity, same content: the revision bump (the ack needs it)
       // WITHOUT touching what the sources ARE.
       s.params.sources = [...s.params.sources];
       s.lastCheckerRun = undefined;
       s.error = undefined;
       s.errorDetails = undefined;
     });
-    this.compile.processSource();
+    // `recompile: false` is the session tier's pre-project case: compiling
+    // here would render the DEFAULT playground model (the #219 trap) — the
+    // host's eventual setProject drives the first compile with the libraries
+    // already in place, so order independence is preserved.
+    if (recompile) this.compile.processSource();
   }
 
   /** Emit a synthetic terminal failure on the operation stream — for wire

--- a/src/state/model.ts
+++ b/src/state/model.ts
@@ -22,6 +22,7 @@ import { canonicalProjectHomePath } from '../fs/project-path.ts';
 import { HostAdapter, WebHostAdapter } from './web-host-adapter.ts';
 import { WasmWorkerBackend, type CompileBackend } from '../runner/openscad-runner.ts';
 import { newId, operationFailure } from '../runner/compile-contract.ts';
+import type { WorkerLibrary } from '../runner/worker-protocol.ts';
 import { ArtifactStore, type StoredArtifact } from './artifact-store.ts';
 import { applyUserFacingError } from './apply-user-facing-error.ts';
 import { CompileCoordinator } from './services/compile-coordinator.ts';
@@ -352,6 +353,29 @@ export class Model extends EventTarget {
    * (exports convert the LAST completed output), `export-format-mismatch` for
    * the wrong dimensionality.
    */
+  /**
+   * Replace the runtime user-library set (ADR 0010 / #195). The set is HOST
+   * state, not project state: it lives on the backend (which retains it and
+   * replays it across worker recycles) and never enters `params` or the
+   * durable slice — a persistence refactor must not write library bytes to
+   * IndexedDB. The mutation still bumps `sourceRevision` (a fresh
+   * `params.sources` array identity — the same signal `setProject` uses) so
+   * the standard machinery provides the recompile, the stale-drop of results
+   * compiled against the OLD set, and the ack correlation (#227 pattern).
+   */
+  setLibraries(libraries: WorkerLibrary[]): void {
+    this.backend.setLibraries?.(libraries);
+    this.mutate((s) => {
+      // Fresh identity, same content: the revision bump + recompile signal
+      // WITHOUT touching what the sources ARE.
+      s.params.sources = [...s.params.sources];
+      s.lastCheckerRun = undefined;
+      s.error = undefined;
+      s.errorDetails = undefined;
+    });
+    this.compile.processSource();
+  }
+
   /** Emit a synthetic terminal failure on the operation stream — for wire
    *  commands that must never end in silence (export #216, render #219). */
   emitOperationFailure(

--- a/src/state/session.ts
+++ b/src/state/session.ts
@@ -6,6 +6,7 @@ import type { ProjectFile, ProjectContract } from './project-contract.ts';
 import type { ProjectFileSystem } from '../fs/project-filesystem.ts';
 import type { State, StatePersister } from './app-state.ts';
 import type { HostAdapter } from './web-host-adapter.ts';
+import type { WorkerLibrary } from '../runner/worker-protocol.ts';
 import type { ExportFormat } from './formats.ts';
 
 /**
@@ -68,6 +69,12 @@ export class OpenScadSession implements ProjectContract {
   }
   setEntryPoint(path: string): void {
     this.model.setEntryPoint(path);
+  }
+
+  /** Replace the runtime user-library set (ADR 0010 / #195): declarative full
+   *  set, revision-bumping (the resulting recompile correlates via the ack). */
+  setLibraries(libraries: WorkerLibrary[]): void {
+    this.model.setLibraries(libraries);
   }
 
   /** Run a FULL render of the current model (#219) — `$preview = false`,

--- a/src/state/session.ts
+++ b/src/state/session.ts
@@ -74,7 +74,10 @@ export class OpenScadSession implements ProjectContract {
   /** Replace the runtime user-library set (ADR 0010 / #195): declarative full
    *  set, revision-bumping (the resulting recompile correlates via the ack). */
   setLibraries(libraries: WorkerLibrary[]): void {
-    this.model.setLibraries(libraries);
+    // Pre-project, apply WITHOUT recompiling: nothing of the host's exists to
+    // compile yet, and compiling would render (and display!) the default
+    // playground model — the same trap the render guard closes (#219 review).
+    this.model.setLibraries(libraries, this.hostProjectSet);
   }
 
   /** Run a FULL render of the current model (#219) — `$preview = false`,

--- a/tests/session.spec.ts
+++ b/tests/session.spec.ts
@@ -24,6 +24,7 @@ declare global {
         status?: string;
         kind?: string;
         requestId?: string;
+        sourceRevision?: number;
         artifact?: { format?: string; artifactId?: string };
       };
       requestId?: string;
@@ -82,32 +83,10 @@ test.describe('session distributable (#193)', () => {
     const manifest = await page.request.get(new URL('session-manifest.json', baseUrl).toString());
     const { protocolVersion } = (await manifest.json()) as { protocolVersion: number };
 
-    // The project includes a (unreferenced) binary asset (#172), so the push
-    // exercises the bytes branch — wire validation, BrowserFS writeBytes, and
-    // the local-source bookkeeping — against the real artifact. The Uint8Array
-    // must be constructed IN PAGE: Playwright's evaluate-arg serialization would
-    // mangle a Node-side one before it ever reached postMessage.
-    await page.evaluate((v) => {
-      const frame = document.getElementById('session-frame') as HTMLIFrameElement;
-      frame.contentWindow!.postMessage(
-        {
-          protocolVersion: v,
-          type: 'setProject',
-          files: [
-            { path: 'main.scad', content: 'use <E2ELib/util.scad>\ne2e_unit();' },
-            { path: 'assets/blob.bin', bytes: new Uint8Array([0xde, 0xad, 0xbe, 0xef]) },
-          ],
-          entryPoint: 'main.scad',
-          requestId: 'e2e-push-1',
-        },
-        window.location.origin,
-      );
-    }, protocolVersion);
-
-    // Runtime user library (ADR 0010 / #195): push it BEFORE the project (the
-    // declarative contract works in either order; this exercises libs-first),
-    // await its ack, and the project below resolves `use <E2ELib/…>` through
-    // the runtime registry + per-job symlink — the full seam, real WASM.
+    // Runtime user library (ADR 0010 / #195), GENUINELY libs-first: pushed
+    // before any project, acked, and — crucially — the session must NOT
+    // compile/display the default playground model in response (the
+    // pre-project recompile guard; the #219-class trap).
     await postToSession(page, {
       protocolVersion,
       type: 'setLibraries',
@@ -128,6 +107,29 @@ test.describe('session distributable (#193)', () => {
       { timeout: 30_000 },
     );
 
+    // The project includes a (unreferenced) binary asset (#172), so the push
+    // exercises the bytes branch — wire validation, BrowserFS writeBytes, and
+    // the local-source bookkeeping — against the real artifact. The Uint8Array
+    // must be constructed IN PAGE: Playwright's evaluate-arg serialization would
+    // mangle a Node-side one before it ever reached postMessage. Its entry
+    // resolves `use <E2ELib/…>` through the runtime registry + per-job symlink.
+    await page.evaluate((v) => {
+      const frame = document.getElementById('session-frame') as HTMLIFrameElement;
+      frame.contentWindow!.postMessage(
+        {
+          protocolVersion: v,
+          type: 'setProject',
+          files: [
+            { path: 'main.scad', content: 'use <E2ELib/util.scad>\ne2e_unit();' },
+            { path: 'assets/blob.bin', bytes: new Uint8Array([0xde, 0xad, 0xbe, 0xef]) },
+          ],
+          entryPoint: 'main.scad',
+          requestId: 'e2e-push-1',
+        },
+        window.location.origin,
+      );
+    }, protocolVersion);
+
     // The push is acked with its assigned revision (#227) before any results.
     await page.waitForFunction(
       () =>
@@ -140,22 +142,41 @@ test.describe('session distributable (#193)', () => {
       null,
       { timeout: 30_000 },
     );
+    const projectRevision = await page.evaluate(
+      () =>
+        window.__sessionMessages?.find(
+          (m) => m?.type === 'project-ack' && m?.requestId === 'e2e-push-1',
+        )?.sourceRevision,
+    );
 
     // A genuine WASM compile fans out to a success operation-result carrying an
-    // OFF artifact (the render bridge also sets it on the embedded viewer, but the
-    // wire result is what proves the engine actually ran). Generous timeout for
-    // cold WASM boot + first compile.
+    // OFF artifact, PINNED to the project push's acked revision — a stray
+    // default-model compile at the libraries revision must not satisfy this.
     await page.waitForFunction(
-      () =>
+      (rev) =>
         window.__sessionMessages?.some(
           (m) =>
             m?.type === 'operation-result' &&
             m?.result?.status === 'success' &&
-            m?.result?.artifact?.format === 'off',
+            m?.result?.artifact?.format === 'off' &&
+            m?.result?.sourceRevision === rev,
         ),
-      null,
+      projectRevision,
       { timeout: 60_000 },
     );
+
+    // The pre-project setLibraries did NOT compile anything: no operation
+    // result exists below the project's revision (the default playground model
+    // was never rendered — the guard the #219 review pattern requires).
+    const strayEarlyResults = await page.evaluate(
+      (rev) =>
+        window.__sessionMessages?.filter(
+          (m) =>
+            m?.type === 'operation-result' && ((m?.result?.sourceRevision ?? rev) as number) < rev,
+        ).length,
+      projectRevision,
+    );
+    expect(strayEarlyResults).toBe(0);
 
     // No protocol/compile error was reported for the valid project.
     const hadError = await page.evaluate(() =>

--- a/tests/session.spec.ts
+++ b/tests/session.spec.ts
@@ -94,7 +94,7 @@ test.describe('session distributable (#193)', () => {
           protocolVersion: v,
           type: 'setProject',
           files: [
-            { path: 'main.scad', content: 'cube([10, 10, 10]);' },
+            { path: 'main.scad', content: 'use <E2ELib/util.scad>\ne2e_unit();' },
             { path: 'assets/blob.bin', bytes: new Uint8Array([0xde, 0xad, 0xbe, 0xef]) },
           ],
           entryPoint: 'main.scad',
@@ -103,6 +103,30 @@ test.describe('session distributable (#193)', () => {
         window.location.origin,
       );
     }, protocolVersion);
+
+    // Runtime user library (ADR 0010 / #195): push it BEFORE the project (the
+    // declarative contract works in either order; this exercises libs-first),
+    // await its ack, and the project below resolves `use <E2ELib/…>` through
+    // the runtime registry + per-job symlink — the full seam, real WASM.
+    await postToSession(page, {
+      protocolVersion,
+      type: 'setLibraries',
+      libraries: [
+        {
+          name: 'E2ELib',
+          files: [{ path: 'util.scad', content: 'module e2e_unit() cube([2, 2, 2]);' }],
+        },
+      ],
+      requestId: 'e2e-libs-1',
+    });
+    await page.waitForFunction(
+      () =>
+        window.__sessionMessages?.some(
+          (m) => m?.type === 'libraries-ack' && m?.requestId === 'e2e-libs-1',
+        ),
+      null,
+      { timeout: 30_000 },
+    );
 
     // The push is acked with its assigned revision (#227) before any results.
     await page.waitForFunction(


### PR DESCRIPTION
## Summary

**Phase B completes #195** (per ADR 0010, on the merged Phase A plumbing): the **`setLibraries { libraries, requestId? }`** wire command — the declarative FULL runtime user-library set, provenance-agnostic (`{name, files, meta?}`; a future library manager is just another producer of this payload).

- **Validation** (ADR §6): single-segment names (reserved list + `.`/`..` rejected — the name becomes a root symlink verbatim; capped and counted toward the budget), safe relative paths (traversal/control chars/DEL rejected), exactly-one-of content|bytes with fatal-UTF-8 at text suffixes, duplicate + path-prefix-conflict atomic rejection, library-count cap, separate size pool with the shared constants, capped opaque `meta` passthrough.
- **Lifecycle** (ADR §4): `Model.setLibraries` hands the set to the backend (Phase A owns retention + recycle replay) and bumps `sourceRevision`, so the recompile-on-arrival, stale-drop, and **`libraries-ack`** correlation all ride existing machinery. The set is host state — never in `params` or the durable slice.
- **Pre-project guard**: applying libraries before the host's first `setProject` does NOT compile — the default playground model stays dark (the #219-class trap, caught by this PR's review and now pinned by the e2e).
- `setLibraries` joins `SESSION_COMMANDS` (feature-detect via `ready`); protocol stays v2. Ships as **v0.4.0**; ADR 0010 → Accepted.

## Review

Adversarially reviewed pre-PR: 1 HIGH (the pre-project default-model compile+display — confirmed end-to-end and fixed with the recompile guard), 1 MEDIUM (uncapped names/library count bypassing the size pool — closed), 3 LOWs (DEL-char parity; ADR §4 promised a rejection signal that can't occur for libraries — corrected to ack-always-advances + rejections-as-uncorrelated-error; the e2e claimed libs-first but wasn't — now genuinely is, with the compile wait pinned to the project-ack revision and an explicit no-stray-early-results assertion). Verified clean: prefix-conflict detection both orders, meta prototype-safety, revision-bump mechanics, capability parity, version/manifest mechanics.

## Testing

664 unit tests (validation matrix incl. the budget-bypass guards; dispatch + ack; capstone recompile/order-independence/backend-handoff/pre-project guard) + 25 e2e. The real-WASM session e2e now runs the full flow: **`setLibraries` (libs-first) → `libraries-ack` → `setProject` using `use <E2ELib/util.scad>` → ack-pinned OFF success → assert nothing compiled before the project existed** — plus the existing render/export/getArtifact chain.

Closes #195.