### PR TITLE
feat(publish): hydrate published project trees into compile surfaces

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,28 @@ release (changelog upkeep and tagging had lapsed between `0.1.0` and `0.2.0`).
 
 ## [Unreleased]
 
+### Added
+
+- **Published project trees boot compile surfaces** (#253): a `projectRoot`
+  target's boot config now carries a `project { entry, files }` list emitted by
+  `deploy-configure`, and the customizer/embed surfaces hydrate every listed
+  file into the compile filesystem (via the existing multi-file `setProject`
+  contract) before compiling — so `use <…>` / `include <…>` between published
+  project files resolve, and binary assets ride along byte-exact. Previously
+  compile surfaces booted from the entry file's text alone, so any sibling
+  reference silently failed (empty geometry, no error) — the live tier
+  effectively supported standalone single-file models only. Malformed or
+  partially unfetchable projects fail the load visibly instead of compiling a
+  partial tree. Additive: single-file `source` targets and explicit `?model=`
+  URLs are unchanged.
+
+### Fixed
+
+- **Compile errors are now visible on published surfaces** (#253): the
+  customizer and embed shells render the compile error inline. Previously the
+  error state existed only in the editor's footer, which published surfaces do
+  not include — a failed compile left an empty viewer with no message.
+
 ## [0.5.1] - 2026-07-28
 
 ### Fixed

--- a/docs/PUBLISHING.md
+++ b/docs/PUBLISHING.md
@@ -124,6 +124,25 @@ Field reference:
 | `targets[].title`        | Optional page title.                                                                       |
 | `targets[].parentOrigin` | Optional embed security setting for trusted iframe parents.                                |
 
+### Multi-File Projects
+
+A `projectRoot` compile target publishes the **whole tree** and boots the
+compiler with it: the boot config carries a `project` file list, the surface
+fetches every file into the compile filesystem before the first compile, and
+`use <…>` / `include <…>` between project files resolve exactly as they do
+locally (relative to the including file). Binary assets (`import()`ed meshes,
+images) ride along byte-exact.
+
+Notes:
+
+- Requires artifact version **>= 0.6** — earlier runtimes boot compile
+  surfaces from the entry file alone, so sibling references silently fail.
+- A dependency outside `projectRoot` is invisible to the publish. Stage
+  external libraries into the tree you publish (e.g. copy the library beside
+  the entry so `include <lib/…>` resolves relative to it).
+- If any project file fails to load, the surface shows an error instead of
+  compiling a partial tree.
+
 ## Static (Pre-Rendered) Surface
 
 The `viewer`/`customizer`/`editor` surfaces run the OpenSCAD **WASM compiler in

--- a/docs/PUBLISHING.md
+++ b/docs/PUBLISHING.md
@@ -136,7 +136,11 @@ images) ride along byte-exact.
 Notes:
 
 - Requires artifact version **>= 0.6** — earlier runtimes boot compile
-  surfaces from the entry file alone, so sibling references silently fail.
+  surfaces from the entry file alone, so sibling references silently fail
+  (`deploy-configure` warns when it can tell the artifact is older).
+- File names must be portable: a name containing `:` or `\` fails the publish
+  (the runtime could not hydrate it). Special-but-legal characters like
+  spaces, `#`, and `%` are fine.
 - A dependency outside `projectRoot` is invisible to the publish. Stage
   external libraries into the tree you publish (e.g. copy the library beside
   the entry so `include <lib/…>` resolves relative to it).

--- a/scripts/__tests__/deploy-configure.test.mjs
+++ b/scripts/__tests__/deploy-configure.test.mjs
@@ -212,6 +212,84 @@ targets:
     expect(config.project).toEqual({ entry: 'main.scad', files: ['main.scad', 'util.scad'] });
   });
 
