### PR TITLE
ci: skip puppeteer's browser download in jobs that don't use it

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,6 +16,12 @@ concurrency:
 jobs:
   build-and-test:
     runs-on: ubuntu-24.04
+    env:
+      # Only the `performance` job drives a puppeteer browser. Skipping the
+      # postinstall download here avoids ~150 MB of transfer and a hard
+      # dependency on Google's chrome-for-testing bucket, which has 403'd
+      # mid-run and failed a required check. See #268.
+      PUPPETEER_SKIP_DOWNLOAD: 'true'
 
     steps:
       - uses: actions/checkout@v7
@@ -78,6 +84,7 @@ jobs:
     runs-on: ubuntu-24.04
     env:
       CI: 'true'
+      PUPPETEER_SKIP_DOWNLOAD: 'true'
 
     steps:
       - uses: actions/checkout@v7
@@ -121,6 +128,7 @@ jobs:
     needs: build-and-test
     env:
       CI: 'true'
+      PUPPETEER_SKIP_DOWNLOAD: 'true'
 
     steps:
       - uses: actions/checkout@v7
@@ -174,6 +182,7 @@ jobs:
     needs: publish-artifact
     env:
       CI: 'true'
+      PUPPETEER_SKIP_DOWNLOAD: 'true'
 
     steps:
       - uses: actions/checkout@v7


### PR DESCRIPTION
Closes #268.

## Why
Only `performance` drives a puppeteer browser (`scripts/perf/capture-baseline.mjs` via `perf:capture:series`). The other four jobs that run `npm ci` — `build-and-test`, `publish-artifact`, `e2e`, `publish-e2e` — downloaded ~150 MB of Chrome they never touch, on every run.

That bucket is not reliable. During #265 it returned:

```
DefaultProvider: Download failed: server returned code 403.
URL: https://storage.googleapis.com/chrome-for-testing-public/151.0.7922.47/linux64/chrome-linux64.zip
```

`publish-artifact` failed at **Install dependencies**, which took down the required `ok` check for a reason unrelated to the change under test.

`e2e` and `publish-e2e` get their browsers from `npx playwright install`, so they are unaffected by this.

## Change
`PUPPETEER_SKIP_DOWNLOAD: 'true'` on those four jobs. `performance` is deliberately left untouched.

| job | flag |
|---|---|
| build-and-test | set |
| publish-artifact | set |
| e2e | set |
| publish-e2e | set |
| **performance** | **unset — needs the browser** |

## Verification
Run locally in a clean worktree:
- `PUPPETEER_SKIP_DOWNLOAD=true npm ci` → succeeds, 656 packages in 5s
- `npm run security:check-install-scripts` with the flag set → still passes (`fsevents, puppeteer`); the guard is metadata-based and does not depend on the download happening

The real proof is this PR's own CI: all four jobs run `npm ci` under the new flag.