### PR TITLE
test(publish): browser e2e for assembled shared-runtime + static mounts (#244)

### DIFF
--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -4,12 +4,15 @@ const serverMode = process.env.E2E_SERVER_MODE ?? 'prod';
 const isDevelopmentServer = serverMode === 'dev';
 const isPublishRootServer = serverMode === 'publish-root';
 const isPublishSubpathServer = serverMode === 'publish-subpath';
+// Assembled publish surfaces (deploy-configure): a multi-target site with a
+// shared runtime + a static mount, served at root. See publish-assembled.spec.ts.
+const isPublishAssembledServer = serverMode === 'publish-assembled';
 // The compile-capable distributable (#193): dist-session served at root (base
 // './'), so session.html sits at http://localhost:3000/session.html.
 const isSessionServer = serverMode === 'session';
 const appUrl = isDevelopmentServer
   ? 'http://localhost:4000/'
-  : isPublishRootServer || isSessionServer
+  : isPublishRootServer || isSessionServer || isPublishAssembledServer
     ? 'http://localhost:3000/'
     : isPublishSubpathServer
       ? 'http://localhost:3000/openscad-web/'
@@ -18,13 +21,15 @@ const webServerCommand = isDevelopmentServer
   ? 'npm run start:development'
   : isSessionServer
     ? 'npm run serve:session'
-    : isPublishRootServer || isPublishSubpathServer
+    : isPublishRootServer || isPublishSubpathServer || isPublishAssembledServer
       ? 'node ./scripts/serve-publish-e2e.mjs'
       : 'npm run start:production';
 
 export default defineConfig({
   testDir: './tests',
-  testMatch: /.*\.spec\.ts$/,
+  // The assembled-surfaces server hosts mounts, not viewer.html/index.html, so
+  // only its own spec runs in that mode; the rest run everywhere else.
+  testMatch: isPublishAssembledServer ? /publish-assembled\.spec\.ts$/ : /.*\.spec\.ts$/,
   timeout: 90_000,
   fullyParallel: false,
   forbidOnly: process.env.CI === 'true',
@@ -84,6 +89,7 @@ export default defineConfig({
       process.env.CI !== 'true' &&
       !isPublishRootServer &&
       !isPublishSubpathServer &&
+      !isPublishAssembledServer &&
       !isSessionServer,
   },
 });

--- a/scripts/run-publish-e2e.mjs
+++ b/scripts/run-publish-e2e.mjs
@@ -38,6 +38,7 @@ async function main() {
 
   await runCommand(resolveCommand('npx'), playwrightArgs, { E2E_SERVER_MODE: 'publish-root' });
   await runCommand(resolveCommand('npx'), playwrightArgs, { E2E_SERVER_MODE: 'publish-subpath' });
+  await runCommand(resolveCommand('npx'), playwrightArgs, { E2E_SERVER_MODE: 'publish-assembled' });
 }
 
 await main();

--- a/scripts/serve-publish-e2e.mjs
+++ b/scripts/serve-publish-e2e.mjs
@@ -1,22 +1,89 @@
 #!/usr/bin/env node
 
 import path from 'node:path';
-import { cp, mkdir, readdir, rm } from 'node:fs/promises';
+import { cp, mkdir, readdir, rm, writeFile } from 'node:fs/promises';
 import { spawn } from 'node:child_process';
 import { fileURLToPath } from 'node:url';
 
 const repoRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..');
 const publishDirPath = path.join(repoRoot, 'dist-publish');
+const publishArchivePath = path.join(repoRoot, 'openscad-web-publish.zip');
+const deployConfigureScriptPath = path.join(repoRoot, 'scripts', 'deploy-configure.mjs');
 const fixtureRootDirPath = path.join(repoRoot, '.publish-e2e');
 const serveBinPath = path.join(repoRoot, 'node_modules', 'serve', 'build', 'main.js');
 
+// A valid single-line-header OFF (a tetrahedron) for the static target.
+const FIXTURE_OFF = [
+  'OFF 4 4 0',
+  '0 0 0',
+  '1 0 0',
+  '0 1 0',
+  '0 0 1',
+  '3 0 1 2',
+  '3 0 1 3',
+  '3 0 2 3',
+  '3 1 2 3',
+  '',
+].join('\n');
+
 function getFixtureMode() {
   const mode = process.env.E2E_SERVER_MODE;
-  if (mode === 'publish-root' || mode === 'publish-subpath') {
+  if (mode === 'publish-root' || mode === 'publish-subpath' || mode === 'publish-assembled') {
     return mode;
   }
 
   throw new Error(`Unsupported E2E_SERVER_MODE for publish fixture server: ${mode ?? '<unset>'}`);
+}
+
+function runNode(args) {
+  return new Promise((resolve, reject) => {
+    const child = spawn(process.execPath, args, { cwd: repoRoot, stdio: 'inherit' });
+    child.on('exit', (code) =>
+      code === 0 ? resolve() : reject(new Error(`node ${args.join(' ')} failed (${code})`)),
+    );
+    child.on('error', reject);
+  });
+}
+
+// Assemble a real multi-target site with deploy-configure: two compile surfaces
+// (which share one runtime) plus a static surface. Exercises the shared-runtime
+// thin mounts (#240) and the self-contained static mount (#241) in a browser.
+async function prepareAssembledFixture() {
+  const fixtureDirPath = path.join(fixtureRootDirPath, 'publish-assembled');
+  await rm(fixtureDirPath, { recursive: true, force: true });
+
+  const inputDirPath = path.join(fixtureDirPath, 'input');
+  const serveDirPath = path.join(fixtureDirPath, 'site');
+  await mkdir(inputDirPath, { recursive: true });
+
+  await writeFile(path.join(inputDirPath, 'model.scad'), 'cube(10);\n');
+  await writeFile(path.join(inputDirPath, 'model.off'), FIXTURE_OFF);
+  await writeFile(
+    path.join(inputDirPath, 'openscad-publish.yml'),
+    `site:
+  outDir: ${serveDirPath}
+targets:
+  - source: ./model.scad
+    surface: viewer
+    mountPath: /viewer/
+  - source: ./model.scad
+    surface: customizer
+    mountPath: /customizer/
+  - surface: static
+    geometry: ./model.off
+    mountPath: /static/
+`,
+  );
+
+  await runNode([
+    deployConfigureScriptPath,
+    '--config',
+    path.join(inputDirPath, 'openscad-publish.yml'),
+    '--artifact-path',
+    publishArchivePath,
+  ]);
+
+  return serveDirPath;
 }
 
 async function prepareFixtureRoot(mode) {
@@ -48,7 +115,8 @@ async function prepareFixtureRoot(mode) {
 
 async function main() {
   const mode = getFixtureMode();
-  const fixtureServeDirPath = await prepareFixtureRoot(mode);
+  const fixtureServeDirPath =
+    mode === 'publish-assembled' ? await prepareAssembledFixture() : await prepareFixtureRoot(mode);
 
   console.log(`[serve-publish-e2e] Serving ${fixtureServeDirPath} for ${mode}`);
 

--- a/tests/publish-assembled.spec.ts
+++ b/tests/publish-assembled.spec.ts
@@ -1,0 +1,65 @@
+import { expect, test } from '@playwright/test';
+
+// Browser coverage for the ASSEMBLED publish surfaces (deploy-configure), not
+// the raw dist-publish. Runs only under E2E_SERVER_MODE=publish-assembled, where
+// scripts/serve-publish-e2e.mjs assembles a multi-target site — two compile
+// surfaces that share one runtime (#240) plus a self-contained static surface
+// (#241) — and serves it at http://localhost:3000/.
+//
+// osc-geometry-viewer sets data-geometry-loaded="true" on its container once the
+// mesh is in the scene; CI Chromium has working WebGL (see viewer.spec), so that
+// DOM signal is a reliable "it rendered" assertion. Playwright's selector engine
+// pierces the component's open shadow root.
+
+const assembled = process.env.E2E_SERVER_MODE === 'publish-assembled';
+const baseUrl = new URL('http://localhost:3000/');
+
+test('a shared-runtime compile mount fetches libraries from the shared runtime and renders (#240)', async ({
+  page,
+}) => {
+  test.skip(!assembled, 'requires E2E_SERVER_MODE=publish-assembled');
+
+  const responses: { url: string; status: number }[] = [];
+  page.on('response', (response) =>
+    responses.push({ url: response.url(), status: response.status() }),
+  );
+
+  await page.goto(new URL('viewer/', baseUrl).toString());
+
+  // A thin compile mount has no libraries/ of its own: the compile renders only
+  // if the worker resolved libraries/fonts.zip against the shared runtime. If it
+  // had resolved against the mount (the #240 blocker), the fetch would 404 and
+  // the geometry would never load.
+  await page.waitForSelector('[data-geometry-loaded="true"]', { timeout: 90_000 });
+
+  // The worker resolves libraries against the SHARED runtime and its fetch of
+  // fonts.zip (done at FS init on every compile) succeeds there. If it had
+  // resolved against the thin mount instead (the #240 blocker), FS init would
+  // have thrown and the geometry above would never have loaded.
+  //
+  // (A separate, harmless main-thread prefetch hint still points a `<link
+  // rel=prefetch>` at the mount path and 404s; that is non-fatal and not what
+  // this test guards.)
+  const sharedFonts = responses.find(
+    (response) =>
+      response.url.includes('/_openscad-web/') && response.url.includes('/libraries/fonts.zip'),
+  );
+  expect(sharedFonts, 'the worker fetched fonts.zip from the shared runtime').toBeTruthy();
+  expect(sharedFonts!.status).toBe(200);
+});
+
+test('a static mount renders the pre-rendered geometry with no WASM (#241)', async ({ page }) => {
+  test.skip(!assembled, 'requires E2E_SERVER_MODE=publish-assembled');
+
+  const requestedUrls: string[] = [];
+  page.on('request', (request) => requestedUrls.push(request.url()));
+
+  await page.goto(new URL('static/', baseUrl).toString());
+
+  await page.waitForSelector('[data-geometry-loaded="true"]', { timeout: 30_000 });
+
+  expect(
+    requestedUrls.filter((url) => url.endsWith('.wasm')),
+    'the static mount loads no OpenSCAD WASM',
+  ).toEqual([]);
+});


### PR DESCRIPTION
Closes #244 — the follow-up from #240/#241: a real browser test of the **assembled** publish surfaces (the existing publish-e2e only serves raw `dist-publish`).

## What
A new `publish-assembled` e2e mode. `serve-publish-e2e.mjs` assembles a real multi-target site with `deploy-configure` — two compile surfaces (which **share one runtime**, #240) + a **static** surface (#241) — and a spec loads the mounts in Chromium.

- **Compile mount (#240 guard):** renders only if the worker resolved `libraries/fonts.zip` against the **shared runtime** (fetched at FS init on every compile). A mount-relative resolution — the original blocker — would 404 and the geometry would never load. Asserts the shared-runtime fonts fetch is 200 *and* the viewer reaches `data-geometry-loaded`.
- **Static mount (#241 guard):** reaches `data-geometry-loaded` with **zero** `.wasm` requests.

GL-tolerant: uses the `osc-geometry-viewer` `data-geometry-loaded` DOM signal (CI Chromium has working WebGL, per `viewer.spec`) + network assertions — the exact regressions layout tests can't catch.

## Verified locally
Both tests pass in real Playwright Chromium (fixture assembles: shared runtime at `_openscad-web/unknown/`, thin compile mounts + self-contained static mount, all 200). The test also surfaced the known non-fatal main-thread prefetch-404 (documented inline; not what it guards).

Wired into `run-publish-e2e.mjs` as a third mode; `playwright.config.ts` restricts that mode to this spec.