### PR TITLE
feat(publish): static (pre-rendered) geometry surface (#241)

### DIFF
--- a/docs/PUBLISHING.md
+++ b/docs/PUBLISHING.md
@@ -116,11 +116,48 @@ Field reference:
 | `targets[].projectRoot`  | Publish boundary for a multi-file project. Everything under this directory becomes public. |
 | `targets[].entry`        | Entry `.scad` file inside `projectRoot`. Resolved relative to `projectRoot`.               |
 | `targets[].mountPath`    | Mount path inside the final site tree, such as `/` or `/model/`.                           |
-| `targets[].surface`      | One of `viewer`, `customizer`, or `editor`.                                                |
+| `targets[].surface`      | One of `viewer`, `customizer`, `editor`, or `static`.                                      |
+| `targets[].geometry`     | **`static` only.** Path to a pre-rendered OFF geometry file (see below).                   |
+| `targets[].poster`       | **`static` only.** Optional path to a pre-rendered PNG poster.                             |
 | `targets[].controls`     | Optional default for embed/customizer controls.                                            |
 | `targets[].download`     | Optional default for download UI.                                                          |
 | `targets[].title`        | Optional page title.                                                                       |
 | `targets[].parentOrigin` | Optional embed security setting for trusted iframe parents.                                |
+
+## Static (Pre-Rendered) Surface
+
+The `viewer`/`customizer`/`editor` surfaces run the OpenSCAD **WASM compiler in
+the browser** (~13 MB) so the model is live. The `static` surface instead ships
+a **pre-rendered** model to a lightweight read-only viewer (~0.6 MB, no WASM) —
+ideal for docs pages that only need to _show_ a model.
+
+Render the geometry (and an optional poster) with the OpenSCAD **CLI** — the
+bundled helper does both:
+
+```bash
+node scripts/render-geometry.mjs --source ./models/widget.scad --out-dir ./rendered
+# -> ./rendered/widget.off  (geometry the viewer displays)
+#    ./rendered/widget.png  (poster; add --no-poster to skip)
+```
+
+(Equivalent by hand: `openscad -o widget.off widget.scad` and
+`openscad -o widget.png --viewall --autocenter --render widget.scad`.)
+
+Then publish the pre-rendered files with `surface: static`:
+
+```yaml
+targets:
+  - surface: static
+    geometry: ./rendered/widget.off
+    poster: ./rendered/widget.png
+    mountPath: /widget/
+    title: Widget
+```
+
+The mount holds `geometry.off`, `poster.png`, a boot config, and the static
+viewer page — no compiler, no `.scad`. The OpenSCAD CLI must be available where
+you run the render step (it is not part of `deploy-configure`, which stays
+dependency-free); GitHub's `ubuntu-*` runners can `apt-get install -y openscad`.
 
 Multiple targets:
 

--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
     "start:development": "cross-env NODE_ENV=development vite",
     "start:production": "cross-env PUBLIC_URL=/dist/ npm run build && serve -l 3000 .",
     "start": "npm run start:development",
-    "build": "cross-env NODE_ENV=production vite build && node ./scripts/build-sw.mjs && node ./scripts/verify-production-build.mjs && node ./scripts/verify-viewer-bundle.mjs",
+    "build": "cross-env NODE_ENV=production vite build && node ./scripts/build-sw.mjs && node ./scripts/verify-production-build.mjs && node ./scripts/verify-viewer-bundle.mjs && node ./scripts/verify-viewer-bundle.mjs --entry static.html",
     "build:publish": "node ./scripts/build-publish.mjs",
     "build:protocol": "tsc -p tsconfig.protocol.json && node ./scripts/rewrite-protocol-dts.mjs && node ./scripts/verify-protocol-emit.mjs",
     "build:viewer": "cross-env NODE_ENV=production vite build --config vite.viewer.config.ts && npm run build:protocol && node ./scripts/verify-viewer-bundle.mjs --dir dist-viewer && node ./scripts/build-viewer-manifest.mjs",

--- a/scripts/__tests__/deploy-configure.test.mjs
+++ b/scripts/__tests__/deploy-configure.test.mjs
@@ -770,6 +770,18 @@ targets:
     expect(indexHtml).toContain('id="viewer-root"');
     expect(indexHtml).toContain('assets/static.js');
 
+    // The mount carries ONLY the static viewer's chunk — not the compiler app's
+    // entry chunk and no library payloads.
+    await expect(
+      readFile(path.join(cwd, 'site', 'widget', 'assets', 'static.js'), 'utf8'),
+    ).resolves.toContain('static viewer');
+    await expect(
+      readFile(path.join(cwd, 'site', 'widget', 'assets', 'app.js'), 'utf8'),
+    ).rejects.toMatchObject({ code: 'ENOENT' });
+    await expect(
+      readFile(path.join(cwd, 'site', 'widget', 'libraries', 'example.zip'), 'utf8'),
+    ).rejects.toMatchObject({ code: 'ENOENT' });
+
     // Geometry + poster copied under fixed names; no .scad project.
     await expect(readFile(path.join(cwd, 'site', 'widget', 'geometry.off'), 'utf8')).resolves.toBe(
       'OFF\n8 12 0\n',
@@ -791,17 +803,22 @@ targets:
     });
   });
 
