### PR TITLE
feat(publish): multi-target assembly — publish every target (#239)

### DIFF
--- a/docs/PUBLISHING.md
+++ b/docs/PUBLISHING.md
@@ -132,6 +132,21 @@ Multiple targets:
 - each assembled target currently carries its own runtime copy; de-duplicating a
   shared runtime across targets is tracked in [#240](https://github.com/CameronBrooks11/openscad-web/issues/240)
 
+### Re-runs and recovery
+
+- **Re-running is safe.** Each mount is stamped with an ownership marker; a later
+  run detects its own mounts and replaces them in place, leaving sibling and
+  unrelated content untouched. Assembly refuses to overwrite a non-empty
+  directory it does not own.
+- **A renamed or removed target orphans its old mount.** Assembly only creates
+  or replaces the mounts named in the current config; it does not delete a mount
+  you published previously and then dropped. If you rename or remove a target,
+  clear its old mount directory yourself.
+- **After a failed assembly, clear the output directory before retrying.** If a
+  run fails partway through a multi-target assembly, a partially written mount
+  may be left without its ownership marker, and the next run will refuse to
+  overwrite it. Remove the output directory (or the offending mount) and re-run.
+
 ## Mixed-Site Example
 
 If your repo already builds other static content at the root and you want OpenSCAD under `/model/`, assemble into the same output directory:

--- a/docs/PUBLISHING.md
+++ b/docs/PUBLISHING.md
@@ -122,12 +122,15 @@ Field reference:
 | `targets[].title`        | Optional page title.                                                                       |
 | `targets[].parentOrigin` | Optional embed security setting for trusted iframe parents.                                |
 
-Important v1 limits:
+Multiple targets:
 
-- only the first `targets[]` entry is assembled
-- if you need multiple published targets, that is deferred to a later phase
+- every `targets[]` entry is assembled, each into its own `mountPath`
+- mount paths must be unique and non-overlapping — one mount path may not be
+  nested inside another, and `mountPath: /` (site root) may only be used when it
+  is the single target
 - `projectRoot` is the publish boundary; files outside it are not copied into the site
-- each assembled target carries its own runtime copy in v1
+- each assembled target currently carries its own runtime copy; de-duplicating a
+  shared runtime across targets is tracked in [#240](https://github.com/CameronBrooks11/openscad-web/issues/240)
 
 ## Mixed-Site Example
 

--- a/scripts/__tests__/deploy-configure.test.mjs
+++ b/scripts/__tests__/deploy-configure.test.mjs
@@ -309,6 +309,93 @@ targets:
     ]);
   });
 
