### PR TITLE
fix(bootstrap): asset-base meta for early, correct thin-mount prefetch (#248)

### DIFF
--- a/scripts/__tests__/deploy-configure.test.mjs
+++ b/scripts/__tests__/deploy-configure.test.mjs
@@ -479,6 +479,10 @@ targets:
     expect(oneIndex).toContain('src="../_openscad-web/v0.4.0/assets/app.js"');
     expect(oneIndex).toContain('href="../_openscad-web/v0.4.0/favicon.ico"');
     expect(oneIndex).not.toContain('="./');
+    // A synchronous asset-base hint for the early (module-eval) library prefetch.
+    expect(oneIndex).toContain(
+      '<meta name="openscad-asset-base" content="../_openscad-web/v0.4.0/" />',
+    );
 
     await expect(
       readJson(path.join(cwd, 'site', 'one', 'openscad-web.config.json')),

--- a/scripts/deploy-configure.mjs
+++ b/scripts/deploy-configure.mjs
@@ -620,9 +620,14 @@ function sharedRuntimeVersionSegment(artifactVersion) {
 // Rewrite the runtime artifact's index.html so its `./`-relative asset refs
 // (entry script/CSS, modulepreload, icons, audio) point at the shared runtime.
 // The app's dynamic chunks, worker, and WASM then chain off the entry script's
-// location; runtime-fetched libraries follow `assetBase` in the boot config.
+// location. A `<meta>` carries the runtime base synchronously so the app's early
+// (module-eval) library prefetch resolves against the shared runtime, not this
+// mount; runtime-fetched libraries also follow `assetBase` in the boot config.
 function rewriteThinIndexHtml(indexHtml, relativeRuntimePrefix) {
-  return indexHtml.replaceAll('="./', `="${relativeRuntimePrefix}`);
+  const assetBaseMeta = `<meta name="openscad-asset-base" content="${relativeRuntimePrefix}" />`;
+  return indexHtml
+    .replace('<head>', `<head>\n    ${assetBaseMeta}`)
+    .replaceAll('="./', `="${relativeRuntimePrefix}`);
 }
 
 async function writeOwnershipMarker(targetDirPath, artifactVersion, now) {

--- a/src/fs/library-delivery.ts
+++ b/src/fs/library-delivery.ts
@@ -11,34 +11,16 @@ export function getPrefetchedArchives(archives: ZipArchive[] = zipArchives): Zip
   return archives.filter((archive) => archive.prefetch === true);
 }
 
-// Absolute runtime-chunk URLs (worker + WASM). These come from Vite `?url`
-// imports, so they are correct the moment the module evaluates and can be
-// prefetched immediately.
-export function getRuntimeBootstrapPrefetchSpecifiers(
-  workerSpecifier?: string,
-  wasmSpecifier?: string,
-): string[] {
-  return [...(wasmSpecifier ? [wasmSpecifier] : []), ...(workerSpecifier ? [workerSpecifier] : [])];
-}
-
-// Relative library archives (fonts + any prefetch-flagged libraries). These
-// resolve against the runtime asset base, which on a shared-runtime thin mount
-// is only known once the boot config's `assetBase` is applied — so prefetch
-// them after that, or the hint 404s against the mount (which has no libraries/).
-export function getLibraryBootstrapPrefetchSpecifiers(
-  archives: ZipArchive[] = zipArchives,
-): string[] {
-  return [...CORE_PREFETCH_SPECIFIERS, ...getPrefetchedArchives(archives).map((a) => a.zipPath)];
-}
-
 export function getBootstrapPrefetchSpecifiers(
   archives: ZipArchive[] = zipArchives,
   workerSpecifier?: string,
   wasmSpecifier?: string,
 ): string[] {
   return [
-    ...getRuntimeBootstrapPrefetchSpecifiers(workerSpecifier, wasmSpecifier),
-    ...getLibraryBootstrapPrefetchSpecifiers(archives),
+    ...(wasmSpecifier ? [wasmSpecifier] : []),
+    ...CORE_PREFETCH_SPECIFIERS,
+    ...(workerSpecifier ? [workerSpecifier] : []),
+    ...getPrefetchedArchives(archives).map((a) => a.zipPath),
   ];
 }
 

--- a/src/fs/library-delivery.ts
+++ b/src/fs/library-delivery.ts
@@ -11,16 +11,34 @@ export function getPrefetchedArchives(archives: ZipArchive[] = zipArchives): Zip
   return archives.filter((archive) => archive.prefetch === true);
 }
 
+// Absolute runtime-chunk URLs (worker + WASM). These come from Vite `?url`
+// imports, so they are correct the moment the module evaluates and can be
+// prefetched immediately.
+export function getRuntimeBootstrapPrefetchSpecifiers(
+  workerSpecifier?: string,
+  wasmSpecifier?: string,
+): string[] {
+  return [...(wasmSpecifier ? [wasmSpecifier] : []), ...(workerSpecifier ? [workerSpecifier] : [])];
+}
+
+// Relative library archives (fonts + any prefetch-flagged libraries). These
+// resolve against the runtime asset base, which on a shared-runtime thin mount
+// is only known once the boot config's `assetBase` is applied — so prefetch
+// them after that, or the hint 404s against the mount (which has no libraries/).
+export function getLibraryBootstrapPrefetchSpecifiers(
+  archives: ZipArchive[] = zipArchives,
+): string[] {
+  return [...CORE_PREFETCH_SPECIFIERS, ...getPrefetchedArchives(archives).map((a) => a.zipPath)];
+}
+
 export function getBootstrapPrefetchSpecifiers(
   archives: ZipArchive[] = zipArchives,
   workerSpecifier?: string,
   wasmSpecifier?: string,
 ): string[] {
   return [
-    ...(wasmSpecifier ? [wasmSpecifier] : []),
-    ...CORE_PREFETCH_SPECIFIERS,
-    ...(workerSpecifier ? [workerSpecifier] : []),
-    ...getPrefetchedArchives(archives).map((a) => a.zipPath),
+    ...getRuntimeBootstrapPrefetchSpecifiers(workerSpecifier, wasmSpecifier),
+    ...getLibraryBootstrapPrefetchSpecifiers(archives),
   ];
 }
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -2,7 +2,8 @@
 
 import { createEditorFS } from './fs/filesystem.ts';
 import {
-  getBootstrapPrefetchSpecifiers,
+  getLibraryBootstrapPrefetchSpecifiers,
+  getRuntimeBootstrapPrefetchSpecifiers,
   injectBootstrapPrefetchHints,
   shouldPreloadEditorLibraries,
 } from './fs/library-delivery.ts';
@@ -39,8 +40,12 @@ if (!import.meta.env.PROD) {
   debug.disable();
 }
 
+// The runtime chunks (worker + WASM) are absolute URLs, correct immediately, so
+// prefetch them now. The library archives (fonts) are relative and resolve
+// against the runtime asset base — deferred to after the boot config sets it
+// (below), so a shared-runtime thin mount doesn't 404 the hint against itself.
 injectBootstrapPrefetchHints(
-  getBootstrapPrefetchSpecifiers(undefined, openSCADWorkerUrl, openSCADWasmUrl),
+  getRuntimeBootstrapPrefetchSpecifiers(openSCADWorkerUrl, openSCADWasmUrl),
 );
 
 window.addEventListener('load', async () => {
@@ -59,6 +64,10 @@ window.addEventListener('load', async () => {
     const resolved = new URL(bootConfig.assetBase, document.baseURI).toString();
     setRuntimeAssetBase(resolved.endsWith('/') ? resolved : `${resolved}/`);
   }
+
+  // Now the runtime base is set, prefetch the library archives (fonts) against
+  // it — the shared runtime for a thin mount, or this document otherwise.
+  injectBootstrapPrefetchHints(getLibraryBootstrapPrefetchSpecifiers());
 
   const urlModeResult = parseUrlMode(mergeConfigIntoSearch(window.location.search, bootConfig));
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -2,8 +2,7 @@
 
 import { createEditorFS } from './fs/filesystem.ts';
 import {
-  getLibraryBootstrapPrefetchSpecifiers,
-  getRuntimeBootstrapPrefetchSpecifiers,
+  getBootstrapPrefetchSpecifiers,
   injectBootstrapPrefetchHints,
   shouldPreloadEditorLibraries,
 } from './fs/library-delivery.ts';
@@ -40,12 +39,21 @@ if (!import.meta.env.PROD) {
   debug.disable();
 }
 
-// The runtime chunks (worker + WASM) are absolute URLs, correct immediately, so
-// prefetch them now. The library archives (fonts) are relative and resolve
-// against the runtime asset base — deferred to after the boot config sets it
-// (below), so a shared-runtime thin mount doesn't 404 the hint against itself.
+// A shared-runtime thin mount injects its asset base as a <meta> so the early
+// library prefetch below (and every other runtime-asset fetch) resolves against
+// the shared runtime rather than this mount, which has no libraries/. The boot
+// config carries the same value and re-applies it in the load handler.
+const assetBaseMeta =
+  typeof document === 'object'
+    ? document.querySelector('meta[name="openscad-asset-base"]')?.getAttribute('content')
+    : null;
+if (assetBaseMeta) {
+  const resolved = new URL(assetBaseMeta, document.baseURI).toString();
+  setRuntimeAssetBase(resolved.endsWith('/') ? resolved : `${resolved}/`);
+}
+
 injectBootstrapPrefetchHints(
-  getRuntimeBootstrapPrefetchSpecifiers(openSCADWorkerUrl, openSCADWasmUrl),
+  getBootstrapPrefetchSpecifiers(undefined, openSCADWorkerUrl, openSCADWasmUrl),
 );
 
 window.addEventListener('load', async () => {
@@ -64,10 +72,6 @@ window.addEventListener('load', async () => {
     const resolved = new URL(bootConfig.assetBase, document.baseURI).toString();
     setRuntimeAssetBase(resolved.endsWith('/') ? resolved : `${resolved}/`);
   }
-
-  // Now the runtime base is set, prefetch the library archives (fonts) against
-  // it — the shared runtime for a thin mount, or this document otherwise.
-  injectBootstrapPrefetchHints(getLibraryBootstrapPrefetchSpecifiers());
 
   const urlModeResult = parseUrlMode(mergeConfigIntoSearch(window.location.search, bootConfig));
 

--- a/tests/publish-assembled.spec.ts
+++ b/tests/publish-assembled.spec.ts
@@ -36,16 +36,19 @@ test('a shared-runtime compile mount fetches libraries from the shared runtime a
   // fonts.zip (done at FS init on every compile) succeeds there. If it had
   // resolved against the thin mount instead (the #240 blocker), FS init would
   // have thrown and the geometry above would never have loaded.
-  //
-  // (A separate, harmless main-thread prefetch hint still points a `<link
-  // rel=prefetch>` at the mount path and 404s; that is non-fatal and not what
-  // this test guards.)
   const sharedFonts = responses.find(
     (response) =>
       response.url.includes('/_openscad-web/') && response.url.includes('/libraries/fonts.zip'),
   );
   expect(sharedFonts, 'the worker fetched fonts.zip from the shared runtime').toBeTruthy();
   expect(sharedFonts!.status).toBe(200);
+
+  // No library asset 404s — the main-thread prefetch hint also targets the
+  // shared runtime, not the mount (guards #248).
+  const libraryNotFound = responses.filter(
+    (response) => response.url.includes('/libraries/') && response.status === 404,
+  );
+  expect(libraryNotFound, 'no library asset 404d').toEqual([]);
 });
 
 test('a static mount renders the pre-rendered geometry with no WASM (#241)', async ({ page }) => {


### PR DESCRIPTION
Closes #248 (surfaced by the #244 e2e).

## Problem
On a shared-runtime thin compile mount, the early (module-eval) library prefetch of `libraries/fonts.zip` resolved against the **mount** (before the boot config's `assetBase` applied) and **404'd**. Non-fatal, but a wasteful failed prefetch.

## Approach
A first attempt *deferred* the library prefetch until after `setRuntimeAssetBase` — but that delayed the 4.4 MB fonts.zip prefetch past config load and **regressed cold-boot perf** (`librariesPreloadMillis` ~2×, `appBootstrapMillis` over budget). Reverted.

The fix instead makes the base known **synchronously**: `deploy-configure` injects `<meta name="openscad-asset-base">` into each thin mount's `index.html`, and the app reads it at **module-eval** and applies `setRuntimeAssetBase` **before** the (still-early) prefetch.

- Thin mount: meta present → prefetch resolves against the shared runtime → **no 404**.
- Normal mount: no meta → resolves against the document, exactly as before → **no perf change**.

The boot config still carries `assetBase` (re-applied in the load handler); the meta is purely the synchronous, early hint.

## Verified
- 43 assembly tests (incl. the injected-meta assertion); tsc/eslint/prettier clean.
- `publish-assembled` e2e tightened to assert **no library 404** on the compile mount — passes locally in Chromium (both mounts render).