-  it('assembles a static thin mount that shares the runtime with a live target', async () => {
+  it('keeps a static mount self-contained even beside a shared runtime', async () => {
     const cwd = await makeTempDir();
     const artifactPath = path.join(cwd, 'openscad-web-publish.zip');
     await createPublishArtifact(artifactPath);
-    await writeTextFile(path.join(cwd, 'models', 'live.scad'), 'cube(1);');
+    await writeTextFile(path.join(cwd, 'models', 'a.scad'), 'cube(1);');
+    await writeTextFile(path.join(cwd, 'models', 'b.scad'), 'cube(2);');
     await writeTextFile(path.join(cwd, 'rendered', 'still.off'), 'OFF\n');
     await writeTextFile(
       path.join(cwd, 'openscad-publish.yml'),
+      // Two compile targets trigger the shared runtime; the static one must not.
       `targets:
-  - source: ./models/live.scad
-    mountPath: /live/
+  - source: ./models/a.scad
+    mountPath: /a/
+    surface: viewer
+  - source: ./models/b.scad
+    mountPath: /b/
     surface: viewer
   - surface: static
     geometry: ./rendered/still.off
@@ -809,7 +826,7 @@ targets:
 `,
     );
 
-    await runDeployConfigure(
+    const result = await runDeployConfigure(
       [
         '--config',
         './openscad-publish.yml',
@@ -823,23 +840,26 @@ targets:
       { cwd },
     );
 
-    // The static mount is thin: its index is the rewritten STATIC page pointing
-    // at the shared runtime, plus its geometry — no runtime copy of its own.
+    // The compile targets share one runtime...
+    expect(result.sharedRuntimeDirPath).toBe(path.join(cwd, 'site', '_openscad-web', 'v0.4.0'));
+    const liveIndex = await readFile(path.join(cwd, 'site', 'a', 'index.html'), 'utf8');
+    expect(liveIndex).toContain('../_openscad-web/v0.4.0/assets/app.js');
+
+    // ...but the static mount is self-contained: its own index + chunk + geometry,
+    // mount-relative refs, and NO assetBase pointing at the shared runtime.
     const stillIndex = await readFile(path.join(cwd, 'site', 'still', 'index.html'), 'utf8');
-    expect(stillIndex).toContain('src="../_openscad-web/v0.4.0/assets/static.js"');
-    expect(stillIndex).not.toContain('="./');
+    expect(stillIndex).toContain('src="./assets/static.js"');
+    await expect(
+      readFile(path.join(cwd, 'site', 'still', 'assets', 'static.js'), 'utf8'),
+    ).resolves.toContain('static viewer');
     await expect(readFile(path.join(cwd, 'site', 'still', 'geometry.off'), 'utf8')).resolves.toBe(
       'OFF\n',
     );
-    await expect(
-      readFile(path.join(cwd, 'site', 'still', 'assets', 'static.js'), 'utf8'),
-    ).rejects.toMatchObject({ code: 'ENOENT' });
     await expect(
       readJson(path.join(cwd, 'site', 'still', 'openscad-web.config.json')),
     ).resolves.toEqual({
       mode: 'static',
       geometry: './geometry.off',
-      assetBase: '../_openscad-web/v0.4.0/',
     });
   });
 

--- a/scripts/__tests__/deploy-configure.test.mjs
+++ b/scripts/__tests__/deploy-configure.test.mjs
@@ -37,6 +37,15 @@ async function createPublishArtifact(zipPath) {
     ),
   );
   archive.addFile('assets/app.js', Buffer.from('console.log("publish artifact");'));
+  archive.addFile(
+    'static.html',
+    Buffer.from(
+      '<!doctype html><html><head>' +
+        '<script type="module" src="./assets/static.js"></script>' +
+        '</head><body><div id="viewer-root"></div></body></html>',
+    ),
+  );
+  archive.addFile('assets/static.js', Buffer.from('console.log("static viewer");'));
   archive.addFile('libraries/example.zip', Buffer.from('placeholder'));
   archive.writeZip(zipPath);
 }
@@ -723,5 +732,156 @@ targets:
         },
       ),
     ).rejects.toThrow(/site\.outDir as a non-empty string/i);
+  });
+
+  it('assembles a static surface from pre-rendered geometry + poster', async () => {
+    const cwd = await makeTempDir();
+    const artifactPath = path.join(cwd, 'openscad-web-publish.zip');
+    await createPublishArtifact(artifactPath);
+    await writeTextFile(path.join(cwd, 'rendered', 'widget.off'), 'OFF\n8 12 0\n');
+    await writeTextFile(path.join(cwd, 'rendered', 'widget.png'), 'PNGDATA');
+    await writeTextFile(
+      path.join(cwd, 'openscad-publish.yml'),
+      `targets:
+  - surface: static
+    geometry: ./rendered/widget.off
+    poster: ./rendered/widget.png
+    mountPath: /widget/
+    title: Widget
+`,
+    );
+
+    const result = await runDeployConfigure(
+      [
+        '--config',
+        './openscad-publish.yml',
+        '--artifact-path',
+        './openscad-web-publish.zip',
+        '--output-dir',
+        './site',
+      ],
+      { cwd },
+    );
+
+    // Single target → self-contained; the mount's index page is the STATIC
+    // viewer (static.html), not the compile app.
+    expect(result.sharedRuntimeDirPath).toBeNull();
+    const indexHtml = await readFile(path.join(cwd, 'site', 'widget', 'index.html'), 'utf8');
+    expect(indexHtml).toContain('id="viewer-root"');
+    expect(indexHtml).toContain('assets/static.js');
+
+    // Geometry + poster copied under fixed names; no .scad project.
+    await expect(readFile(path.join(cwd, 'site', 'widget', 'geometry.off'), 'utf8')).resolves.toBe(
+      'OFF\n8 12 0\n',
+    );
+    await expect(readFile(path.join(cwd, 'site', 'widget', 'poster.png'), 'utf8')).resolves.toBe(
+      'PNGDATA',
+    );
+    await expect(
+      readFile(path.join(cwd, 'site', 'widget', 'project', 'anything'), 'utf8'),
+    ).rejects.toMatchObject({ code: 'ENOENT' });
+
+    await expect(
+      readJson(path.join(cwd, 'site', 'widget', 'openscad-web.config.json')),
+    ).resolves.toEqual({
+      mode: 'static',
+      geometry: './geometry.off',
+      poster: './poster.png',
+      title: 'Widget',
+    });
+  });
+
+  it('assembles a static thin mount that shares the runtime with a live target', async () => {
+    const cwd = await makeTempDir();
+    const artifactPath = path.join(cwd, 'openscad-web-publish.zip');
+    await createPublishArtifact(artifactPath);
+    await writeTextFile(path.join(cwd, 'models', 'live.scad'), 'cube(1);');
+    await writeTextFile(path.join(cwd, 'rendered', 'still.off'), 'OFF\n');
+    await writeTextFile(
+      path.join(cwd, 'openscad-publish.yml'),
+      `targets:
+  - source: ./models/live.scad
+    mountPath: /live/
+    surface: viewer
+  - surface: static
+    geometry: ./rendered/still.off
+    mountPath: /still/
+`,
+    );
+
+    await runDeployConfigure(
+      [
+        '--config',
+        './openscad-publish.yml',
+        '--artifact-path',
+        './openscad-web-publish.zip',
+        '--artifact-version',
+        'v0.4.0',
+        '--output-dir',
+        './site',
+      ],
+      { cwd },
+    );
+
+    // The static mount is thin: its index is the rewritten STATIC page pointing
+    // at the shared runtime, plus its geometry — no runtime copy of its own.
+    const stillIndex = await readFile(path.join(cwd, 'site', 'still', 'index.html'), 'utf8');
+    expect(stillIndex).toContain('src="../_openscad-web/v0.4.0/assets/static.js"');
+    expect(stillIndex).not.toContain('="./');
+    await expect(readFile(path.join(cwd, 'site', 'still', 'geometry.off'), 'utf8')).resolves.toBe(
+      'OFF\n',
+    );
+    await expect(
+      readFile(path.join(cwd, 'site', 'still', 'assets', 'static.js'), 'utf8'),
+    ).rejects.toMatchObject({ code: 'ENOENT' });
+    await expect(
+      readJson(path.join(cwd, 'site', 'still', 'openscad-web.config.json')),
+    ).resolves.toEqual({
+      mode: 'static',
+      geometry: './geometry.off',
+      assetBase: '../_openscad-web/v0.4.0/',
+    });
+  });
+
+  it('rejects a static target with no geometry', async () => {
+    const cwd = await makeTempDir();
+    const artifactPath = path.join(cwd, 'openscad-web-publish.zip');
+    await createPublishArtifact(artifactPath);
+    await writeTextFile(
+      path.join(cwd, 'openscad-publish.yml'),
+      `targets:
+  - surface: static
+    mountPath: /widget/
+`,
+    );
+    await expect(
+      runDeployConfigure(
+        ['--config', './openscad-publish.yml', '--artifact-path', './openscad-web-publish.zip'],
+        { cwd },
+      ),
+    ).rejects.toThrow(/geometry is required/i);
+  });
+
+  it('rejects a static target that also passes a .scad source', async () => {
+    const cwd = await makeTempDir();
+    const artifactPath = path.join(cwd, 'openscad-web-publish.zip');
+    await createPublishArtifact(artifactPath);
+    await writeTextFile(path.join(cwd, 'rendered', 'widget.off'), 'OFF\n');
+    await writeTextFile(path.join(cwd, 'models', 'widget.scad'), 'cube(1);');
+    await writeTextFile(
+      path.join(cwd, 'openscad-publish.yml'),
+      `targets:
+  - surface: static
+    geometry: ./rendered/widget.off
+    source: ./models/widget.scad
+    mountPath: /widget/
+`,
+    );
+    await expect(
+      runDeployConfigure(
+        ['--config', './openscad-publish.yml', '--artifact-path', './openscad-web-publish.zip'],
+        { cwd },
+      ),
+    ).rejects.toThrow(/static surface does not use source/i);
   });
 });

