### PR TITLE
feat(publish): share one runtime across multi-target publishes (#240)

### DIFF
--- a/docs/PUBLISHING.md
+++ b/docs/PUBLISHING.md
@@ -129,8 +129,25 @@ Multiple targets:
   nested inside another, and `mountPath: /` (site root) may only be used when it
   is the single target
 - `projectRoot` is the publish boundary; files outside it are not copied into the site
-- each assembled target currently carries its own runtime copy; de-duplicating a
-  shared runtime across targets is tracked in [#240](https://github.com/CameronBrooks11/openscad-web/issues/240)
+
+### Runtime sharing
+
+- **A single target is self-contained.** Its mount holds the whole runtime plus
+  its project and boot config — the mount directory is complete on its own.
+- **Multiple targets share one runtime.** The runtime is assembled once into
+  `<site>/_openscad-web/<artifact-version>/`, and each target's mount is thin: a
+  rewritten `index.html` pointing at the shared runtime, plus its own `project/`
+  and `openscad-web.config.json`. So a site with N models is roughly
+  `runtime + N × (small project payload)` instead of N runtime copies.
+- The shared runtime path is versioned, so publishing with a new artifact
+  version adds a new runtime alongside the old one rather than replacing it.
+- `/_openscad-web/` is reserved; a `mountPath` may not live under it.
+- Shared-runtime paths are **relative**, so the site works under any base URL
+  (repo Pages subpath, user site, or a custom domain) with no configuration.
+- If you serve the assembled tree by feeding it **back through a Jekyll build**
+  (rather than uploading it as a static Pages artifact, the normal path), add a
+  `.nojekyll` file so the underscore-prefixed `_openscad-web/` directory is not
+  stripped.
 
 ### Re-runs and recovery
 

--- a/scripts/__tests__/deploy-configure.test.mjs
+++ b/scripts/__tests__/deploy-configure.test.mjs
@@ -27,7 +27,15 @@ async function writeTextFile(filePath, contents) {
 
 async function createPublishArtifact(zipPath) {
   const archive = new AdmZip();
-  archive.addFile('index.html', Buffer.from('<!doctype html><div id="root"></div>'));
+  archive.addFile(
+    'index.html',
+    Buffer.from(
+      '<!doctype html><html><head>' +
+        '<link rel="icon" href="./favicon.ico" />' +
+        '<script type="module" src="./assets/app.js"></script>' +
+        '</head><body><div id="root"></div></body></html>',
+    ),
+  );
   archive.addFile('assets/app.js', Buffer.from('console.log("publish artifact");'));
   archive.addFile('libraries/example.zip', Buffer.from('placeholder'));
   archive.writeZip(zipPath);
@@ -295,12 +303,23 @@ targets:
     await expect(readFile(path.join(cwd, 'site', 'two', 'index.html'), 'utf8')).resolves.toContain(
       '<div id="root"></div>',
     );
+    // Multiple targets share one runtime, so each mount's boot config carries
+    // an assetBase pointing at it (default artifact version -> "unknown").
     await expect(
       readJson(path.join(cwd, 'site', 'one', 'openscad-web.config.json')),
-    ).resolves.toEqual({ mode: 'embed', model: './project/one.scad' });
+    ).resolves.toEqual({
+      mode: 'embed',
+      model: './project/one.scad',
+      assetBase: '../_openscad-web/unknown/',
+    });
     await expect(
       readJson(path.join(cwd, 'site', 'two', 'openscad-web.config.json')),
-    ).resolves.toEqual({ mode: 'customizer', model: './project/two.scad', controls: true });
+    ).resolves.toEqual({
+      mode: 'customizer',
+      model: './project/two.scad',
+      controls: true,
+      assetBase: '../_openscad-web/unknown/',
+    });
 
     expect(result.targets).toHaveLength(2);
     expect(result.targets.map((entry) => entry.mountDirPath)).toEqual([
@@ -394,6 +413,136 @@ targets:
     await expect(
       readFile(path.join(cwd, 'site', 'one', 'stale.txt'), 'utf8'),
     ).rejects.toMatchObject({ code: 'ENOENT' });
+  });
+
+  it('assembles the runtime once and thin mounts for multiple targets', async () => {
+    const cwd = await makeTempDir();
+    const artifactPath = path.join(cwd, 'openscad-web-publish.zip');
+    await createPublishArtifact(artifactPath);
+    await writeTextFile(path.join(cwd, 'models', 'one.scad'), 'cube(1);');
+    await writeTextFile(path.join(cwd, 'models', 'two.scad'), 'cube(2);');
+    await writeTextFile(
+      path.join(cwd, 'openscad-publish.yml'),
+      `targets:
+  - source: ./models/one.scad
+    mountPath: /one/
+    surface: viewer
+  - source: ./models/two.scad
+    mountPath: /two/
+    surface: viewer
+`,
+    );
+
+    const result = await runDeployConfigure(
+      [
+        '--config',
+        './openscad-publish.yml',
+        '--artifact-path',
+        './openscad-web-publish.zip',
+        '--artifact-version',
+        'v0.4.0',
+        '--output-dir',
+        './site',
+      ],
+      { cwd },
+    );
+
+    // Exactly one runtime copy, at the versioned shared path.
+    const sharedDir = path.join(cwd, 'site', '_openscad-web', 'v0.4.0');
+    expect(result.sharedRuntimeDirPath).toBe(sharedDir);
+    await expect(readFile(path.join(sharedDir, 'assets', 'app.js'), 'utf8')).resolves.toContain(
+      'publish artifact',
+    );
+    await expect(readFile(path.join(sharedDir, 'libraries', 'example.zip'), 'utf8')).resolves.toBe(
+      'placeholder',
+    );
+
+    // Each mount is thin: model + rewritten index.html + config, but no runtime.
+    await expect(
+      readFile(path.join(cwd, 'site', 'one', 'project', 'one.scad'), 'utf8'),
+    ).resolves.toBe('cube(1);');
+    await expect(
+      readFile(path.join(cwd, 'site', 'one', 'assets', 'app.js'), 'utf8'),
+    ).rejects.toMatchObject({ code: 'ENOENT' });
+
+    // The mount's index.html points its asset refs at the shared runtime.
+    const oneIndex = await readFile(path.join(cwd, 'site', 'one', 'index.html'), 'utf8');
+    expect(oneIndex).toContain('src="../_openscad-web/v0.4.0/assets/app.js"');
+    expect(oneIndex).toContain('href="../_openscad-web/v0.4.0/favicon.ico"');
+    expect(oneIndex).not.toContain('="./');
+
+    await expect(
+      readJson(path.join(cwd, 'site', 'one', 'openscad-web.config.json')),
+    ).resolves.toEqual({
+      mode: 'embed',
+      model: './project/one.scad',
+      assetBase: '../_openscad-web/v0.4.0/',
+    });
+  });
+
+  it('keeps a single target self-contained without a shared runtime', async () => {
+    const cwd = await makeTempDir();
+    const artifactPath = path.join(cwd, 'openscad-web-publish.zip');
+    await createPublishArtifact(artifactPath);
+    await writeTextFile(path.join(cwd, 'models', 'widget.scad'), 'cube(10);');
+    await writeTextFile(
+      path.join(cwd, 'openscad-publish.yml'),
+      `targets:
+  - source: ./models/widget.scad
+    mountPath: /model/
+    surface: viewer
+`,
+    );
+
+    const result = await runDeployConfigure(
+      [
+        '--config',
+        './openscad-publish.yml',
+        '--artifact-path',
+        './openscad-web-publish.zip',
+        '--output-dir',
+        './site',
+      ],
+      { cwd },
+    );
+
+    expect(result.sharedRuntimeDirPath).toBeNull();
+    // The single mount carries its own runtime and no assetBase.
+    await expect(
+      readFile(path.join(cwd, 'site', 'model', 'assets', 'app.js'), 'utf8'),
+    ).resolves.toContain('publish artifact');
+    await expect(
+      readFile(path.join(cwd, 'site', '_openscad-web', 'unknown', 'index.html'), 'utf8'),
+    ).rejects.toMatchObject({ code: 'ENOENT' });
+    await expect(
+      readJson(path.join(cwd, 'site', 'model', 'openscad-web.config.json')),
+    ).resolves.toEqual({ mode: 'embed', model: './project/widget.scad' });
+  });
+
+  it('rejects a mount path under the reserved shared-runtime directory', async () => {
+    const cwd = await makeTempDir();
+    const artifactPath = path.join(cwd, 'openscad-web-publish.zip');
+    await createPublishArtifact(artifactPath);
+    await writeTextFile(path.join(cwd, 'models', 'one.scad'), 'cube(1);');
+    await writeTextFile(path.join(cwd, 'models', 'two.scad'), 'cube(2);');
+    await writeTextFile(
+      path.join(cwd, 'openscad-publish.yml'),
+      `targets:
+  - source: ./models/one.scad
+    mountPath: /one/
+    surface: viewer
+  - source: ./models/two.scad
+    mountPath: /_openscad-web/two/
+    surface: viewer
+`,
+    );
+
+    await expect(
+      runDeployConfigure(
+        ['--config', './openscad-publish.yml', '--artifact-path', './openscad-web-publish.zip'],
+        { cwd },
+      ),
+    ).rejects.toThrow(/reserved shared-runtime path/i);
   });
 
   it('rejects duplicate mount paths across targets', async () => {

--- a/scripts/__tests__/deploy-configure.test.mjs
+++ b/scripts/__tests__/deploy-configure.test.mjs
@@ -545,6 +545,42 @@ targets:
     ).rejects.toThrow(/reserved shared-runtime path/i);
   });
 
+  it('does not let a path-traversal artifact version escape the shared-runtime dir', async () => {
+    const cwd = await makeTempDir();
+    const artifactPath = path.join(cwd, 'openscad-web-publish.zip');
+    await createPublishArtifact(artifactPath);
+    await writeTextFile(path.join(cwd, 'models', 'one.scad'), 'cube(1);');
+    await writeTextFile(path.join(cwd, 'models', 'two.scad'), 'cube(2);');
+    await writeTextFile(
+      path.join(cwd, 'openscad-publish.yml'),
+      `targets:
+  - source: ./models/one.scad
+    mountPath: /one/
+    surface: viewer
+  - source: ./models/two.scad
+    mountPath: /two/
+    surface: viewer
+`,
+    );
+
+    const result = await runDeployConfigure(
+      [
+        '--config',
+        './openscad-publish.yml',
+        '--artifact-path',
+        './openscad-web-publish.zip',
+        '--artifact-version',
+        '..',
+        '--output-dir',
+        './site',
+      ],
+      { cwd },
+    );
+
+    // '..' would resolve to the site root; it must fall back to a safe segment.
+    expect(result.sharedRuntimeDirPath).toBe(path.join(cwd, 'site', '_openscad-web', 'unknown'));
+  });
+
   it('rejects duplicate mount paths across targets', async () => {
     const cwd = await makeTempDir();
     const artifactPath = path.join(cwd, 'openscad-web-publish.zip');

--- a/scripts/deploy-configure.mjs
+++ b/scripts/deploy-configure.mjs
@@ -453,7 +453,7 @@ async function assertMountDirectoryCanBeReplaced(mountDirPath) {
   return { replaceExisting: true };
 }
 
-function buildBootConfig(target, modelPath) {
+function buildBootConfig(target, modelPath, assetBase) {
   const bootConfig = {
     mode: SURFACE_TO_MODE[target.surface],
     model: modelPath,
@@ -464,8 +464,27 @@ function buildBootConfig(target, modelPath) {
   if (typeof target.title === 'string' && target.title.trim() !== '')
     bootConfig.title = target.title;
   if (typeof target.parentOrigin === 'string') bootConfig.parentOrigin = target.parentOrigin;
+  if (typeof assetBase === 'string') bootConfig.assetBase = assetBase;
 
   return bootConfig;
+}
+
+// Directory (under the site root) that holds the shared runtime, versioned so
+// multiple artifact versions can coexist. Thin mounts reference it via a
+// relative path so the site works under any base URL.
+const SHARED_RUNTIME_DIRNAME = '_openscad-web';
+
+function sharedRuntimeVersionSegment(artifactVersion) {
+  const segment = getString(artifactVersion)?.replace(/[^A-Za-z0-9._-]/g, '_');
+  return segment == null || segment === '' ? DEFAULT_ARTIFACT_VERSION : segment;
+}
+
+// Rewrite the runtime artifact's index.html so its `./`-relative asset refs
+// (entry script/CSS, modulepreload, icons, audio) point at the shared runtime.
+// The app's dynamic chunks, worker, and WASM then chain off the entry script's
+// location; runtime-fetched libraries follow `assetBase` in the boot config.
+function rewriteThinIndexHtml(indexHtml, relativeRuntimePrefix) {
+  return indexHtml.replaceAll('="./', `="${relativeRuntimePrefix}`);
 }
 
 async function writeOwnershipMarker(targetDirPath, artifactVersion, now) {
@@ -542,12 +561,43 @@ export async function runDeployConfigure(
   const extractedArtifactDirPath = path.join(tempRootDirPath, 'artifact');
 
   try {
-    // Extract the runtime once as an immutable base; each target is composed
-    // into its own mount from it (its own runtime copy — a shared runtime is
-    // tracked separately in #240).
+    // Extract the runtime once as an immutable base. With a single target each
+    // mount is self-contained (its own runtime copy). With multiple targets the
+    // runtime is assembled once into a shared dir and each mount is thin,
+    // pointing at it — one runtime copy for the whole site (#240).
     await mkdir(extractedArtifactDirPath, { recursive: true });
     new AdmZip(path.resolve(cwd, artifactPath)).extractAllTo(extractedArtifactDirPath, true);
     await assertArtifactLayout(extractedArtifactDirPath);
+
+    const useSharedRuntime = targets.length > 1;
+    let sharedRuntimeDirPath = null;
+    let baseIndexHtml = null;
+
+    if (useSharedRuntime) {
+      const reservedPrefix = `/${SHARED_RUNTIME_DIRNAME}/`;
+      for (const target of targets) {
+        if (target.mountPath.startsWith(reservedPrefix)) {
+          throw new Error(
+            `mountPath must not use the reserved shared-runtime path ${reservedPrefix}. Got: ${target.mountPath}`,
+          );
+        }
+      }
+
+      sharedRuntimeDirPath = path.join(
+        outputDirPath,
+        SHARED_RUNTIME_DIRNAME,
+        sharedRuntimeVersionSegment(args.artifactVersion),
+      );
+      const sharedReplace = await assertMountDirectoryCanBeReplaced(sharedRuntimeDirPath);
+      if (sharedReplace.replaceExisting) {
+        await rm(sharedRuntimeDirPath, { recursive: true, force: true });
+      }
+      await mkdir(path.dirname(sharedRuntimeDirPath), { recursive: true });
+      await copyDirectoryContents(extractedArtifactDirPath, sharedRuntimeDirPath);
+      await writeOwnershipMarker(sharedRuntimeDirPath, args.artifactVersion, now);
+
+      baseIndexHtml = await readFile(path.join(extractedArtifactDirPath, 'index.html'), 'utf8');
+    }
 
     const assembled = [];
     for (const target of targets) {
@@ -557,11 +607,24 @@ export async function runDeployConfigure(
         await rm(mountDirPath, { recursive: true, force: true });
       }
 
-      await mkdir(path.dirname(mountDirPath), { recursive: true });
-      await copyDirectoryContents(extractedArtifactDirPath, mountDirPath);
+      await mkdir(mountDirPath, { recursive: true });
+
+      let assetBase;
+      if (useSharedRuntime) {
+        // Thin mount: a rewritten index.html pointing at the shared runtime,
+        // plus its own project payload, boot config, and ownership marker.
+        assetBase = `${toPosixPath(path.relative(mountDirPath, sharedRuntimeDirPath))}/`;
+        await writeFile(
+          path.join(mountDirPath, 'index.html'),
+          rewriteThinIndexHtml(baseIndexHtml, assetBase),
+          'utf8',
+        );
+      } else {
+        await copyDirectoryContents(extractedArtifactDirPath, mountDirPath);
+      }
 
       const modelPath = await populateProjectPayload(mountDirPath, target);
-      const bootConfig = buildBootConfig(target, modelPath);
+      const bootConfig = buildBootConfig(target, modelPath, assetBase);
       await writeFile(
         path.join(mountDirPath, 'openscad-web.config.json'),
         `${JSON.stringify(bootConfig, null, 2)}\n`,
@@ -574,6 +637,7 @@ export async function runDeployConfigure(
 
     return {
       outputDirPath,
+      sharedRuntimeDirPath,
       targets: assembled,
       json: args.json,
     };
@@ -592,6 +656,7 @@ if (isMainModule) {
       process.stdout.write(
         `${JSON.stringify({
           outputDirPath: result.outputDirPath,
+          sharedRuntimeDirPath: result.sharedRuntimeDirPath,
           targets: result.targets.map((entry) => ({
             mountDirPath: entry.mountDirPath,
             mode: entry.bootConfig.mode,

--- a/scripts/deploy-configure.mjs
+++ b/scripts/deploy-configure.mjs
@@ -476,7 +476,12 @@ const SHARED_RUNTIME_DIRNAME = '_openscad-web';
 
 function sharedRuntimeVersionSegment(artifactVersion) {
   const segment = getString(artifactVersion)?.replace(/[^A-Za-z0-9._-]/g, '_');
-  return segment == null || segment === '' ? DEFAULT_ARTIFACT_VERSION : segment;
+  // Never let the version escape the shared-runtime dir. The version is
+  // maintainer/CI-controlled, but '.'/'..' would resolve to the parent tree.
+  if (segment == null || segment === '' || segment === '.' || segment === '..') {
+    return DEFAULT_ARTIFACT_VERSION;
+  }
+  return segment;
 }
 
 // Rewrite the runtime artifact's index.html so its `./`-relative asset refs
@@ -569,20 +574,23 @@ export async function runDeployConfigure(
     new AdmZip(path.resolve(cwd, artifactPath)).extractAllTo(extractedArtifactDirPath, true);
     await assertArtifactLayout(extractedArtifactDirPath);
 
+    // `/_openscad-web/` is reserved for the shared runtime — reject it for any
+    // publish (not only multi-target), so a single-target mount there can't
+    // collide with a shared runtime assembled later into the same output dir.
+    const reservedPrefix = `/${SHARED_RUNTIME_DIRNAME}/`;
+    for (const target of targets) {
+      if (target.mountPath.startsWith(reservedPrefix)) {
+        throw new Error(
+          `mountPath must not use the reserved shared-runtime path ${reservedPrefix}. Got: ${target.mountPath}`,
+        );
+      }
+    }
+
     const useSharedRuntime = targets.length > 1;
     let sharedRuntimeDirPath = null;
     let baseIndexHtml = null;
 
     if (useSharedRuntime) {
-      const reservedPrefix = `/${SHARED_RUNTIME_DIRNAME}/`;
-      for (const target of targets) {
-        if (target.mountPath.startsWith(reservedPrefix)) {
-          throw new Error(
-            `mountPath must not use the reserved shared-runtime path ${reservedPrefix}. Got: ${target.mountPath}`,
-          );
-        }
-      }
-
       sharedRuntimeDirPath = path.join(
         outputDirPath,
         SHARED_RUNTIME_DIRNAME,

--- a/src/index.ts
+++ b/src/index.ts
@@ -49,10 +49,12 @@ window.addEventListener('load', async () => {
   if (typeof bootConfig.title === 'string' && bootConfig.title.trim() !== '') {
     document.title = bootConfig.title;
   }
-  // A shared-runtime mount (multi-target publish) points main-thread
-  // runtime-asset fetches (libraries/fonts) at the shared runtime, resolved
-  // relative to this document. The compile worker lives in the shared runtime
-  // and derives the same base from its own location, so it needs no override.
+  // A shared-runtime mount (multi-target publish) points runtime-asset fetches
+  // (libraries/fonts) at the shared runtime, resolved relative to this document.
+  // This runs before the session (and thus the compile worker) is created, so
+  // the worker inherits the shared base via its configure message
+  // (workerConfigPayload -> getDefaultRuntimeBaseUrl) — the thin mount itself
+  // has no libraries/.
   if (typeof bootConfig.assetBase === 'string' && bootConfig.assetBase.trim() !== '') {
     const resolved = new URL(bootConfig.assetBase, document.baseURI).toString();
     setRuntimeAssetBase(resolved.endsWith('/') ? resolved : `${resolved}/`);

--- a/src/index.ts
+++ b/src/index.ts
@@ -8,6 +8,7 @@ import {
 } from './fs/library-delivery.ts';
 import { ensureBrowserFSLoaded, getBrowserFS } from './runtime/browserfs-runtime.ts';
 import { loadBootConfig, mergeConfigIntoSearch } from './runtime/boot-config.ts';
+import { setRuntimeAssetBase } from './runtime/asset-urls.ts';
 import { registerAppServiceWorker } from './runtime/service-worker.ts';
 import { readStateFromFragment, writeStateInFragment } from './state/fragment-state.ts';
 import { readPersistedState, writePersistedState } from './state/persisted-state.ts';
@@ -47,6 +48,14 @@ window.addEventListener('load', async () => {
   const bootConfig = await loadBootConfig();
   if (typeof bootConfig.title === 'string' && bootConfig.title.trim() !== '') {
     document.title = bootConfig.title;
+  }
+  // A shared-runtime mount (multi-target publish) points main-thread
+  // runtime-asset fetches (libraries/fonts) at the shared runtime, resolved
+  // relative to this document. The compile worker lives in the shared runtime
+  // and derives the same base from its own location, so it needs no override.
+  if (typeof bootConfig.assetBase === 'string' && bootConfig.assetBase.trim() !== '') {
+    const resolved = new URL(bootConfig.assetBase, document.baseURI).toString();
+    setRuntimeAssetBase(resolved.endsWith('/') ? resolved : `${resolved}/`);
   }
 
   const urlModeResult = parseUrlMode(mergeConfigIntoSearch(window.location.search, bootConfig));

--- a/src/runner/__tests__/worker-bootstrap.test.ts
+++ b/src/runner/__tests__/worker-bootstrap.test.ts
@@ -9,6 +9,7 @@ import {
   createOpenSCADWorker,
   workerConfigPayload,
 } from '../worker-bootstrap.ts';
+import { setRuntimeAssetBase } from '../../runtime/asset-urls.ts';
 
 const workerArgs: { url: unknown; opts: unknown }[] = [];
 const origCreateObjectURL = URL.createObjectURL;
@@ -45,6 +46,19 @@ describe('worker bootstrap (#196)', () => {
     createOpenSCADWorker();
     expect(workerArgs.at(-1)).toMatchObject({ opts: { type: 'module' } });
     expect(String(workerArgs.at(-1)!.url)).not.toMatch(/^blob:/);
+  });
+
+  // Regression (#240): on a shared-runtime thin mount (no webview configure),
+  // setRuntimeAssetBase pins the main-thread base to the shared runtime. The
+  // worker's configure payload must carry THAT base, not the mount's
+  // document.baseURI — the thin mount has no libraries/fonts of its own.
+  it('shared-runtime override → the config payload carries the shared base', () => {
+    setRuntimeAssetBase('https://site.example/_openscad-web/v0.4.0/');
+    try {
+      expect(workerConfigPayload().assetBase).toBe('https://site.example/_openscad-web/v0.4.0/');
+    } finally {
+      setRuntimeAssetBase(null);
+    }
   });
 
   it('after configure → a classic blob worker, and the payload carries the injected base', async () => {

--- a/src/runner/worker-bootstrap.ts
+++ b/src/runner/worker-bootstrap.ts
@@ -15,7 +15,7 @@
 
 import openSCADWorkerUrl from './openscad-worker.ts?worker&url';
 import { openSCADWasmUrl } from './openscad-asset-urls.ts';
-import { resolveDefaultRuntimeBaseUrl } from '../runtime/asset-urls.ts';
+import { getDefaultRuntimeBaseUrl } from '../runtime/asset-urls.ts';
 import type { ConfigureRequest } from './worker-protocol.ts';
 
 let blobWorkerUrl: string | null = null;
@@ -62,11 +62,17 @@ export function createOpenSCADWorker(): Worker {
  * The `configure` message the host posts to a freshly-created worker, before any
  * compile. `wasmUrl` and `assetBase` are resolved HERE (main thread), where
  * `import.meta.url` is a real URL, then handed to the worker verbatim (#196).
+ *
+ * `assetBase` goes through `getDefaultRuntimeBaseUrl()` so it honors a
+ * `setRuntimeAssetBase()` override — e.g. a shared-runtime thin mount pins the
+ * base to the shared runtime, which is where the worker's libraries/fonts live.
+ * Without that, the worker would inherit the mount's `document.baseURI`, which
+ * on a thin mount has no `libraries/`.
  */
 export function workerConfigPayload(): ConfigureRequest {
   return {
     type: 'configure',
-    assetBase: assetBaseOverride ?? resolveDefaultRuntimeBaseUrl(import.meta.env.BASE_URL),
+    assetBase: assetBaseOverride ?? getDefaultRuntimeBaseUrl(),
     wasmUrl: wasmUrlOverride ?? openSCADWasmUrl,
     ...(assetUrlsOverride ? { assetUrls: assetUrlsOverride } : {}),
   };

--- a/src/runtime/__tests__/boot-config.test.ts
+++ b/src/runtime/__tests__/boot-config.test.ts
@@ -68,6 +68,7 @@ describe('loadBootConfig', () => {
             download: false,
             parentOrigin: 'https://store.example.com',
             title: 'Configured Project',
+            assetBase: '../_openscad-web/v0.4.0/',
             unknown: 'ignored',
           }),
           {
@@ -89,6 +90,7 @@ describe('loadBootConfig', () => {
       download: false,
       parentOrigin: 'https://store.example.com',
       title: 'Configured Project',
+      assetBase: '../_openscad-web/v0.4.0/',
     });
   });
 

--- a/src/runtime/asset-urls.ts
+++ b/src/runtime/asset-urls.ts
@@ -66,7 +66,7 @@ export function setRuntimeAssetBase(base: string | null): void {
   overrideBase = base;
 }
 
-function getDefaultRuntimeBaseUrl(): string {
+export function getDefaultRuntimeBaseUrl(): string {
   return overrideBase ?? resolveDefaultRuntimeBaseUrl(import.meta.env.BASE_URL);
 }
 

--- a/src/runtime/boot-config.ts
+++ b/src/runtime/boot-config.ts
@@ -5,6 +5,13 @@ export interface BootConfig {
   download?: boolean;
   parentOrigin?: string;
   title?: string;
+  /**
+   * Base for runtime-fetched assets (libraries/fonts), relative to this
+   * surface's document. Set when a shared runtime is assembled once and
+   * multiple thin mounts point at it (multi-target publish). Absent for a
+   * self-contained mount, where assets resolve relative to the document.
+   */
+  assetBase?: string;
 }
 
 export const BOOT_CONFIG_TIMEOUT_MS = 2_000;
@@ -26,6 +33,7 @@ function normalizeBootConfig(value: unknown): BootConfig {
   if (typeof value.download === 'boolean') config.download = value.download;
   if (typeof value.parentOrigin === 'string') config.parentOrigin = value.parentOrigin;
   if (typeof value.title === 'string') config.title = value.title;
+  if (typeof value.assetBase === 'string') config.assetBase = value.assetBase;
 
   return config;
 }


### PR DESCRIPTION
Closes #240. Convergence Phase 2 (P2.2), building on #239. A docs site with many models no longer pays N× the runtime.

## Problem
Each published target carried its own ~13 MB runtime copy. 10 models = ~230 MB of duplicated WASM/JS/libraries.

## Change
For **>1 target**, the runtime is assembled **once** into `<site>/_openscad-web/<artifact-version>/`, and each mount is **thin**: a rewritten `index.html` pointing at the shared runtime + its own `project/` + `openscad-web.config.json`. A **single target stays self-contained** (unchanged), so the existing single-model path — including the docs template's current embed — is untouched.

### How assets resolve
- **Build-graph** (entry JS/CSS, dynamic chunks, worker, WASM): the thin `index.html`'s `./`-relative refs are rewritten to the shared path; Vite's relative base then chains chunks/worker/WASM off the entry script's location.
- **Runtime-fetched** (libraries/fonts): boot config gains `assetBase`; the app applies it via the existing `setRuntimeAssetBase()` hook (`asset-urls.ts`). The compile **worker lives in the shared runtime** and derives the same base from its own `self.location`, so it needs no override.
- Shared paths are **relative** → base-URL agnostic (Pages subpath / user site / custom domain).
- `/_openscad-web/` is reserved; a `mountPath` under it is rejected.

## Verification (local)
- **Size:** real 2-target assembly → **23 MB** shared runtime + **16 KB** per thin mount (vs 46 MB before).
- **Resolution proof:** served the real assembled site; every thin-mount reference returns 200 — `config`/`project` mount-relative, and entry JS + CSS + preload + **worker** + **WASM** from the single `/_openscad-web/v0.4.0/`.
- **Tests:** 33 assembly (3 new: shared-runtime layout, single-target self-containment, reserved-path reject) + boot-config `assetBase` unit test; tsc / eslint / prettier clean.

## Follow-up
The sandbox browser can't execute localhost pages here, so the in-browser boot of a thin mount is proven by the network-resolution trace above rather than a screenshot. Adding a **multi-target thin-mount scenario to the publish-e2e harness** (a new server mode + spec) is a worthwhile follow-up — flagging for the review to weigh in on whether to include it here or track separately.

Scope: builds on multi-target (#239).