+  it('fails the publish loudly when a project file name would be dropped by the runtime (#253)', async () => {
+    const cwd = await makeTempDir();
+    const artifactPath = path.join(cwd, 'openscad-web-publish.zip');
+    const logger = { log() {}, warn() {}, error() {} };
+    await createPublishArtifact(artifactPath);
+    await writeTextFile(path.join(cwd, 'proj', 'main.scad'), 'cube(1);');
+    // Legal on Linux, but the runtime's path validator rejects ':' — publishing
+    // it would make the runtime drop the whole project silently at boot.
+    await writeTextFile(path.join(cwd, 'proj', 'part:v2.scad'), 'cube(2);');
+    await writeTextFile(
+      path.join(cwd, 'openscad-publish.yml'),
+      `site:
+  outDir: ./site
+targets:
+  - projectRoot: ./proj
+    entry: ./main.scad
+    mountPath: /model/
+    surface: customizer
+`,
+    );
+
+    await expect(
+      runDeployConfigure(
+        ['--config', './openscad-publish.yml', '--artifact-path', './openscad-web-publish.zip'],
+        { cwd, logger },
+      ),
+    ).rejects.toThrow(/part:v2\.scad/);
+  });
+
+  it('warns when a project target is assembled with a pre-0.6 artifact (#253)', async () => {
+    const cwd = await makeTempDir();
+    const artifactPath = path.join(cwd, 'openscad-web-publish.zip');
+    const warnings = [];
+    const logger = { log() {}, warn: (m) => warnings.push(m), error() {} };
+    await createPublishArtifact(artifactPath);
+    await writeTextFile(path.join(cwd, 'proj', 'main.scad'), 'cube(1);');
+    await writeTextFile(
+      path.join(cwd, 'openscad-publish.yml'),
+      `site:
+  outDir: ./site
+targets:
+  - projectRoot: ./proj
+    entry: ./main.scad
+    mountPath: /model/
+    surface: customizer
+`,
+    );
+
+    await runDeployConfigure(
+      [
+        '--config',
+        './openscad-publish.yml',
+        '--artifact-path',
+        './openscad-web-publish.zip',
+        '--artifact-version',
+        'v0.5.1',
+      ],
+      { cwd, logger },
+    );
+    expect(warnings.some((m) => m.includes('>= 0.6'))).toBe(true);
+
+    // A 0.6+ artifact does not warn.
+    warnings.length = 0;
+    await rm(path.join(cwd, 'site'), { recursive: true, force: true });
+    await runDeployConfigure(
+      [
+        '--config',
+        './openscad-publish.yml',
+        '--artifact-path',
+        './openscad-web-publish.zip',
+        '--artifact-version',
+        'v0.6.0',
+      ],
+      { cwd, logger },
+    );
+    expect(warnings).toEqual([]);
+  });
+
   it('places a root mount directly into the output directory', async () => {
     const cwd = await makeTempDir();
     const artifactPath = path.join(cwd, 'openscad-web-publish.zip');

--- a/scripts/__tests__/deploy-configure.test.mjs
+++ b/scripts/__tests__/deploy-configure.test.mjs
@@ -4,7 +4,7 @@ import AdmZip from 'adm-zip';
 import os from 'node:os';
 import path from 'node:path';
 import { afterEach, describe, expect, it } from 'vitest';
-import { mkdtemp, mkdir, readFile, rm, writeFile } from 'node:fs/promises';
+import { mkdtemp, mkdir, readFile, rm, symlink, writeFile } from 'node:fs/promises';
 
 import {
   DEFAULT_ARTIFACT_VERSION,
@@ -164,6 +164,11 @@ targets:
       download: true,
       title: 'Assembly Configurator',
       parentOrigin: 'https://store.example.com',
+      // #253: the published file list the runtime hydrates the compile FS from.
+      project: {
+        entry: 'main.scad',
+        files: ['main.scad', 'parts/bracket.scad'],
+      },
     });
     await expect(
       readJson(path.join(cwd, 'publish', 'assembled-site', 'assembly', OWNERSHIP_MARKER_FILENAME)),
@@ -171,6 +176,40 @@ targets:
       version: DEFAULT_ARTIFACT_VERSION,
       assembledAt: expect.any(String),
     });