--- a/scripts/__tests__/render-geometry.test.mjs
+++ b/scripts/__tests__/render-geometry.test.mjs
@@ -1,0 +1,100 @@
+// @vitest-environment node
+
+import os from 'node:os';
+import path from 'node:path';
+import { afterEach, describe, expect, it } from 'vitest';
+import { mkdtemp, rm } from 'node:fs/promises';
+
+import {
+  DEFAULT_POSTER_SIZE,
+  buildOffArgs,
+  buildPosterArgs,
+  renderGeometry,
+} from '../render-geometry.mjs';
+
+describe('render-geometry arg builders', () => {
+  it('buildOffArgs exports OFF to the given path', () => {
+    expect(buildOffArgs('/m/widget.scad', '/out/widget.off')).toEqual([
+      '/m/widget.scad',
+      '-o',
+      '/out/widget.off',
+    ]);
+  });
+
+  it('buildPosterArgs renders a framed PNG at the default size', () => {
+    expect(buildPosterArgs('/m/widget.scad', '/out/widget.png')).toEqual([
+      '/m/widget.scad',
+      '-o',
+      '/out/widget.png',
+      `--imgsize=${DEFAULT_POSTER_SIZE[0]},${DEFAULT_POSTER_SIZE[1]}`,
+      '--viewall',
+      '--autocenter',
+      '--render',
+    ]);
+  });
+
+  it('buildPosterArgs honors imgsize + colorscheme', () => {
+    expect(
+      buildPosterArgs('/m.scad', '/p.png', { imgsize: [1200, 900], colorscheme: 'Tomorrow' }),
+    ).toEqual([
+      '/m.scad',
+      '-o',
+      '/p.png',
+      '--imgsize=1200,900',
+      '--viewall',
+      '--autocenter',
+      '--render',
+      '--colorscheme=Tomorrow',
+    ]);
+  });
+});
+
+describe('renderGeometry', () => {
+  const tempDirs = [];
+
+  afterEach(async () => {
+    await Promise.all(tempDirs.splice(0).map((dir) => rm(dir, { recursive: true, force: true })));
+  });
+
+  async function makeOutDir() {
+    const dir = await mkdtemp(path.join(os.tmpdir(), 'render-geometry-'));
+    tempDirs.push(dir);
+    return dir;
+  }
+
+  it('invokes the runner for OFF and poster and returns their paths', async () => {
+    const outDir = await makeOutDir();
+    const calls = [];
+    const runner = async (cmd, args) => {
+      calls.push({ cmd, args });
+    };
+
+    const result = await renderGeometry({ entryPath: '/m/widget.scad', outDir, runner });
+
+    expect(result.off).toBe(path.join(outDir, 'widget.off'));
+    expect(result.poster).toBe(path.join(outDir, 'widget.png'));
+    expect(calls).toHaveLength(2);
+    expect(calls[0].args).toEqual(['/m/widget.scad', '-o', path.join(outDir, 'widget.off')]);
+    expect(calls[1].args).toContain('--render');
+  });
+
+  it('skips the poster when poster is false and honors an explicit name', async () => {
+    const outDir = await makeOutDir();
+    const calls = [];
+    const runner = async (_cmd, args) => {
+      calls.push(args);
+    };
+
+    const result = await renderGeometry({
+      entryPath: '/m/widget.scad',
+      outDir,
+      name: 'thing',
+      poster: false,
+      runner,
+    });
+
+    expect(result.poster).toBeNull();
+    expect(result.off).toBe(path.join(outDir, 'thing.off'));
+    expect(calls).toHaveLength(1);
+  });
+});

--- a/scripts/deploy-configure.mjs
+++ b/scripts/deploy-configure.mjs
@@ -496,6 +496,50 @@ async function copyDirectoryContents(sourceDirPath, targetDirPath) {
   );
 }
 