+  it('allows sibling mounts that share a path prefix but are not nested', async () => {
+    // /model/ and /modelx/ share the "/model" prefix but neither is nested in
+    // the other. Trailing-slash normalization must keep them distinct; if the
+    // collision check dropped it, this would wrongly throw.
+    const cwd = await makeTempDir();
+    const artifactPath = path.join(cwd, 'openscad-web-publish.zip');
+    await createPublishArtifact(artifactPath);
+    await writeTextFile(path.join(cwd, 'models', 'a.scad'), 'cube(1);');
+    await writeTextFile(path.join(cwd, 'models', 'b.scad'), 'cube(2);');
+    await writeTextFile(
+      path.join(cwd, 'openscad-publish.yml'),
+      `targets:
+  - source: ./models/a.scad
+    mountPath: /model/
+    surface: viewer
+  - source: ./models/b.scad
+    mountPath: /modelx/
+    surface: viewer
+`,
+    );
+
+    await runDeployConfigure(
+      [
+        '--config',
+        './openscad-publish.yml',
+        '--artifact-path',
+        './openscad-web-publish.zip',
+        '--output-dir',
+        './site',
+      ],
+      { cwd },
+    );
+
+    await expect(
+      readFile(path.join(cwd, 'site', 'model', 'project', 'a.scad'), 'utf8'),
+    ).resolves.toBe('cube(1);');
+    await expect(
+      readFile(path.join(cwd, 'site', 'modelx', 'project', 'b.scad'), 'utf8'),
+    ).resolves.toBe('cube(2);');
+  });
+
+  it('re-assembles an already-published multi-target site idempotently', async () => {
+    const cwd = await makeTempDir();
+    const artifactPath = path.join(cwd, 'openscad-web-publish.zip');
+    await createPublishArtifact(artifactPath);
+    await writeTextFile(path.join(cwd, 'models', 'one.scad'), 'cube(1);');
+    await writeTextFile(path.join(cwd, 'models', 'two.scad'), 'cube(2);');
+    await writeTextFile(
+      path.join(cwd, 'openscad-publish.yml'),
+      `targets:
+  - source: ./models/one.scad
+    mountPath: /one/
+    surface: viewer
+  - source: ./models/two.scad
+    mountPath: /two/
+    surface: viewer
+`,
+    );
+
+    const args = [
+      '--config',
+      './openscad-publish.yml',
+      '--artifact-path',
+      './openscad-web-publish.zip',
+      '--output-dir',
+      './site',
+    ];
+
+    await runDeployConfigure(args, { cwd });
+    // A stale file inside an owned mount must be cleared on the second run.
+    await writeTextFile(path.join(cwd, 'site', 'one', 'stale.txt'), 'remove me');
+
+    // Second run over the already-assembled site: each mount is detected as
+    // owned and replaced rather than rejected as unowned.
+    await runDeployConfigure(args, { cwd });
+
+    await expect(
+      readFile(path.join(cwd, 'site', 'one', 'project', 'one.scad'), 'utf8'),
+    ).resolves.toBe('cube(1);');
+    await expect(
+      readFile(path.join(cwd, 'site', 'two', 'project', 'two.scad'), 'utf8'),
+    ).resolves.toBe('cube(2);');
+    await expect(
+      readFile(path.join(cwd, 'site', 'one', 'stale.txt'), 'utf8'),
+    ).rejects.toMatchObject({ code: 'ENOENT' });
+  });
+
   it('rejects duplicate mount paths across targets', async () => {
     const cwd = await makeTempDir();
     const artifactPath = path.join(cwd, 'openscad-web-publish.zip');

--- a/scripts/__tests__/deploy-configure.test.mjs
+++ b/scripts/__tests__/deploy-configure.test.mjs
@@ -251,10 +251,9 @@ targets:
     });
   });
 
