### PR TITLE
chore(deps): hold monaco-editor at 0.55.x

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -17,6 +17,16 @@ updates:
       interval: 'weekly'
     commit-message:
       prefix: 'chore(deps): '
+    ignore:
+      # monaco 0.56 rewrote `editor.api` from a re-export shim into a module
+      # that statically pulls the standalone editor and its CSS, and dropped
+      # every CSS subpath export. That breaks the editor panel's lazy-loaded
+      # stylesheet and makes the monaco chunk eager. Held at 0.55.x until
+      # monaco ships a CSS-free API entry again -- see #254.
+      - dependency-name: 'monaco-editor'
+        update-types:
+          - 'version-update:semver-minor'
+          - 'version-update:semver-major'
     groups:
       npm-production:
         dependency-type: 'production'

--- a/package-lock.json
+++ b/package-lock.json
@@ -15,7 +15,7 @@
         "debug": "^4.4.0",
         "jszip": "^3.10.1",
         "lit": "^3.3.3",
-        "monaco-editor": "^0.55.1",
+        "monaco-editor": "~0.55.1",
         "three": "^0.185.1",
         "thumbhash": "^0.1.1",
         "uuid": "^14.0.1",

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "debug": "^4.4.0",
     "jszip": "^3.10.1",
     "lit": "^3.3.3",
-    "monaco-editor": "^0.55.1",
+    "monaco-editor": "~0.55.1",
     "three": "^0.185.1",
     "thumbhash": "^0.1.1",
     "uuid": "^14.0.1",


### PR DESCRIPTION
Closes the monaco 0.56 question opened in #254. Supersedes #250.

## What monaco 0.56 changed
Both verified against the published tarballs and reproduced in a build:

1. **Every CSS subpath export was dropped.** The map became `"./*.js": "./esm/vs/*.js"` / `"./*": "./esm/vs/*.js"`, so no stylesheet resolves — `min/vs/editor/editor.main.css`, `esm/vs/…` and `editor/…` all fail. The 350 KB file still ships; it is simply unreachable by specifier.
2. **`editor.api` stopped being API-only.** 0.55.1 ships a 227-byte re-export shim. 0.56 ships a 2,969-byte module that statically imports `standalone/browser/standaloneEditor.js`, `standaloneLanguages.js` and `contrib/format/browser/format.js` — pulling monaco's CSS tree into the JS graph.

## Why that blocks the bump
`osc-editor-panel.ts` imports `editor.api` *because* it carried no CSS, and imports the monolithic stylesheet separately so the CSS loads only with the editor panel. Point 2 voids that premise.

Measured on `index.html`:

| | monaco refs in index.html |
|---|---|
| 0.55.1 (today) | **0** |
| 0.56.0 | eager `<link rel=stylesheet>` 358 KB + `modulepreload` for the 2.6 MB monaco chunk |

I isolated the cause rather than assuming it:
- aliasing the stylesheet past the exports map **is not** the trigger — applying the same alias on 0.55.1 keeps `index.html` at 0 monaco refs;
- migrating the specifiers to 0.56's form (`monaco-editor/editor/editor.api`) does not restore it;
- **removing the CSS import entirely does not restore it** — a monaco CSS chunk is still emitted and still linked eagerly.

So the regression is monaco's own module graph. A CSS alias makes CI green while shipping ~3 MB of eager payload on the main app.

## Decision
0.56 fixes no advisory — 0.55.1 and 0.56.0 bundle the identical vulnerable dompurify range, so the bump buys nothing. Narrow to `~0.55.1` (patches still flow) and ignore monaco minors/majors until upstream ships a CSS-free API entry again.

Restoring laziness on 0.56 is possible — only three modules pull monaco statically, and only for enum *values* (`CompletionItemKind`, `MarkerSeverity`, `IndentAction`) — but that is a refactor with no payoff today. Left in #254.

## Verification
- `vite build` passes; `index.html` still has **0** monaco refs
- `tsc --noEmit` and `prettier --check` clean
- resolves monaco 0.55.1 as before

> The red default branch was a **separate** problem — a dompurify override pinned inside the advisory range — fixed in #265.