+// The asset files (basenames under assets/) reachable from an entry HTML: its
+// script/modulepreload refs plus their transitive chunk imports. This lets a
+// static mount copy only the viewer chunks, never the compiler/WASM/libraries.
+async function collectReachableAssetFiles(artifactDirPath, entryHtml) {
+  const assetsDirPath = path.join(artifactDirPath, 'assets');
+  const referenceRe = /["'`](?:[^"'`]*\/)?([\w-]+\.(?:js|css))["'`]/g;
+  const reachable = new Set();
+  const queue = [...entryHtml.matchAll(referenceRe)].map((match) => match[1]);
+  while (queue.length > 0) {
+    const file = queue.shift();
+    if (reachable.has(file)) continue;
+    reachable.add(file);
+    if (!file.endsWith('.js')) continue;
+    let content;
+    try {
+      content = await readFile(path.join(assetsDirPath, file), 'utf8');
+    } catch {
+      continue; // not an emitted assets chunk
+    }
+    for (const match of content.matchAll(referenceRe)) {
+      if (!reachable.has(match[1])) queue.push(match[1]);
+    }
+  }
+  return reachable;
+}
+
+// Assemble a self-contained static mount: the static viewer page as index.html
+// plus only the assets it references — no compiler, WASM, Monaco, or libraries.
+async function assembleStaticMount(artifactDirPath, mountDirPath) {
+  const staticHtml = await readFile(path.join(artifactDirPath, 'static.html'), 'utf8');
+  await writeFile(path.join(mountDirPath, 'index.html'), staticHtml, 'utf8');
+
+  const assetFiles = await collectReachableAssetFiles(artifactDirPath, staticHtml);
+  await mkdir(path.join(mountDirPath, 'assets'), { recursive: true });
+  await Promise.all(
+    [...assetFiles].map(async (file) => {
+      const sourcePath = path.join(artifactDirPath, 'assets', file);
+      if ((await pathKind(sourcePath)) === 'file') {
+        await cp(sourcePath, path.join(mountDirPath, 'assets', file));
+      }
+    }),
+  );
+}
+
 function resolveMountDirectory(outputDirPath, mountPath) {
   if (mountPath === '/') {
     return outputDirPath;
@@ -545,7 +589,7 @@ function buildBootConfig(target, modelPath, assetBase) {
   return bootConfig;
 }
 
-function buildStaticBootConfig(target, geometryUrl, posterUrl, assetBase) {
+function buildStaticBootConfig(target, geometryUrl, posterUrl) {
   const bootConfig = {
     mode: SURFACE_TO_MODE.static,
     geometry: geometryUrl,
@@ -554,7 +598,6 @@ function buildStaticBootConfig(target, geometryUrl, posterUrl, assetBase) {
   if (typeof posterUrl === 'string') bootConfig.poster = posterUrl;
   if (typeof target.title === 'string' && target.title.trim() !== '')
     bootConfig.title = target.title;
-  if (typeof assetBase === 'string') bootConfig.assetBase = assetBase;
 
   return bootConfig;
 }
@@ -699,7 +742,12 @@ export async function runDeployConfigure(
       return entryHtmlCache.get(name);
     };
 
-    const useSharedRuntime = targets.length > 1;
+    // Only compile surfaces (viewer/customizer/editor) use the ~13 MB runtime;
+    // static mounts are always self-contained and light. So the shared runtime
+    // is assembled only when more than one *compile* target would otherwise each
+    // carry its own copy.
+    const compileTargetCount = targets.filter((target) => target.surface !== 'static').length;
+    const useSharedRuntime = compileTargetCount > 1;
     let sharedRuntimeDirPath = null;
 
     if (useSharedRuntime) {
@@ -720,7 +768,6 @@ export async function runDeployConfigure(
     const assembled = [];
     for (const target of targets) {
       const isStatic = target.surface === 'static';
-      const entryHtmlName = isStatic ? 'static.html' : 'index.html';
       const mountDirPath = resolveMountDirectory(outputDirPath, target.mountPath);
       const { replaceExisting } = await assertMountDirectoryCanBeReplaced(mountDirPath);
       if (replaceExisting) {
@@ -729,32 +776,26 @@ export async function runDeployConfigure(
 
       await mkdir(mountDirPath, { recursive: true });
 
-      let assetBase;
-      if (useSharedRuntime) {
-        // Thin mount: the entry page rewritten to point at the shared runtime,
-        // plus its own payload, boot config, and ownership marker.
-        assetBase = `${toPosixPath(path.relative(mountDirPath, sharedRuntimeDirPath))}/`;
-        await writeFile(
-          path.join(mountDirPath, 'index.html'),
-          rewriteThinIndexHtml(await readEntryHtml(entryHtmlName), assetBase),
-          'utf8',
-        );
-      } else {
-        await copyDirectoryContents(extractedArtifactDirPath, mountDirPath);
-        if (isStatic) {
-          // Serve the static viewer as the mount's index page.
-          await cp(
-            path.join(extractedArtifactDirPath, 'static.html'),
-            path.join(mountDirPath, 'index.html'),
-          );
-        }
-      }
-
       let bootConfig;
       if (isStatic) {
+        // Self-contained light mount: the static viewer page + only its chunks +
+        // the pre-rendered geometry. No compiler runtime, no shared runtime.
+        await assembleStaticMount(extractedArtifactDirPath, mountDirPath);
         const { geometry, poster } = await populateGeometryPayload(mountDirPath, target);
-        bootConfig = buildStaticBootConfig(target, geometry, poster, assetBase);
+        bootConfig = buildStaticBootConfig(target, geometry, poster);
       } else {
+        let assetBase;
+        if (useSharedRuntime) {
+          // Thin mount: index.html rewritten to point at the shared runtime.
+          assetBase = `${toPosixPath(path.relative(mountDirPath, sharedRuntimeDirPath))}/`;
+          await writeFile(
+            path.join(mountDirPath, 'index.html'),
+            rewriteThinIndexHtml(await readEntryHtml('index.html'), assetBase),
+            'utf8',
+          );
+        } else {
+          await copyDirectoryContents(extractedArtifactDirPath, mountDirPath);
+        }
         const modelPath = await populateProjectPayload(mountDirPath, target);
         bootConfig = buildBootConfig(target, modelPath, assetBase);
       }

--- a/scripts/deploy-configure.mjs
+++ b/scripts/deploy-configure.mjs
@@ -15,6 +15,9 @@ const SURFACE_TO_MODE = Object.freeze({
   viewer: 'embed',
   customizer: 'customizer',
   editor: 'editor',
+  // Read-only pre-rendered geometry (no in-browser compile). Uses a different
+  // page (static.html) and takes `geometry`/`poster` instead of a `.scad` source.
+  static: 'static',
 });
 
 const SUPPORTED_FLAGS = new Set([
@@ -24,6 +27,8 @@ const SUPPORTED_FLAGS = new Set([
   'entry',
   'surface',
   'mount-path',
+  'geometry',
+  'poster',
   'artifact-path',
   'artifact-version',
   'output-dir',
@@ -35,6 +40,7 @@ const HELP_TEXT = `Usage:
   node scripts/deploy-configure.mjs --config ./openscad-publish.yml --artifact-path ./openscad-web-publish.zip [--output-dir ./site]
   node scripts/deploy-configure.mjs --source ./models/widget.scad --surface viewer --mount-path /model/ --artifact-path ./openscad-web-publish.zip [--output-dir ./site]
   node scripts/deploy-configure.mjs --project-root ./models/assembly --entry ./main.scad --surface customizer --mount-path /assembly/ --artifact-path ./openscad-web-publish.zip [--output-dir ./site]
+  node scripts/deploy-configure.mjs --surface static --geometry ./models/widget.off --poster ./models/widget.png --mount-path /widget/ --artifact-path ./openscad-web-publish.zip [--output-dir ./site]
 `;
 
 function isRecord(value) {
@@ -174,6 +180,8 @@ function parseCliArgs(argv) {
     entry: parsed.entry,
     surface: parsed.surface,
     mountPath: parsed['mount-path'],
+    geometry: parsed.geometry,
+    poster: parsed.poster,
     artifactPath: parsed['artifact-path'],
     artifactVersion: parsed['artifact-version'] ?? DEFAULT_ARTIFACT_VERSION,
     outputDir: parsed['output-dir'],
@@ -243,6 +251,8 @@ function resolveTargetsFromShorthand(args, cwdPath) {
         entry: args.entry,
         surface: args.surface,
         mountPath: args.mountPath,
+        geometry: args.geometry,
+        poster: args.poster,
       },
     ],
   };
@@ -291,6 +301,12 @@ async function validateAndResolveTarget(rawTarget, baseDirPath) {
     normalizedMountPath = normalizeMountPath(mountPath);
   } catch (error) {
     errors.push(error instanceof Error ? error.message : String(error));
+  }
+
+  // The static surface takes a pre-rendered geometry (+ optional poster), not a
+  // .scad source — validate and resolve it on its own path.
+  if (surface === 'static') {
+    return resolveStaticTarget(rawTarget, baseDirPath, normalizedMountPath, errors);
   }
 
   if (source != null && (projectRoot != null || entry != null)) {
@@ -377,6 +393,51 @@ async function validateAndResolveTarget(rawTarget, baseDirPath) {
   };
 }
 
+async function resolveStaticTarget(rawTarget, baseDirPath, normalizedMountPath, errors) {
+  const geometry = getString(rawTarget.geometry);
+  const poster = getString(rawTarget.poster);
+
+  for (const field of ['source', 'projectRoot', 'entry', 'controls', 'download', 'parentOrigin']) {
+    if (rawTarget[field] !== undefined) {
+      errors.push(`static surface does not use ${field}.`);
+    }
+  }
+  if (geometry == null) {
+    errors.push('geometry is required for the static surface.');
+  }
+  if (rawTarget.title !== undefined && typeof rawTarget.title !== 'string') {
+    errors.push('title must be a string when provided.');
+  }
+
+  let geometryPath = null;
+  if (geometry != null) {
+    geometryPath = path.resolve(baseDirPath, geometry);
+    if ((await pathKind(geometryPath)) !== 'file') {
+      errors.push(`geometry file not found: ${geometryPath}`);
+    }
+  }
+
+  let posterPath = null;
+  if (poster != null) {
+    posterPath = path.resolve(baseDirPath, poster);
+    if ((await pathKind(posterPath)) !== 'file') {
+      errors.push(`poster file not found: ${posterPath}`);
+    }
+  }
+
+  if (errors.length > 0) {
+    throw new Error(`Invalid publish target:\n- ${errors.join('\n- ')}`);
+  }
+
+  return {
+    mountPath: /** @type {string} */ (normalizedMountPath),
+    surface: 'static',
+    geometryPath,
+    posterPath,
+    title: rawTarget.title,
+  };
+}
+
 async function assertArtifactLayout(artifactDirPath) {
   const requiredPaths = ['index.html', 'assets', 'libraries'];
   const missing = [];
@@ -406,6 +467,21 @@ async function populateProjectPayload(targetDirPath, target) {
 
   await copyDirectoryContents(target.projectRootPath, projectDirPath);
   return `./project/${target.entryPath}`;
+}
+
+// Copy a static target's pre-rendered geometry (+ optional poster) into the
+// mount under fixed names, and return their mount-relative URLs for the config.
+async function populateGeometryPayload(targetDirPath, target) {
+  await cp(target.geometryPath, path.join(targetDirPath, 'geometry.off'));
+
+  let posterUrl = null;
+  if (target.posterPath != null) {
+    const posterFileName = `poster${path.extname(target.posterPath) || '.png'}`;
+    await cp(target.posterPath, path.join(targetDirPath, posterFileName));
+    posterUrl = `./${posterFileName}`;
+  }
+
+  return { geometry: './geometry.off', poster: posterUrl };
 }
 
 async function copyDirectoryContents(sourceDirPath, targetDirPath) {
@@ -469,6 +545,20 @@ function buildBootConfig(target, modelPath, assetBase) {
   return bootConfig;
 }
 
+function buildStaticBootConfig(target, geometryUrl, posterUrl, assetBase) {
+  const bootConfig = {
+    mode: SURFACE_TO_MODE.static,
+    geometry: geometryUrl,
+  };
+
+  if (typeof posterUrl === 'string') bootConfig.poster = posterUrl;
+  if (typeof target.title === 'string' && target.title.trim() !== '')
+    bootConfig.title = target.title;
+  if (typeof assetBase === 'string') bootConfig.assetBase = assetBase;
+
+  return bootConfig;
+}
+
 // Directory (under the site root) that holds the shared runtime, versioned so
 // multiple artifact versions can coexist. Thin mounts reference it via a
 // relative path so the site works under any base URL.
@@ -523,19 +613,22 @@ export async function runDeployConfigure(
     args.entry,
     args.surface,
     args.mountPath,
+    args.geometry,
+    args.poster,
   ].some((value) => getString(value) != null);
 
   const sourceSelectionProvided =
     getString(args.source) != null ||
     getString(args.projectRoot) != null ||
-    getString(args.entry) != null;
+    getString(args.entry) != null ||
+    getString(args.geometry) != null;
 
   if (getString(args.config) != null && shorthandFieldsProvided) {
     throw new Error('Use either --config or the shorthand target flags, not both.');
   }
   if (getString(args.config) == null && !sourceSelectionProvided) {
     throw new Error(
-      'You must provide either --config or one of --source / --project-root with shorthand target flags.',
+      'You must provide either --config or a shorthand target (--source / --project-root / --geometry).',
     );
   }
 
@@ -586,9 +679,28 @@ export async function runDeployConfigure(
       }
     }
 
+    // The static surface serves a different entry page (static.html). Require it
+    // in the artifact when any target needs it, and cache entry HTML for thin
+    // mounts (index.html for compile surfaces, static.html for static).
+    const needsStatic = targets.some((target) => target.surface === 'static');
+    if (
+      needsStatic &&
+      (await pathKind(path.join(extractedArtifactDirPath, 'static.html'))) !== 'file'
+    ) {
+      throw new Error(
+        'Publish artifact does not contain static.html; the static surface needs a newer artifact version.',
+      );
+    }
+    const entryHtmlCache = new Map();
+    const readEntryHtml = async (name) => {
+      if (!entryHtmlCache.has(name)) {
+        entryHtmlCache.set(name, await readFile(path.join(extractedArtifactDirPath, name), 'utf8'));
+      }
+      return entryHtmlCache.get(name);
+    };
+
     const useSharedRuntime = targets.length > 1;
     let sharedRuntimeDirPath = null;
-    let baseIndexHtml = null;
 
     if (useSharedRuntime) {
       sharedRuntimeDirPath = path.join(
@@ -603,12 +715,12 @@ export async function runDeployConfigure(
       await mkdir(path.dirname(sharedRuntimeDirPath), { recursive: true });
       await copyDirectoryContents(extractedArtifactDirPath, sharedRuntimeDirPath);
       await writeOwnershipMarker(sharedRuntimeDirPath, args.artifactVersion, now);
-
-      baseIndexHtml = await readFile(path.join(extractedArtifactDirPath, 'index.html'), 'utf8');
     }
 
     const assembled = [];
     for (const target of targets) {
+      const isStatic = target.surface === 'static';
+      const entryHtmlName = isStatic ? 'static.html' : 'index.html';
       const mountDirPath = resolveMountDirectory(outputDirPath, target.mountPath);
       const { replaceExisting } = await assertMountDirectoryCanBeReplaced(mountDirPath);
       if (replaceExisting) {
@@ -619,20 +731,33 @@ export async function runDeployConfigure(
 
       let assetBase;
       if (useSharedRuntime) {
-        // Thin mount: a rewritten index.html pointing at the shared runtime,
-        // plus its own project payload, boot config, and ownership marker.
+        // Thin mount: the entry page rewritten to point at the shared runtime,
+        // plus its own payload, boot config, and ownership marker.
         assetBase = `${toPosixPath(path.relative(mountDirPath, sharedRuntimeDirPath))}/`;
         await writeFile(
           path.join(mountDirPath, 'index.html'),
-          rewriteThinIndexHtml(baseIndexHtml, assetBase),
+          rewriteThinIndexHtml(await readEntryHtml(entryHtmlName), assetBase),
           'utf8',
         );
       } else {
         await copyDirectoryContents(extractedArtifactDirPath, mountDirPath);
+        if (isStatic) {
+          // Serve the static viewer as the mount's index page.
+          await cp(
+            path.join(extractedArtifactDirPath, 'static.html'),
+            path.join(mountDirPath, 'index.html'),
+          );
+        }
       }
 
-      const modelPath = await populateProjectPayload(mountDirPath, target);
-      const bootConfig = buildBootConfig(target, modelPath, assetBase);
+      let bootConfig;
+      if (isStatic) {
+        const { geometry, poster } = await populateGeometryPayload(mountDirPath, target);
+        bootConfig = buildStaticBootConfig(target, geometry, poster, assetBase);
+      } else {
+        const modelPath = await populateProjectPayload(mountDirPath, target);
+        bootConfig = buildBootConfig(target, modelPath, assetBase);
+      }
       await writeFile(
         path.join(mountDirPath, 'openscad-web.config.json'),
         `${JSON.stringify(bootConfig, null, 2)}\n`,

--- a/scripts/render-geometry.mjs
+++ b/scripts/render-geometry.mjs
@@ -1,0 +1,122 @@
+#!/usr/bin/env node
+
+// Pre-render an OpenSCAD model to the artifacts the `static` publish surface
+// consumes: an OFF geometry file (what the read-only viewer displays) and,
+// optionally, a PNG poster. Both come straight from the OpenSCAD CLI — no WASM,
+// no browser, no GLB. Run this in CI before `deploy-configure --surface static`.
+//
+// Usage:
+//   node scripts/render-geometry.mjs --source ./models/widget.scad --out-dir ./rendered
+//   node scripts/render-geometry.mjs --source ./m.scad --out-dir ./out --name widget --no-poster
+//   node scripts/render-geometry.mjs --source ./m.scad --out-dir ./out --imgsize 1200,900 --colorscheme Tomorrow
+//
+// Emits JSON: { "off": "<path>", "poster": "<path>|null" }.
+
+import { execFile } from 'node:child_process';
+import { mkdir } from 'node:fs/promises';
+import path from 'node:path';
+import { promisify } from 'node:util';
+import { fileURLToPath } from 'node:url';
+
+const execFileAsync = promisify(execFile);
+
+export const DEFAULT_POSTER_SIZE = [1000, 750];
+
+/** OpenSCAD CLI args to export OFF geometry from an entry `.scad`. */
+export function buildOffArgs(entryPath, offPath) {
+  return [entryPath, '-o', offPath];
+}
+
+/** OpenSCAD CLI args to render a PNG poster (full CGAL render, framed to bounds). */
+export function buildPosterArgs(
+  entryPath,
+  pngPath,
+  { imgsize = DEFAULT_POSTER_SIZE, colorscheme } = {},
+) {
+  const args = [
+    entryPath,
+    '-o',
+    pngPath,
+    `--imgsize=${imgsize[0]},${imgsize[1]}`,
+    '--viewall',
+    '--autocenter',
+    '--render',
+  ];
+  if (typeof colorscheme === 'string' && colorscheme !== '') {
+    args.push(`--colorscheme=${colorscheme}`);
+  }
+  return args;
+}
+
+/**
+ * Render `entryPath` to `<outDir>/<name>.off` (+ `<name>.png` unless
+ * `poster: false`) using the OpenSCAD CLI. Returns the produced paths.
+ */
+export async function renderGeometry({
+  entryPath,
+  outDir,
+  name,
+  openscad = process.env.OPENSCAD ?? 'openscad',
+  poster = true,
+  imgsize,
+  colorscheme,
+  runner = execFileAsync,
+}) {
+  const modelName = name ?? path.basename(entryPath, path.extname(entryPath));
+  await mkdir(outDir, { recursive: true });
+
+  const offPath = path.join(outDir, `${modelName}.off`);
+  await runner(openscad, buildOffArgs(entryPath, offPath));
+
+  let posterPath = null;
+  if (poster) {
+    posterPath = path.join(outDir, `${modelName}.png`);
+    await runner(openscad, buildPosterArgs(entryPath, posterPath, { imgsize, colorscheme }));
+  }
+
+  return { off: offPath, poster: posterPath };
+}
+
+function parseArgs(argv) {
+  const args = {};
+  for (let i = 0; i < argv.length; i += 1) {
+    const flag = argv[i];
+    if (flag === '--no-poster') {
+      args.poster = false;
+      continue;
+    }
+    if (!flag.startsWith('--')) throw new Error(`Unexpected argument: ${flag}`);
+    const value = argv[i + 1];
+    if (value == null || value.startsWith('--')) throw new Error(`Missing value for ${flag}`);
+    args[flag.slice(2)] = value;
+    i += 1;
+  }
+  return args;
+}
+
+const isMainModule =
+  process.argv[1] != null && path.resolve(process.argv[1]) === fileURLToPath(import.meta.url);
+
+if (isMainModule) {
+  try {
+    const args = parseArgs(process.argv.slice(2));
+    const entryPath =
+      args.source ??
+      (args['project-root'] && args.entry ? path.join(args['project-root'], args.entry) : null);
+    if (entryPath == null) throw new Error('Provide --source, or --project-root and --entry.');
+    if (args['out-dir'] == null) throw new Error('--out-dir is required.');
+
+    const result = await renderGeometry({
+      entryPath,
+      outDir: args['out-dir'],
+      name: args.name,
+      poster: args.poster !== false,
+      imgsize: args.imgsize ? args.imgsize.split(',').map(Number) : undefined,
+      colorscheme: args.colorscheme,
+    });
+    process.stdout.write(`${JSON.stringify(result)}\n`);
+  } catch (error) {
+    process.stderr.write(`${error instanceof Error ? error.message : String(error)}\n`);
+    process.exitCode = 1;
+  }
+}

--- a/scripts/verify-publish-archive.mjs
+++ b/scripts/verify-publish-archive.mjs
@@ -40,6 +40,8 @@ async function main() {
 
   assertArchiveHas(entrySet, 'index.html');
   assertArchiveHas(entrySet, 'viewer.html');
+  // The `static` publish surface hard-requires static.html from the artifact.
+  assertArchiveHas(entrySet, 'static.html');
   assertArchiveHasPrefix(entryNames, 'assets/');
   assertArchiveHasPrefix(entryNames, 'libraries/');
 

--- a/scripts/verify-viewer-bundle.mjs
+++ b/scripts/verify-viewer-bundle.mjs
@@ -7,10 +7,19 @@
 import { readFile } from 'node:fs/promises';
 import path from 'node:path';
 
-function distRoot() {
-  const i = process.argv.indexOf('--dir');
-  return path.resolve(i === -1 ? 'dist' : (process.argv[i + 1] ?? 'dist'));
+function argValue(flag, fallback) {
+  const i = process.argv.indexOf(flag);
+  return i === -1 ? fallback : (process.argv[i + 1] ?? fallback);
 }
+
+function distRoot() {
+  return path.resolve(argValue('--dir', 'dist'));
+}
+
+// Which HTML entry to gate: the postMessage viewer (`viewer.html`, default) or
+// the self-loading static geometry viewer (`static.html`). Both must stay free
+// of the editor/compiler stack.
+const entryHtmlName = argValue('--entry', 'viewer.html');
 
 function basename(p) {
   return p.split('/').pop();
@@ -24,11 +33,11 @@ function fail(message) {
 const dist = distRoot();
 const assetsDir = path.join(dist, 'assets');
 
-const viewerHtml = await readFile(path.join(dist, 'viewer.html'), 'utf8').catch(() => {
-  fail(`viewer.html not found under ${dist}`);
+const entryHtml = await readFile(path.join(dist, entryHtmlName), 'utf8').catch(() => {
+  fail(`${entryHtmlName} not found under ${dist}`);
 });
-const entryMatch = viewerHtml.match(/<script[^>]*\btype="module"[^>]*\bsrc="([^"]+)"/);
-if (!entryMatch) fail('viewer.html has no module entry script');
+const entryMatch = entryHtml.match(/<script[^>]*\btype="module"[^>]*\bsrc="([^"]+)"/);
+if (!entryMatch) fail(`${entryHtmlName} has no module entry script`);
 const entryFile = basename(entryMatch[1]);
 
 // BFS the reachable chunk graph. The reference regex captures any quoted `*.js`

--- a/src/runtime/__tests__/boot-config.test.ts
+++ b/src/runtime/__tests__/boot-config.test.ts
@@ -69,6 +69,8 @@ describe('loadBootConfig', () => {
             parentOrigin: 'https://store.example.com',
             title: 'Configured Project',
             assetBase: '../_openscad-web/v0.4.0/',
+            geometry: './geometry.off',
+            poster: './poster.png',
             unknown: 'ignored',
           }),
           {
@@ -91,6 +93,8 @@ describe('loadBootConfig', () => {
       parentOrigin: 'https://store.example.com',
       title: 'Configured Project',
       assetBase: '../_openscad-web/v0.4.0/',
+      geometry: './geometry.off',
+      poster: './poster.png',
     });
   });
 

--- a/src/runtime/boot-config.ts
+++ b/src/runtime/boot-config.ts
@@ -12,6 +12,17 @@ export interface BootConfig {
    * self-contained mount, where assets resolve relative to the document.
    */
   assetBase?: string;
+  /**
+   * URL (relative to this document) of a pre-rendered OFF geometry file, for the
+   * `static` surface — the standalone geometry viewer fetches and displays it
+   * with no in-browser compile.
+   */
+  geometry?: string;
+  /**
+   * URL (relative to this document) of a pre-rendered PNG poster for the
+   * `static` surface, shown before the geometry loads / as a social preview.
+   */
+  poster?: string;
 }
 
 export const BOOT_CONFIG_TIMEOUT_MS = 2_000;
@@ -34,6 +45,8 @@ function normalizeBootConfig(value: unknown): BootConfig {
   if (typeof value.parentOrigin === 'string') config.parentOrigin = value.parentOrigin;
   if (typeof value.title === 'string') config.title = value.title;
   if (typeof value.assetBase === 'string') config.assetBase = value.assetBase;
+  if (typeof value.geometry === 'string') config.geometry = value.geometry;
+  if (typeof value.poster === 'string') config.poster = value.poster;
 
   return config;
 }

--- a/src/static-entry/index.ts
+++ b/src/static-entry/index.ts
@@ -1,0 +1,54 @@
+// Static geometry entry: a standalone, read-only <osc-geometry-viewer> that
+// fetches a PRE-RENDERED OFF file named in the boot config and displays it —
+// no host transport, no compiler, no WASM. This powers the `static` publish
+// surface: a docs page embeds it to show a model with no in-browser render.
+//
+// Like viewer-entry it deliberately pulls in NOTHING from the app shell — no
+// Model, BrowserFS, OpenSCAD WASM, Monaco, or service worker — so it stays
+// small; scripts/verify-viewer-bundle.mjs enforces that exclusion.
+
+import '../components/elements/osc-geometry-viewer.ts';
+import type { GeometryViewer } from '../viewer-host/controller.ts';
+import { loadBootConfig } from '../runtime/boot-config.ts';
+
+function showMessage(root: HTMLElement, text: string): void {
+  const message = document.createElement('div');
+  message.style.cssText =
+    'padding:1rem;font-family:system-ui,sans-serif;color:#d2dbc5;font-size:0.9rem;';
+  message.textContent = text;
+  root.replaceChildren(message);
+}
+
+window.addEventListener('load', async () => {
+  const root = document.getElementById('viewer-root')!;
+  const config = await loadBootConfig();
+
+  if (typeof config.title === 'string' && config.title.trim() !== '') {
+    document.title = config.title;
+  }
+
+  if (typeof config.geometry !== 'string' || config.geometry.trim() === '') {
+    showMessage(root, 'No geometry configured for this model.');
+    return;
+  }
+
+  const viewer = document.createElement('osc-geometry-viewer') as GeometryViewer;
+  // Display-only: no preview-thumbnail hashing (needs a GL readback we don't use).
+  viewer.generateThumbnails = false;
+  root.replaceChildren(viewer);
+
+  const geometryUrl = new URL(config.geometry, document.baseURI).toString();
+  try {
+    const response = await fetch(geometryUrl, { cache: 'no-store' });
+    if (!response.ok) {
+      showMessage(root, `Failed to load geometry (HTTP ${response.status}).`);
+      return;
+    }
+    viewer.offText = await response.text();
+  } catch (error) {
+    showMessage(
+      root,
+      `Failed to load geometry: ${error instanceof Error ? error.message : String(error)}`,
+    );
+  }
+});

--- a/src/static-entry/index.ts
+++ b/src/static-entry/index.ts
@@ -35,6 +35,15 @@ window.addEventListener('load', async () => {
   const viewer = document.createElement('osc-geometry-viewer') as GeometryViewer;
   // Display-only: no preview-thumbnail hashing (needs a GL readback we don't use).
   viewer.generateThumbnails = false;
+  // A parse/render failure of the geometry surfaces as a `viewer-error` event
+  // rather than rejecting the fetch — show it instead of a blank viewport.
+  viewer.addEventListener('viewer-error', (event) => {
+    const detail = (event as CustomEvent).detail;
+    showMessage(
+      root,
+      `Failed to render geometry: ${detail instanceof Error ? detail.message : String(detail)}`,
+    );
+  });
   root.replaceChildren(viewer);
 
   const geometryUrl = new URL(config.geometry, document.baseURI).toString();

--- a/static.html
+++ b/static.html
@@ -1,0 +1,30 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>OpenSCAD model</title>
+    <meta
+      name="description"
+      content="Standalone read-only OpenSCAD model view: a pre-rendered geometry displayed with no editor, filesystem, or compiler."
+    />
+    <style>
+      html,
+      body {
+        margin: 0;
+        height: 100%;
+        background: var(--osc-viewer-bg, #1e1e1e);
+      }
+      #viewer-root,
+      osc-geometry-viewer {
+        display: block;
+        width: 100%;
+        height: 100vh;
+      }
+    </style>
+  </head>
+  <body>
+    <div id="viewer-root"></div>
+    <script type="module" src="/src/static-entry/index.ts"></script>
+  </body>
+</html>

--- a/vite.shared.ts
+++ b/vite.shared.ts
@@ -24,14 +24,15 @@ export function getPackageHomepagePath(): string {
 export function createAppViteConfig({
   base,
   outDir,
-  entries = ['index.html', 'viewer.html'],
+  entries = ['index.html', 'viewer.html', 'static.html'],
   publicDir = 'public',
 }: {
   base: string;
   outDir: string;
   /**
-   * The HTML entry files to build. Defaults to the full app (`index.html`) + the
-   * standalone viewer (`viewer.html`). The distributable viewer-only build
+   * The HTML entry files to build. Defaults to the full app (`index.html`), the
+   * postMessage-driven standalone viewer (`viewer.html`), and the self-loading
+   * static geometry viewer (`static.html`). The distributable viewer-only build
    * (`vite.viewer.config.ts`) passes just `['viewer.html']`. Each entry's chunk is
    * keyed by its base name, so `index.html` keeps the `index-*` chunk name the
    * bundle budgets / tooling rely on.


### PR DESCRIPTION
Closes #241. Convergence Phase 3 (P3.1) — the lightweight tier: a docs page can show a model with **no in-browser WASM compile**.

## What
A new `static` publish surface that ships a **pre-rendered** model to a read-only viewer (~0.6 MB: viewer + three + off-loader, **no WASM/Monaco**).

- **`static.html` + `src/static-entry/`** — a self-loading viewer: reads its boot config, `fetch`es a pre-rendered OFF, sets `osc-geometry-viewer.offText`. No host transport, no compiler. Rides in the app/publish build; gated WASM-free by `verify-viewer-bundle --entry static.html`.
- **`scripts/render-geometry.mjs`** — OpenSCAD **CLI** wrapper → `.off` (+ optional `.png` poster). OFF is exactly what the viewer consumes, so no GLB conversion. Consumers run this before publishing.
- **`deploy-configure` `static` surface** — takes pre-rendered `geometry`/`poster` (not a `.scad`), serves `static.html` as the mount index, writes a `{mode:static, geometry, poster}` config. Works self-contained (1 target) or thin against the shared runtime (#240, multi-target). The assembler stays **pure-Node** — rendering is upstream (your CI `apt-get install -y openscad`).

## Design decision
Render location = **consumer CI**, not the Action/assembler — keeps `deploy-configure` dependency-free and the OpenSCAD version in the consumer's control. `render-geometry.mjs` is the turnkey helper.

## Verification (local, real artifact)
- `render-geometry.mjs` → `widget.off` (41 KB, valid OFF) + `widget.png` (1000×750) from a `.scad`.
- Static surface assembled from the **real** rebuilt artifact; browser boot-trace of the mount shows `GET config → geometry.off` with **zero WASM requests** — it renders with no compiler.
- Build: `static.html` (1.26 KB) + `static.js` (0.95 KB); **both** viewer-bundle gates pass (viewer + static, WASM/Monaco/BrowserFS-free).
- 43 assembly tests (5 new: static fat, static thin+shared-runtime, no-geometry reject, source-on-static reject) + render-geometry arg/runner tests + boot-config geometry/poster; 683 unit tests; tsc/eslint/prettier clean.

## Follow-up
Same as #240: the sandbox can't run localhost pages in a real browser, so the render is proven by the network boot-trace; a **publish-e2e browser scenario for the static surface** belongs with #244. Next: the template's static-default include (#7) consumes this.

Builds on shared runtime (#240).