+  });
+
+  it('dereferences symlinked project files so they are published and listed (#253)', async () => {
+    const cwd = await makeTempDir();
+    const artifactPath = path.join(cwd, 'openscad-web-publish.zip');
+    const logger = { log() {}, warn() {}, error() {} };
+    await createPublishArtifact(artifactPath);
+    await writeTextFile(path.join(cwd, 'shared-lib', 'util.scad'), 'module util() { cube(1); }');
+    await writeTextFile(path.join(cwd, 'proj', 'main.scad'), 'use <util.scad>\nutil();');
+    await symlink(path.join(cwd, 'shared-lib', 'util.scad'), path.join(cwd, 'proj', 'util.scad'));
+    await writeTextFile(
+      path.join(cwd, 'openscad-publish.yml'),
+      `site:
+  outDir: ./site
+targets:
+  - projectRoot: ./proj
+    entry: ./main.scad
+    mountPath: /model/
+    surface: customizer
+`,
+    );
+
+    await runDeployConfigure(
+      ['--config', './openscad-publish.yml', '--artifact-path', './openscad-web-publish.zip'],
+      { cwd, logger },
+    );
+
+    // The symlinked file was copied as a regular file (self-contained tree)…
+    await expect(
+      readFile(path.join(cwd, 'site', 'model', 'project', 'util.scad'), 'utf8'),
+    ).resolves.toBe('module util() { cube(1); }');
+    // …and appears in the hydration list, so the runtime fetches it.
+    const config = await readJson(path.join(cwd, 'site', 'model', 'openscad-web.config.json'));
+    expect(config.project).toEqual({ entry: 'main.scad', files: ['main.scad', 'util.scad'] });
   });
 
   it('places a root mount directly into the output directory', async () => {

--- a/scripts/deploy-configure.mjs
+++ b/scripts/deploy-configure.mjs
@@ -462,11 +462,32 @@ async function populateProjectPayload(targetDirPath, target) {
   if (target.sourcePath != null) {
     const sourceFileName = path.basename(target.sourcePath);
     await cp(target.sourcePath, path.join(projectDirPath, sourceFileName));
-    return `./project/${sourceFileName}`;
+    return { modelPath: `./project/${sourceFileName}`, project: null };
   }
 
-  await copyDirectoryContents(target.projectRootPath, projectDirPath);
-  return `./project/${target.entryPath}`;
+  // Dereference symlinks: the published tree must be self-contained regular
+  // files, and the file list below counts only regular files — a symlink
+  // copied verbatim would be published but never hydrated (#253).
+  await copyDirectoryContents(target.projectRootPath, projectDirPath, { dereference: true });
+  // The published file list (#253): the runtime hydrates the compile FS from
+  // it, so use <…>/include <…> between project files resolve. Walked from the
+  // copied tree so it lists exactly what was published.
+  const files = await listFilesRecursive(projectDirPath);
+  return {
+    modelPath: `./project/${target.entryPath}`,
+    project: { entry: target.entryPath, files },
+  };
+}
+
+// Every file under `rootDirPath`, as sorted root-relative POSIX paths.
+async function listFilesRecursive(rootDirPath) {
+  const entries = await readdir(rootDirPath, { recursive: true, withFileTypes: true });
+  return entries
+    .filter((entry) => entry.isFile())
+    .map((entry) =>
+      path.relative(rootDirPath, path.join(entry.parentPath, entry.name)).split(path.sep).join('/'),
+    )
+    .sort();
 }
 
 // Copy a static target's pre-rendered geometry (+ optional poster) into the
@@ -484,13 +505,14 @@ async function populateGeometryPayload(targetDirPath, target) {
   return { geometry: './geometry.off', poster: posterUrl };
 }
 
-async function copyDirectoryContents(sourceDirPath, targetDirPath) {
+async function copyDirectoryContents(sourceDirPath, targetDirPath, { dereference = false } = {}) {
   await mkdir(targetDirPath, { recursive: true });
   const entryNames = await readdir(sourceDirPath);
   await Promise.all(
     entryNames.map((entryName) =>
       cp(path.join(sourceDirPath, entryName), path.join(targetDirPath, entryName), {
         recursive: true,
+        dereference,
       }),
     ),
   );
@@ -573,7 +595,7 @@ async function assertMountDirectoryCanBeReplaced(mountDirPath) {
   return { replaceExisting: true };
 }
 
-function buildBootConfig(target, modelPath, assetBase) {
+function buildBootConfig(target, modelPath, assetBase, project) {
   const bootConfig = {
     mode: SURFACE_TO_MODE[target.surface],
     model: modelPath,
@@ -585,6 +607,7 @@ function buildBootConfig(target, modelPath, assetBase) {
     bootConfig.title = target.title;
   if (typeof target.parentOrigin === 'string') bootConfig.parentOrigin = target.parentOrigin;
   if (typeof assetBase === 'string') bootConfig.assetBase = assetBase;
+  if (project != null) bootConfig.project = project;
 
   return bootConfig;
 }
@@ -801,8 +824,8 @@ export async function runDeployConfigure(
         } else {
           await copyDirectoryContents(extractedArtifactDirPath, mountDirPath);
         }
-        const modelPath = await populateProjectPayload(mountDirPath, target);
-        bootConfig = buildBootConfig(target, modelPath, assetBase);
+        const { modelPath, project } = await populateProjectPayload(mountDirPath, target);
+        bootConfig = buildBootConfig(target, modelPath, assetBase, project);
       }
       await writeFile(
         path.join(mountDirPath, 'openscad-web.config.json'),

--- a/scripts/deploy-configure.mjs
+++ b/scripts/deploy-configure.mjs
@@ -473,10 +473,44 @@ async function populateProjectPayload(targetDirPath, target) {
   // it, so use <…>/include <…> between project files resolve. Walked from the
   // copied tree so it lists exactly what was published.
   const files = await listFilesRecursive(projectDirPath);
+  assertHydratableProjectFiles(files, target.entryPath, target.projectRootPath);
   return {
     modelPath: `./project/${target.entryPath}`,
     project: { entry: target.entryPath, files },
   };
+}
+
+// The runtime's boot-config validator drops the WHOLE project (falling back to
+// the silent-empty-geometry single-file boot #253 exists to fix) when any
+// listed path violates its rules — so enforce the same rules here, at publish
+// time, where the failure is loud and the fix (rename the file) is obvious.
+// Mirrors isSafeProjectRelativePath in src/runtime/boot-config.ts.
+function assertHydratableProjectFiles(files, entryPath, projectRootPath) {
+  const offending = files.filter((file) => {
+    if (file.includes('\\') || file.includes(':')) return true;
+    return file.split('/').some((segment) => segment === '' || segment === '.' || segment === '..');
+  });
+  if (offending.length > 0) {
+    throw new Error(
+      `Project files under ${projectRootPath} have non-portable names the runtime cannot ` +
+        `hydrate (':' or '\\' in a name): ${offending.join(', ')}. Rename them to publish.`,
+    );
+  }
+  if (!files.includes(entryPath)) {
+    throw new Error(
+      `Entry ${entryPath} is not among the published project files of ${projectRootPath} ` +
+        `(exact case and path must match a real file): found ${files.length} file(s).`,
+    );
+  }
+}
+
+// Whether the artifact runtime understands the boot config `project` field
+// (#253, shipped in 0.6). Unknown versions return false so the caller can warn.
+function artifactSupportsProjectHydration(artifactVersion) {
+  const match = /^v?(\d+)\.(\d+)/.exec(getString(artifactVersion) ?? '');
+  if (!match) return false;
+  const [major, minor] = [Number(match[1]), Number(match[2])];
+  return major > 0 || minor >= 6;
 }
 
 // Every file under `rootDirPath`, as sorted root-relative POSIX paths.
@@ -825,6 +859,14 @@ export async function runDeployConfigure(
           await copyDirectoryContents(extractedArtifactDirPath, mountDirPath);
         }
         const { modelPath, project } = await populateProjectPayload(mountDirPath, target);
+        if (project != null && !artifactSupportsProjectHydration(args.artifactVersion)) {
+          logger.warn(
+            `Warning: multi-file project target ${target.mountPath} needs an artifact ` +
+              `>= 0.6 to hydrate sibling files; this artifact reports version ` +
+              `"${getString(args.artifactVersion) ?? 'unknown'}". An older runtime will ` +
+              `ignore the project field and boot from the entry file alone.`,
+          );
+        }
         bootConfig = buildBootConfig(target, modelPath, assetBase, project);
       }
       await writeFile(

--- a/scripts/serve-publish-e2e.mjs
+++ b/scripts/serve-publish-e2e.mjs
@@ -58,6 +58,18 @@ async function prepareAssembledFixture() {
 
   await writeFile(path.join(inputDirPath, 'model.scad'), 'cube(10);\n');
   await writeFile(path.join(inputDirPath, 'model.off'), FIXTURE_OFF);
+  // A multi-file project (#253): the entry compiles to geometry ONLY if the
+  // sibling file was hydrated into the compile FS — a single-file boot warns
+  // about the unresolved `use` and yields an empty top level.
+  await mkdir(path.join(inputDirPath, 'project', 'lib'), { recursive: true });
+  await writeFile(
+    path.join(inputDirPath, 'project', 'main.scad'),
+    'use <lib/box.scad>\nbox(12);\n',
+  );
+  await writeFile(
+    path.join(inputDirPath, 'project', 'lib', 'box.scad'),
+    'module box(size) { cube(size); }\n',
+  );
   await writeFile(
     path.join(inputDirPath, 'openscad-publish.yml'),
     `site:
@@ -69,6 +81,10 @@ targets:
   - source: ./model.scad
     surface: customizer
     mountPath: /customizer/
+  - projectRoot: ./project
+    entry: ./main.scad
+    surface: customizer
+    mountPath: /assembly/
   - surface: static
     geometry: ./model.off
     mountPath: /static/

--- a/src/components/elements/osc-customizer-shell.ts
+++ b/src/components/elements/osc-customizer-shell.ts
@@ -4,7 +4,7 @@ import { LitElement, html, css } from 'lit';
 import { customElement, property, state } from 'lit/decorators.js';
 import { provideSession } from '../../state/session-context.ts';
 import type { OpenScadSession } from '../../state/session.ts';
-import { UrlModeParams, fetchExternalModel } from '../../state/url-mode.ts';
+import { UrlModeParams, fetchExternalModel, fetchPublishedProject } from '../../state/url-mode.ts';
 import type { State } from '../../state/app-state.ts';
 import type { Model } from '../../state/model.ts';
 import './osc-viewer-panel.ts';
@@ -58,6 +58,14 @@ export class OscCustomizerShell extends LitElement {
       padding: 2rem;
       color: var(--osc-error);
     }
+    .compile-error {
+      padding: 4px 8px;
+      font-size: 0.8em;
+      font-family: monospace;
+      white-space: pre-wrap;
+      color: var(--osc-error);
+      background: var(--osc-overlay-hover);
+    }
   `;
 
   @property({ attribute: false }) urlParams!: UrlModeParams;
@@ -103,17 +111,34 @@ export class OscCustomizerShell extends LitElement {
     }
 
     (async () => {
+      const applyPreVars = () => {
+        const preVars = params.prePopulatedVars;
+        if (Object.keys(preVars).length > 0) {
+          this._model.mutate((s) => {
+            s.params.vars = { ...(s.params.vars ?? {}), ...coerceUrlVars(preVars) };
+          });
+        }
+      };
+
+      // A published multi-file project (#253): hydrate the whole tree so
+      // use <…> / include <…> between project files resolve in the compile FS.
+      if (params.project) {
+        const files = await fetchPublishedProject(params.project);
+        if ('error' in files) {
+          this._loadError = files.error;
+          return;
+        }
+        applyPreVars();
+        this._model.setProject(files, params.project.entry);
+        return;
+      }
+
       const result = await fetchExternalModel(params.modelUrl!);
       if (typeof result === 'object' && 'error' in result) {
         this._loadError = result.error;
         return;
       }
-      const preVars = params.prePopulatedVars;
-      if (Object.keys(preVars).length > 0) {
-        this._model.mutate((s) => {
-          s.params.vars = { ...(s.params.vars ?? {}), ...coerceUrlVars(preVars) };
-        });
-      }
+      applyPreVars();
       this._model.source = result;
     })();
   }
@@ -129,6 +154,12 @@ export class OscCustomizerShell extends LitElement {
         </div>
         <osc-customizer-panel></osc-customizer-panel>
       </div>
+      ${
+        // Published surfaces have no footer/editor chrome, so a failed compile
+        // must surface here — an empty viewer with no message is the silent
+        // failure mode #253 removes.
+        this._st?.error ? html`<div class="compile-error">${this._st.error}</div>` : ''
+      }
       <div class="back-bar">
         <a href=${buildEditorUrl()} target="_blank" rel="noopener noreferrer">View in Editor</a>
       </div>

--- a/src/components/elements/osc-embed-shell.ts
+++ b/src/components/elements/osc-embed-shell.ts
@@ -5,7 +5,7 @@ import { LitElement, html, css } from 'lit';
 import { customElement, property, state } from 'lit/decorators.js';
 import { provideSession } from '../../state/session-context.ts';
 import type { OpenScadSession } from '../../state/session.ts';
-import { UrlModeParams, fetchExternalModel } from '../../state/url-mode.ts';
+import { UrlModeParams, fetchExternalModel, fetchPublishedProject } from '../../state/url-mode.ts';
 import type { State } from '../../state/app-state.ts';
 import type { Model } from '../../state/model.ts';
 import './osc-viewer-panel.ts';
@@ -67,6 +67,14 @@ export class OscEmbedShell extends LitElement {
     .error {
       padding: 2rem;
       color: var(--osc-error);
+    }
+    .compile-error {
+      padding: 4px 8px;
+      font-size: 0.8em;
+      font-family: monospace;
+      white-space: pre-wrap;
+      color: var(--osc-error);
+      background: var(--osc-overlay-hover);
     }
   `;
 
@@ -255,18 +263,36 @@ export class OscEmbedShell extends LitElement {
 
     // Load external model
     (async () => {
+      const applyPreVars = () => {
+        const preVars = params.prePopulatedVars;
+        if (Object.keys(preVars).length > 0) {
+          this._model.mutate((s) => {
+            s.params.vars = { ...(s.params.vars ?? {}), ...coerceUrlVars(preVars) };
+          });
+        }
+      };
+
+      // A published multi-file project (#253): hydrate the whole tree so
+      // use <…> / include <…> between project files resolve in the compile FS.
+      if (params.project) {
+        const files = await fetchPublishedProject(params.project);
+        if ('error' in files) {
+          this._loadError = files.error;
+          this._notifyHost('stateChange', { error: files.error });
+          return;
+        }
+        applyPreVars();
+        this._model.setProject(files, params.project.entry);
+        return;
+      }
+
       const result = await fetchExternalModel(params.modelUrl!);
       if (typeof result === 'object' && 'error' in result) {
         this._loadError = result.error;
         this._notifyHost('stateChange', { error: result.error });
         return;
       }
-      const preVars = params.prePopulatedVars;
-      if (Object.keys(preVars).length > 0) {
-        this._model.mutate((s) => {
-          s.params.vars = { ...(s.params.vars ?? {}), ...coerceUrlVars(preVars) };
-        });
-      }
+      applyPreVars();
       this._model.source = result;
     })();
   }
@@ -280,6 +306,12 @@ export class OscEmbedShell extends LitElement {
       <div class="viewer-wrap">
         <osc-viewer-panel></osc-viewer-panel>
       </div>
+      ${
+        // Published surfaces have no footer/editor chrome, so a failed compile
+        // must surface here — an empty viewer with no message is the silent
+        // failure mode #253 removes.
+        this._st?.error ? html`<div class="compile-error">${this._st.error}</div>` : ''
+      }
       ${
         params?.embedControls
           ? html`<osc-customizer-panel style="max-height:40vh;"></osc-customizer-panel>`

--- a/src/index.ts
+++ b/src/index.ts
@@ -75,6 +75,17 @@ window.addEventListener('load', async () => {
 
   const urlModeResult = parseUrlMode(mergeConfigIntoSearch(window.location.search, bootConfig));
 
+  // A published multi-file project (#253) applies only while the model URL
+  // still points at the project's entry — an explicit `?model=` override took
+  // precedence in the merge above and keeps plain single-file behavior.
+  if (
+    !('error' in urlModeResult) &&
+    bootConfig.project &&
+    urlModeResult.modelUrl === `./project/${bootConfig.project.entry}`
+  ) {
+    urlModeResult.project = bootConfig.project;
+  }
+
   if ('error' in urlModeResult) {
     markPerf('osc:app-bootstrap-error');
     rootEl.replaceChildren();

--- a/src/runtime/__tests__/boot-config.test.ts
+++ b/src/runtime/__tests__/boot-config.test.ts
@@ -103,6 +103,60 @@ describe('loadBootConfig', () => {
   });
 });
 
+describe('loadBootConfig — project field (#253)', () => {
+  const loadWithConfig = (value: unknown) =>
+    loadBootConfig({
+      fetchImpl: (async () =>
+        new Response(JSON.stringify(value), {
+          status: 200,
+          headers: { 'content-type': 'application/json' },
+        })) as typeof fetch,
+      configUrl: 'https://example.com/openscad-web.config.json',
+    });
+
+  it('parses a valid project tree', async () => {
+    await expect(
+      loadWithConfig({
+        mode: 'customizer',
+        model: './project/examples/main.scad',
+        project: {
+          entry: 'examples/main.scad',
+          files: ['examples/main.scad', 'lib.scad', 'parts/bracket.scad'],
+        },
+      }),
+    ).resolves.toEqual({
+      mode: 'customizer',
+      model: './project/examples/main.scad',
+      project: {
+        entry: 'examples/main.scad',
+        files: ['examples/main.scad', 'lib.scad', 'parts/bracket.scad'],
+      },
+    });
+  });
+
+  // Malformed projects are dropped whole rather than partially honored: a
+  // half-hydrated tree would compile against missing files — the silent
+  // failure the field exists to eliminate.
+  it.each([
+    ['entry missing', { files: ['a.scad'] }],
+    ['entry not listed in files', { entry: 'main.scad', files: ['other.scad'] }],
+    ['files empty', { entry: 'main.scad', files: [] }],
+    ['files not an array', { entry: 'main.scad', files: 'main.scad' }],
+    ['duplicate files', { entry: 'a.scad', files: ['a.scad', 'a.scad'] }],
+    ['absolute path', { entry: '/etc/passwd', files: ['/etc/passwd'] }],
+    ['parent traversal', { entry: '../outside.scad', files: ['../outside.scad'] }],
+    ['dot segment', { entry: './main.scad', files: ['./main.scad'] }],
+    ['empty segment', { entry: 'a//b.scad', files: ['a//b.scad'] }],
+    ['backslash separator', { entry: 'a\\b.scad', files: ['a\\b.scad'] }],
+    ['scheme or drive colon', { entry: 'https://x/a.scad', files: ['https://x/a.scad'] }],
+    ['non-string file entry', { entry: 'a.scad', files: ['a.scad', 42] }],
+  ])('drops a malformed project (%s)', async (_label, project) => {
+    await expect(loadWithConfig({ mode: 'customizer', project })).resolves.toEqual({
+      mode: 'customizer',
+    });
+  });
+});
+
 describe('mergeConfigIntoSearch', () => {
   it('projects config values into the search string when the URL search is empty', () => {
     expect(

--- a/src/runtime/boot-config.ts
+++ b/src/runtime/boot-config.ts
@@ -69,13 +69,20 @@ function isSafeProjectRelativePath(value: unknown): value is string {
  * silent failure this field exists to fix.
  */
 function normalizeBootProject(value: unknown): BootProject | undefined {
-  if (!isRecord(value)) return undefined;
+  const dropped = (reason: string) => {
+    // A dropped project falls back to single-file boot, whose sibling
+    // references fail with no other diagnostic — say why, loudly.
+    console.warn(`[openscad-web] boot config "project" ignored (${reason}).`);
+    return undefined;
+  };
+  if (!isRecord(value)) return dropped('not an object');
   const { entry, files } = value;
-  if (!isSafeProjectRelativePath(entry)) return undefined;
-  if (!Array.isArray(files) || files.length === 0) return undefined;
-  if (!files.every(isSafeProjectRelativePath)) return undefined;
+  if (!isSafeProjectRelativePath(entry)) return dropped('invalid entry path');
+  if (!Array.isArray(files) || files.length === 0) return dropped('files missing or empty');
+  if (!files.every(isSafeProjectRelativePath)) return dropped('invalid file path in files');
   const unique = new Set(files);
-  if (unique.size !== files.length || !unique.has(entry)) return undefined;
+  if (unique.size !== files.length) return dropped('duplicate file paths');
+  if (!unique.has(entry)) return dropped('entry not listed in files');
   return { entry, files: [...files] };
 }
 
@@ -96,8 +103,10 @@ function normalizeBootConfig(value: unknown): BootConfig {
   if (typeof value.geometry === 'string') config.geometry = value.geometry;
   if (typeof value.poster === 'string') config.poster = value.poster;
 
-  const project = normalizeBootProject(value.project);
-  if (project) config.project = project;
+  if (value.project != null) {
+    const project = normalizeBootProject(value.project);
+    if (project) config.project = project;
+  }
 
   return config;
 }

--- a/src/runtime/boot-config.ts
+++ b/src/runtime/boot-config.ts
@@ -1,3 +1,18 @@
+/**
+ * A published multi-file project (#253). `deploy-configure` emits this for
+ * compile-surface targets assembled from a `projectRoot`: every published file,
+ * as paths relative to the mount's `project/` directory (POSIX separators).
+ * The runtime fetches each file from `./project/<path>` and boots the compiler
+ * with the whole tree, so `use <…>` / `include <…>` between project files
+ * resolve. Absent for single-file (`source`) targets.
+ */
+export interface BootProject {
+  /** The entry `.scad` file, relative to `project/`. Always listed in `files`. */
+  entry: string;
+  /** Every published project file, relative to `project/` (entry included). */
+  files: string[];
+}
+
 export interface BootConfig {
   model?: string;
   mode?: string;
@@ -5,6 +20,8 @@ export interface BootConfig {
   download?: boolean;
   parentOrigin?: string;
   title?: string;
+  /** The published project tree for a multi-file compile target (#253). */
+  project?: BootProject;
   /**
    * Base for runtime-fetched assets (libraries/fonts), relative to this
    * surface's document. Set when a shared runtime is assembled once and
@@ -31,6 +48,37 @@ function isRecord(value: unknown): value is Record<string, unknown> {
   return value != null && typeof value === 'object' && !Array.isArray(value);
 }
 
+/**
+ * A project-relative path that is safe to resolve under the mount's `project/`
+ * directory: non-empty, relative, forward-slash separated, and unable to
+ * escape (`..`), re-anchor (leading `/`, drive letter, URL scheme), or smuggle
+ * odd segments (empty, `.`). The boot config is same-origin data, but it is
+ * still fetched input — validate before building fetch URLs from it.
+ */
+function isSafeProjectRelativePath(value: unknown): value is string {
+  if (typeof value !== 'string' || value === '') return false;
+  if (value.includes('\\') || value.includes(':') || value.startsWith('/')) return false;
+  const segments = value.split('/');
+  return segments.every((segment) => segment !== '' && segment !== '.' && segment !== '..');
+}
+
+/**
+ * Validate a raw `project` value. Malformed input yields `undefined` (the
+ * surface falls back to single-file boot) rather than a partial project — a
+ * half-hydrated tree would compile against missing files, which is exactly the
+ * silent failure this field exists to fix.
+ */
+function normalizeBootProject(value: unknown): BootProject | undefined {
+  if (!isRecord(value)) return undefined;
+  const { entry, files } = value;
+  if (!isSafeProjectRelativePath(entry)) return undefined;
+  if (!Array.isArray(files) || files.length === 0) return undefined;
+  if (!files.every(isSafeProjectRelativePath)) return undefined;
+  const unique = new Set(files);
+  if (unique.size !== files.length || !unique.has(entry)) return undefined;
+  return { entry, files: [...files] };
+}
+
 function normalizeBootConfig(value: unknown): BootConfig {
   if (!isRecord(value)) {
     return {};
@@ -47,6 +95,9 @@ function normalizeBootConfig(value: unknown): BootConfig {
   if (typeof value.assetBase === 'string') config.assetBase = value.assetBase;
   if (typeof value.geometry === 'string') config.geometry = value.geometry;
   if (typeof value.poster === 'string') config.poster = value.poster;
+
+  const project = normalizeBootProject(value.project);
+  if (project) config.project = project;
 
   return config;
 }

--- a/src/state/__tests__/url-mode.test.ts
+++ b/src/state/__tests__/url-mode.test.ts
@@ -314,4 +314,22 @@ describe('fetchPublishedProject', () => {
 
     expect(result).toHaveProperty('error');
   });
+  it('percent-encodes special filename characters in fetch URLs', async () => {
+    const fetched: string[] = [];
+    vi.spyOn(globalThis, 'fetch').mockImplementation(async (input) => {
+      fetched.push(String(input));
+      return new Response('cube(1);', { status: 200 });
+    });
+
+    const result = await fetchPublishedProject({
+      entry: 'notes #1.scad',
+      files: ['notes #1.scad', 'lib/50%.scad'],
+    });
+
+    expect('error' in result).toBe(false);
+    // '#' would otherwise become a fragment, '%' would be server-decoded, and
+    // a space is invalid raw — each segment must be percent-encoded.
+    expect(fetched.some((url) => url.endsWith('/project/notes%20%231.scad'))).toBe(true);
+    expect(fetched.some((url) => url.endsWith('/project/lib/50%25.scad'))).toBe(true);
+  });
 });

--- a/src/state/__tests__/url-mode.test.ts
+++ b/src/state/__tests__/url-mode.test.ts
@@ -258,3 +258,60 @@ describe('buildCustomizerShareUrl', () => {
     expect(parsed.searchParams.has('teeth')).toBe(false);
   });
 });
+
+// ---------------------------------------------------------------------------
+// fetchPublishedProject (#253)
+// ---------------------------------------------------------------------------
+
+import { fetchPublishedProject } from '../url-mode.ts';
+
+describe('fetchPublishedProject', () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('fetches every project file as bytes from ./project/<path>', async () => {
+    const bodies: Record<string, string> = {
+      'examples/main.scad': 'use <../lib.scad>; part();',
+      'lib.scad': 'module part() { cube(5); }',
+    };
+    const fetchMock = vi.spyOn(globalThis, 'fetch').mockImplementation(async (input) => {
+      const url = String(input);
+      const match = Object.keys(bodies).find((rel) => url.endsWith(`/project/${rel}`));
+      if (!match) return new Response('missing', { status: 404 });
+      return new Response(bodies[match], { status: 200 });
+    });
+
+    const result = await fetchPublishedProject({
+      entry: 'examples/main.scad',
+      files: ['examples/main.scad', 'lib.scad'],
+    });
+
+    expect('error' in result).toBe(false);
+    if ('error' in result) return;
+    expect(result.map((f) => f.path)).toEqual(['examples/main.scad', 'lib.scad']);
+    expect(new TextDecoder().decode(result[0].bytes)).toBe(bodies['examples/main.scad']);
+    expect(new TextDecoder().decode(result[1].bytes)).toBe(bodies['lib.scad']);
+    // Every fetch resolved under the mount's own project/ directory.
+    for (const call of fetchMock.mock.calls) {
+      const url = new URL(String(call[0]));
+      expect(url.origin).toBe(new URL(window.location.href).origin);
+      expect(url.pathname).toContain('/project/');
+    }
+  });
+
+  it('fails the whole load when any file fails (no partial hydration)', async () => {
+    vi.spyOn(globalThis, 'fetch').mockImplementation(async (input) => {
+      const url = String(input);
+      if (url.endsWith('/project/lib.scad')) return new Response('missing', { status: 404 });
+      return new Response('use <lib.scad>;', { status: 200 });
+    });
+
+    const result = await fetchPublishedProject({
+      entry: 'main.scad',
+      files: ['main.scad', 'lib.scad'],
+    });
+
+    expect(result).toHaveProperty('error');
+  });
+});

--- a/src/state/url-mode.ts
+++ b/src/state/url-mode.ts
@@ -188,9 +188,11 @@ export async function fetchExternalModel(modelUrl: string): Promise<string | { e
  *  `projectRoot` target's tree into `<mount>/project/`. */
 const PUBLISHED_PROJECT_BASE = './project/';
 
-/** The mount-relative URL of a published project file. */
+/** The mount-relative URL of a published project file. Each segment is
+ *  percent-encoded so legal-but-special filename characters (`#`, `?`, `%`,
+ *  spaces) fetch the literal file instead of being parsed as URL syntax. */
 export function publishedProjectFileUrl(relativePath: string): string {
-  return `${PUBLISHED_PROJECT_BASE}${relativePath}`;
+  return PUBLISHED_PROJECT_BASE + relativePath.split('/').map(encodeURIComponent).join('/');
 }
 
 /**

--- a/src/state/url-mode.ts
+++ b/src/state/url-mode.ts
@@ -8,6 +8,8 @@ import {
   resolveExternalSourceUrl,
 } from '../external-source.ts';
 import { formatExternalLoadError } from '../user-facing-errors.ts';
+import type { BootProject } from '../runtime/boot-config.ts';
+import type { ProjectFile } from '../state/project-store.ts';
 
 export type AppMode = 'editor' | 'customizer' | 'embed';
 
@@ -23,6 +25,14 @@ export interface UrlModeParams {
     color?: string;
     lineNumbers?: boolean;
   };
+  /**
+   * The published multi-file project tree, when this surface boots a mount
+   * assembled from a `projectRoot` (#253). Comes from the boot config only —
+   * never from the URL — and is attached by the booter after validating that
+   * `modelUrl` still points at the project's entry (an explicit `?model=`
+   * override keeps plain single-file behavior).
+   */
+  project?: BootProject;
 }
 
 /** Query-param keys that are reserved by the router and must NOT be treated
@@ -164,6 +174,52 @@ export async function fetchExternalModel(modelUrl: string): Promise<string | { e
   try {
     const buffer = await fetchResolvedExternalSourceBytes(resolved, { maxBytes: MODEL_MAX_BYTES });
     return new TextDecoder().decode(buffer);
+  } catch (e) {
+    return { error: formatExternalLoadError(e, 'model') };
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Published project hydration (#253)
+// ---------------------------------------------------------------------------
+
+/** Where a mount's published project files live, relative to its document.
+ *  Fixed by the publish contract: `deploy-configure` always assembles a
+ *  `projectRoot` target's tree into `<mount>/project/`. */
+const PUBLISHED_PROJECT_BASE = './project/';
+
+/** The mount-relative URL of a published project file. */
+export function publishedProjectFileUrl(relativePath: string): string {
+  return `${PUBLISHED_PROJECT_BASE}${relativePath}`;
+}
+
+/**
+ * Fetch every file of a published project tree, ready for
+ * `model.setProject(files, project.entry)`.
+ *
+ * All files are fetched as bytes and pushed uniformly — `setProject` decodes
+ * text-suffix paths itself (session-contract `ProjectFile` semantics), so
+ * `.scad` sources become editable text while binary assets (images,
+ * `import()`ed meshes) keep their exact bytes. Paths were validated as safe
+ * relative paths by the boot-config normalizer, and resolve under the mount's
+ * own `project/` directory, so every fetch is same-origin.
+ *
+ * Any failed file fails the whole load: compiling a partially hydrated tree
+ * is the silent-empty-geometry failure #253 exists to eliminate.
+ */
+export async function fetchPublishedProject(
+  project: BootProject,
+): Promise<ProjectFile[] | { error: string }> {
+  try {
+    return await Promise.all(
+      project.files.map(async (relativePath): Promise<ProjectFile> => {
+        const resolved = new URL(publishedProjectFileUrl(relativePath), window.location.href);
+        const bytes = await fetchResolvedExternalSourceBytes(resolved, {
+          maxBytes: MODEL_MAX_BYTES,
+        });
+        return { path: relativePath, bytes };
+      }),
+    );
   } catch (e) {
     return { error: formatExternalLoadError(e, 'model') };
   }

--- a/tests/publish-assembled.spec.ts
+++ b/tests/publish-assembled.spec.ts
@@ -51,6 +51,32 @@ test('a shared-runtime compile mount fetches libraries from the shared runtime a
   expect(libraryNotFound, 'no library asset 404d').toEqual([]);
 });
 
+test('a projectRoot mount hydrates the published tree and compiles a multi-file model (#253)', async ({
+  page,
+}) => {
+  test.skip(!assembled, 'requires E2E_SERVER_MODE=publish-assembled');
+
+  const responses: { url: string; status: number }[] = [];
+  page.on('response', (response) =>
+    responses.push({ url: response.url(), status: response.status() }),
+  );
+
+  await page.goto(new URL('assembly/', baseUrl).toString());
+
+  // The entry is `use <lib/box.scad> box(12);` — geometry exists only if the
+  // sibling file reached the compile FS. Before #253 the boot loaded just the
+  // entry text, the `use` silently failed to resolve, and the compile produced
+  // an empty top level (no geometry, no error).
+  await page.waitForSelector('[data-geometry-loaded="true"]', { timeout: 90_000 });
+
+  // The sibling was actually fetched from the mount's published project tree.
+  const sibling = responses.find((response) =>
+    response.url.endsWith('/assembly/project/lib/box.scad'),
+  );
+  expect(sibling, 'the runtime fetched the sibling project file').toBeTruthy();
+  expect(sibling!.status).toBe(200);
+});
+
 test('a static mount renders the pre-rendered geometry with no WASM (#241)', async ({ page }) => {
   test.skip(!assembled, 'requires E2E_SERVER_MODE=publish-assembled');
 


### PR DESCRIPTION
Closes #253.

## What

`projectRoot` publish targets now actually work on compile surfaces:

- **`deploy-configure`** emits `project { entry, files }` into the mount's boot config — the full published file list, walked from the copied tree (sorted, POSIX paths). Symlinks are dereferenced on copy so the published tree is self-contained and the list is complete.
- **Boot config** validates the field hard (relative paths only, no `..`/empty/dot segments, no backslash/colon, entry listed, no duplicates); a malformed project is dropped whole → single-file fallback, never a partial tree.
- **Customizer + embed shells** fetch every listed file from `./project/<path>` as bytes and boot through the existing multi-file `setProject` contract (session-contract `ProjectFile` semantics: text-suffix paths decode, binary assets ride byte-exact). Any failed fetch fails the whole load with a visible error.
- **`?model=` override** disables hydration (the booter attaches `project` only while the model URL still points at the project entry) — explicit URLs keep today's behavior.
- **Compile errors are now visible on published surfaces**: both shells render `state.error` inline; previously it surfaced only in the editor footer, which published surfaces don't include — a failed compile left an empty viewer with no message.

## Why

Found dogfooding iLOX (CameronBrooks11/iLOX#12): `deploy-configure` publishes a `projectRoot` tree into the mount, but the boot path fetched only the entry file's text — any `use <…>`/`include <…>` of a sibling silently compiled to empty geometry. The live tier effectively supported standalone single-file models only.

## Coverage

- unit: boot-config project validation (13 cases), `fetchPublishedProject` (URL shape, bytes, whole-load failure), deploy-configure layout (project field, nested files, symlink dereference; single-file targets assert **no** project field)
- e2e (`publish-assembled`): new `projectRoot` mount whose entry compiles **only if** the sibling hydrated — asserts geometry renders and the sibling was fetched from the mount. Passing locally alongside #240/#241 specs and the full 35-test publish suite.
- `npm run verify` green.

Additive contract change: new boot-config field; single-file targets and old configs unchanged. Consumers need artifact >= 0.6 (PUBLISHING.md notes this).