-  it('warns and uses only the first target when config defines multiple targets', async () => {
+  it('assembles every target defined in config', async () => {
     const cwd = await makeTempDir();
     const artifactPath = path.join(cwd, 'openscad-web-publish.zip');
-    const warnings = [];
     await createPublishArtifact(artifactPath);
     await writeTextFile(path.join(cwd, 'models', 'one.scad'), 'cube(1);');
     await writeTextFile(path.join(cwd, 'models', 'two.scad'), 'cube(2);');
@@ -266,11 +265,12 @@ targets:
     surface: viewer
   - source: ./models/two.scad
     mountPath: /two/
-    surface: viewer
+    surface: customizer
+    controls: true
 `,
     );
 
-    await runDeployConfigure(
+    const result = await runDeployConfigure(
       [
         '--config',
         './openscad-publish.yml',
@@ -279,28 +279,112 @@ targets:
         '--output-dir',
         './site',
       ],
-      {
-        cwd,
-        logger: {
-          log() {},
-          warn(message) {
-            warnings.push(String(message));
-          },
-          error() {},
-        },
-      },
+      { cwd },
     );
 
-    expect(warnings).toHaveLength(1);
-    expect(warnings[0]).toMatch(/Multiple targets are not supported in v1/i);
+    // Every target is assembled into its own mount, each with its own runtime.
     await expect(
       readFile(path.join(cwd, 'site', 'one', 'project', 'one.scad'), 'utf8'),
     ).resolves.toBe('cube(1);');
     await expect(
       readFile(path.join(cwd, 'site', 'two', 'project', 'two.scad'), 'utf8'),
-    ).rejects.toMatchObject({
-      code: 'ENOENT',
-    });
+    ).resolves.toBe('cube(2);');
+    await expect(readFile(path.join(cwd, 'site', 'one', 'index.html'), 'utf8')).resolves.toContain(
+      '<div id="root"></div>',
+    );
+    await expect(readFile(path.join(cwd, 'site', 'two', 'index.html'), 'utf8')).resolves.toContain(
+      '<div id="root"></div>',
+    );
+    await expect(
+      readJson(path.join(cwd, 'site', 'one', 'openscad-web.config.json')),
+    ).resolves.toEqual({ mode: 'embed', model: './project/one.scad' });
+    await expect(
+      readJson(path.join(cwd, 'site', 'two', 'openscad-web.config.json')),
+    ).resolves.toEqual({ mode: 'customizer', model: './project/two.scad', controls: true });
+
+    expect(result.targets).toHaveLength(2);
+    expect(result.targets.map((entry) => entry.mountDirPath)).toEqual([
+      path.join(cwd, 'site', 'one'),
+      path.join(cwd, 'site', 'two'),
+    ]);
+  });
+
+  it('rejects duplicate mount paths across targets', async () => {
+    const cwd = await makeTempDir();
+    const artifactPath = path.join(cwd, 'openscad-web-publish.zip');
+    await createPublishArtifact(artifactPath);
+    await writeTextFile(path.join(cwd, 'models', 'one.scad'), 'cube(1);');
+    await writeTextFile(path.join(cwd, 'models', 'two.scad'), 'cube(2);');
+    await writeTextFile(
+      path.join(cwd, 'openscad-publish.yml'),
+      `targets:
+  - source: ./models/one.scad
+    mountPath: /model/
+    surface: viewer
+  - source: ./models/two.scad
+    mountPath: /model/
+    surface: viewer
+`,
+    );
+
+    await expect(
+      runDeployConfigure(
+        ['--config', './openscad-publish.yml', '--artifact-path', './openscad-web-publish.zip'],
+        { cwd },
+      ),
+    ).rejects.toThrow(/duplicate mount path/i);
+  });
+
+  it('rejects a mount path nested inside another target mount path', async () => {
+    const cwd = await makeTempDir();
+    const artifactPath = path.join(cwd, 'openscad-web-publish.zip');
+    await createPublishArtifact(artifactPath);
+    await writeTextFile(path.join(cwd, 'models', 'one.scad'), 'cube(1);');
+    await writeTextFile(path.join(cwd, 'models', 'two.scad'), 'cube(2);');
+    await writeTextFile(
+      path.join(cwd, 'openscad-publish.yml'),
+      `targets:
+  - source: ./models/one.scad
+    mountPath: /model/
+    surface: viewer
+  - source: ./models/two.scad
+    mountPath: /model/nested/
+    surface: viewer
+`,
+    );
+
+    await expect(
+      runDeployConfigure(
+        ['--config', './openscad-publish.yml', '--artifact-path', './openscad-web-publish.zip'],
+        { cwd },
+      ),
+    ).rejects.toThrow(/overlapping mount path/i);
+  });
+
+  it('rejects a root mount combined with additional targets', async () => {
+    const cwd = await makeTempDir();
+    const artifactPath = path.join(cwd, 'openscad-web-publish.zip');
+    await createPublishArtifact(artifactPath);
+    await writeTextFile(path.join(cwd, 'models', 'one.scad'), 'cube(1);');
+    await writeTextFile(path.join(cwd, 'models', 'two.scad'), 'cube(2);');
+    await writeTextFile(
+      path.join(cwd, 'openscad-publish.yml'),
+      `targets:
+  - source: ./models/one.scad
+    mountPath: /
+    surface: viewer
+  - source: ./models/two.scad
+    mountPath: /two/
+    surface: viewer
+`,
+    );
+
+    await expect(
+      runDeployConfigure(
+        ['--config', './openscad-publish.yml', '--artifact-path', './openscad-web-publish.zip'],
+        { cwd },
+      ),
+    ).rejects.toThrow(/overlapping mount path/i);
   });
 
   it('lets --output-dir override site.outDir from config', async () => {

--- a/scripts/deploy-configure.mjs
+++ b/scripts/deploy-configure.mjs
@@ -198,7 +198,7 @@ function parseYamlConfig(fileContents, configPath) {
   return parsedConfig;
 }
 
-async function resolveTargetFromConfig(configPath, logger) {
+async function resolveTargetsFromConfig(configPath) {
   const configFilePath = path.resolve(configPath);
   const configDirPath = path.dirname(configFilePath);
   const configText = await readFile(configFilePath, 'utf8');
@@ -216,12 +216,6 @@ async function resolveTargetFromConfig(configPath, logger) {
     throw new Error(`Publish config ${configFilePath} must define at least one target.`);
   }
 
-  if (targets.length > 1) {
-    logger.warn(
-      `[deploy-configure] Multiple targets are not supported in v1; using only the first target from ${configFilePath}.`,
-    );
-  }
-
   if (site.outDir !== undefined && getString(site.outDir) == null) {
     throw new Error(
       `Publish config ${configFilePath} must define site.outDir as a non-empty string when provided.`,
@@ -234,22 +228,42 @@ async function resolveTargetFromConfig(configPath, logger) {
       getString(site.outDir) == null
         ? null
         : path.resolve(configDirPath, /** @type {string} */ (site.outDir)),
-    rawTarget: targets[0],
+    rawTargets: targets,
   };
 }
 
-function resolveTargetFromShorthand(args, cwdPath) {
+function resolveTargetsFromShorthand(args, cwdPath) {
   return {
     baseDirPath: cwdPath,
     outputDirPath: null,
-    rawTarget: {
-      source: args.source,
-      projectRoot: args.projectRoot,
-      entry: args.entry,
-      surface: args.surface,
-      mountPath: args.mountPath,
-    },
+    rawTargets: [
+      {
+        source: args.source,
+        projectRoot: args.projectRoot,
+        entry: args.entry,
+        surface: args.surface,
+        mountPath: args.mountPath,
+      },
+    ],
   };
+}
+
+// Mount paths are normalized to end with '/', so a simple prefix test detects
+// nesting: '/a/' is a prefix of '/a/b/'. Root ('/') is a prefix of everything,
+// so it may only be used when it is the sole target.
+function assertMountPathsDoNotCollide(resolvedTargets) {
+  for (let i = 0; i < resolvedTargets.length; i += 1) {
+    for (let j = i + 1; j < resolvedTargets.length; j += 1) {
+      const a = resolvedTargets[i].mountPath;
+      const b = resolvedTargets[j].mountPath;
+      if (a === b) {
+        throw new Error(`Duplicate mount path across targets: ${a}`);
+      }
+      if (b.startsWith(a) || a.startsWith(b)) {
+        throw new Error(`Overlapping mount path across targets: ${a} and ${b}`);
+      }
+    }
+  }
 }
 
 async function validateAndResolveTarget(rawTarget, baseDirPath) {
@@ -508,9 +522,9 @@ export async function runDeployConfigure(
 
   let resolvedInput;
   if (getString(args.config) != null) {
-    resolvedInput = await resolveTargetFromConfig(path.resolve(cwd, args.config), logger);
+    resolvedInput = await resolveTargetsFromConfig(path.resolve(cwd, args.config));
   } else {
-    resolvedInput = resolveTargetFromShorthand(args, cwd);
+    resolvedInput = resolveTargetsFromShorthand(args, cwd);
   }
 
   const outputDirPath =
@@ -518,39 +532,49 @@ export async function runDeployConfigure(
       ? path.resolve(cwd, args.outputDir)
       : (resolvedInput.outputDirPath ?? path.resolve(cwd, DEFAULT_OUTPUT_DIR));
 
-  const target = await validateAndResolveTarget(resolvedInput.rawTarget, resolvedInput.baseDirPath);
+  const targets = [];
+  for (const rawTarget of resolvedInput.rawTargets) {
+    targets.push(await validateAndResolveTarget(rawTarget, resolvedInput.baseDirPath));
+  }
+  assertMountPathsDoNotCollide(targets);
 
   const tempRootDirPath = await mkdtemp(path.join(os.tmpdir(), 'openscad-web-assemble-'));
   const extractedArtifactDirPath = path.join(tempRootDirPath, 'artifact');
 
   try {
+    // Extract the runtime once as an immutable base; each target is composed
+    // into its own mount from it (its own runtime copy — a shared runtime is
+    // tracked separately in #240).
     await mkdir(extractedArtifactDirPath, { recursive: true });
     new AdmZip(path.resolve(cwd, artifactPath)).extractAllTo(extractedArtifactDirPath, true);
     await assertArtifactLayout(extractedArtifactDirPath);
 
-    const modelPath = await populateProjectPayload(extractedArtifactDirPath, target);
-    const bootConfig = buildBootConfig(target, modelPath);
-    await writeFile(
-      path.join(extractedArtifactDirPath, 'openscad-web.config.json'),
-      `${JSON.stringify(bootConfig, null, 2)}\n`,
-      'utf8',
-    );
-    await writeOwnershipMarker(extractedArtifactDirPath, args.artifactVersion, now);
+    const assembled = [];
+    for (const target of targets) {
+      const mountDirPath = resolveMountDirectory(outputDirPath, target.mountPath);
+      const { replaceExisting } = await assertMountDirectoryCanBeReplaced(mountDirPath);
+      if (replaceExisting) {
+        await rm(mountDirPath, { recursive: true, force: true });
+      }
 
-    const mountDirPath = resolveMountDirectory(outputDirPath, target.mountPath);
-    const { replaceExisting } = await assertMountDirectoryCanBeReplaced(mountDirPath);
-    if (replaceExisting) {
-      await rm(mountDirPath, { recursive: true, force: true });
+      await mkdir(path.dirname(mountDirPath), { recursive: true });
+      await copyDirectoryContents(extractedArtifactDirPath, mountDirPath);
+
+      const modelPath = await populateProjectPayload(mountDirPath, target);
+      const bootConfig = buildBootConfig(target, modelPath);
+      await writeFile(
+        path.join(mountDirPath, 'openscad-web.config.json'),
+        `${JSON.stringify(bootConfig, null, 2)}\n`,
+        'utf8',
+      );
+      await writeOwnershipMarker(mountDirPath, args.artifactVersion, now);
+
+      assembled.push({ mountDirPath, target, bootConfig });
     }
-
-    await mkdir(path.dirname(mountDirPath), { recursive: true });
-    await copyDirectoryContents(extractedArtifactDirPath, mountDirPath);
 
     return {
       outputDirPath,
-      mountDirPath,
-      target,
-      bootConfig,
+      targets: assembled,
       json: args.json,
     };
   } finally {
@@ -568,9 +592,11 @@ if (isMainModule) {
       process.stdout.write(
         `${JSON.stringify({
           outputDirPath: result.outputDirPath,
-          mountDirPath: result.mountDirPath,
-          mode: result.bootConfig.mode,
-          model: result.bootConfig.model,
+          targets: result.targets.map((entry) => ({
+            mountDirPath: entry.mountDirPath,
+            mode: entry.bootConfig.mode,
+            model: entry.bootConfig.model,
+          })),
         })}\n`,
       );
     }


### PR DESCRIPTION
Closes #239. Convergence Phase 2 for the [docs-template epic](https://github.com/CameronBrooks11/just-the-docs-template-openscad/issues/1) — a docs site inherently showcases many models, so one-model-per-site was the hard ceiling.

## Change
`deploy-configure` assembled only the first `targets[]` entry (with a warning). It now assembles **all** of them, each into its own mount with its own runtime copy.

- `resolveTargets*` return every target; the single-target warning is gone
- `runDeployConfigure` extracts the artifact **once** as an immutable base and composes each mount from it — no cross-target mutation / leakage
- **mount-path validation**: unique + non-overlapping; a nested mount (`/a/` + `/a/b/`), a duplicate, or `/` combined with other targets is rejected
- `--json` output gains `targets[]` (`{mountDirPath, mode, model}`); top-level `outputDirPath` retained → **`action.yml` unchanged**
- `PUBLISHING.md`: single-target limit replaced with multi-target docs

## Scope
Each target still carries its own runtime copy — shared-runtime de-duplication is the separate **#240**.

## Verification
- 28/28 assembly tests pass, incl. 4 new: multi-target assembly, duplicate-mount reject, nested-mount reject, root+others reject
- eslint clean, prettier clean, `tsc --noEmit` clean
- only `action.yml`'s `outputDirPath` consumer touched the JSON output; preserved. Per-mount output shape unchanged, so the browser publish-e2e is unaffected (full `verify:full` runs here in CI).