### PR TITLE
chore(deps): take monaco-editor 0.56

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -17,16 +17,6 @@ updates:
       interval: 'weekly'
     commit-message:
       prefix: 'chore(deps): '
-    ignore:
-      # monaco 0.56 rewrote `editor.api` from a re-export shim into a module
-      # that statically pulls the standalone editor and its CSS, and dropped
-      # every CSS subpath export. That breaks the editor panel's lazy-loaded
-      # stylesheet and makes the monaco chunk eager. Held at 0.55.x until
-      # monaco ships a CSS-free API entry again -- see #254.
-      - dependency-name: 'monaco-editor'
-        update-types:
-          - 'version-update:semver-minor'
-          - 'version-update:semver-major'
     groups:
       npm-production:
         dependency-type: 'production'

--- a/bundle-budgets.json
+++ b/bundle-budgets.json
@@ -1,5 +1,5 @@
 {
-  "_comment": "Gzipped-size budgets (KB) enforced in CI by scripts/check-bundle-budgets.mjs (#68). These bound regressions of the boot-critical artifacts; update deliberately when a size change is intended and understood. A pattern matching no file is a FAILURE, so a removed artifact must be removed here too. Three.js is split into its own named chunk (#68) and only loaded by the viewer. Monaco has no bundled chunk: it is loaded at runtime from the AMD build in public/monaco/vs (#254, #267), so it is budgeted as a shipped asset rather than a chunk.",
+  "_comment": "Gzipped-size budgets (KB) enforced in CI by scripts/check-bundle-budgets.mjs (#68). These bound regressions of the boot-critical artifacts; update deliberately when a size change is intended and understood. A pattern matching no file is a FAILURE, so a removed artifact must be removed here too. Three.js is split into its own named chunk (#68) and only loaded by the viewer. Monaco has no bundled chunk: it is loaded at runtime from the AMD build in public/monaco/vs (#254, #267), so it is budgeted as a shipped asset rather than a chunk. Its payload is budgeted as the whole root-level *.js set rather than a single file, because those filenames are content-hashed and rename on every Monaco release.",
   "budgets": [
     {
       "label": "initial app JS",
@@ -27,14 +27,14 @@
       "maxGzipKB": 3072
     },
     {
-      "label": "monaco AMD core",
-      "pattern": "monaco/vs/editor.api-*.js",
-      "maxGzipKB": 1100
+      "label": "monaco AMD payload",
+      "pattern": "monaco/vs/*.js",
+      "maxGzipKB": 1450
     },
     {
       "label": "monaco AMD CSS",
       "pattern": "monaco/vs/editor/editor.main.css",
-      "maxGzipKB": 120
+      "maxGzipKB": 140
     }
   ]
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -15,7 +15,7 @@
         "debug": "^4.4.0",
         "jszip": "^3.10.1",
         "lit": "^3.3.3",
-        "monaco-editor": "~0.55.1",
+        "monaco-editor": "^0.56.0",
         "three": "^0.185.1",
         "thumbhash": "^0.1.1",
         "uuid": "^14.0.1",
@@ -7243,12 +7243,12 @@
       }
     },
     "node_modules/monaco-editor": {
-      "version": "0.55.1",
-      "resolved": "https://registry.npmjs.org/monaco-editor/-/monaco-editor-0.55.1.tgz",
-      "integrity": "sha512-jz4x+TJNFHwHtwuV9vA9rMujcZRb0CEilTEwG2rRSpe/A7Jdkuj8xPKttCgOh+v/lkHy7HsZ64oj+q3xoAFl9A==",
+      "version": "0.56.0",
+      "resolved": "https://registry.npmjs.org/monaco-editor/-/monaco-editor-0.56.0.tgz",
+      "integrity": "sha512-sXboRm3BeBeLm938eaiyLMe0OxzfXIlZvbv4ir/jVgQy1zDhWjgmny0WoN45fuDKhCCQsYMbBJrv/A6jd8aCUg==",
       "license": "MIT",
       "dependencies": {
-        "dompurify": "3.2.7",
+        "dompurify": "3.4.8",
         "marked": "14.0.0"
       }
     },

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "debug": "^4.4.0",
     "jszip": "^3.10.1",
     "lit": "^3.3.3",
-    "monaco-editor": "~0.55.1",
+    "monaco-editor": "^0.56.0",
     "three": "^0.185.1",
     "thumbhash": "^0.1.1",
     "uuid": "^14.0.1",

--- a/scripts/sync-monaco-assets.mjs
+++ b/scripts/sync-monaco-assets.mjs
@@ -9,11 +9,11 @@
 //
 // Pruning matters because the service worker precaches everything in dist
 // (scripts/build-sw.mjs), so anything shipped here is downloaded on first
-// visit. The full `min/vs` is ~16 MB, of which ~8.7 MB is language-service
-// workers for TypeScript, CSS, HTML and JSON. This app registers exactly one
-// language — OpenSCAD, via Monarch — and never creates a model in any of
-// those, so their workers are never spawned. The extra locale bundles are
-// likewise dead: we never call `loader.config({ 'vs/nls': ... })`.
+// visit. The full `min/vs` is ~23 MB, most of it language-service workers for
+// TypeScript, CSS, HTML and JSON — which 0.56 ships in triplicate — plus
+// translated UI strings. This app registers exactly one language (OpenSCAD,
+// via Monarch) and never creates a model in any of those, so their workers are
+// never spawned.
 //
 // Exclusions are matched by PATTERN, not by exact filename, because these
 // assets are content-hashed and the hashes change on every Monaco release.
@@ -22,36 +22,50 @@ import { cpSync, existsSync, mkdirSync, readdirSync, rmSync, statSync } from 'no
 import { createRequire } from 'node:module';
 import path from 'node:path';
 
-/** Language-service workers for languages this app never registers. */
-const EXCLUDED_WORKERS = [
-  /^ts\.worker-.*\.js$/,
-  /^css\.worker-.*\.js$/,
-  /^html\.worker-.*\.js$/,
-  /^json\.worker-.*\.js$/,
-];
+/**
+ * The heavy language-service worker bundles, for languages this app never
+ * registers. `editor.worker` is deliberately not in this set — the core editor
+ * needs it.
+ *
+ * These are pruned only under `assets/`. 0.56 also ships a ~200-byte AMD stub
+ * for each at the root (`ts.worker-<hash>.js` and friends) whose whole job is
+ * to resolve the `assets/` URL. Those stubs are loaded EAGERLY when the editor
+ * boots, so dropping them 404s and the editor never initializes — pruning them
+ * is what broke the first attempt at this upgrade. They are kept; the multi-MB
+ * bundles they point at stay lazy and are never fetched.
+ */
+const EXCLUDED_WORKER = /^(ts|css|html|json)\.worker(-[^.]+)?\.js$/;
 
-/** Localized UI strings. `nls.messages.js.js` is the built-in English bundle. */
-const EXCLUDED_NLS = /^nls\.messages\.(?!js\.js$).+\.js\.js$/;
+/**
+ * Whole directories with nothing we use.
+ *
+ * `language/` holds the per-language mode entry points for TypeScript, CSS,
+ * HTML and JSON, including a second ~6.4 MB copy of ts.worker. `nls/` holds the
+ * translated UI strings for thirteen locales; the English strings are baked
+ * into the editor bundle and we never call `loader.config({ 'vs/nls': ... })`.
+ */
+const EXCLUDED_DIRS = ['language', 'nls'];
 
 /**
  * Files that must survive the prune. If Monaco reorganizes and one of these
- * stops matching, fail the build rather than ship a broken editor.
+ * stops matching, fail the build rather than ship a broken editor. This is not
+ * theoretical: 0.56 moved the NLS bundles into `nls/` and this list caught it.
  */
 const REQUIRED = [
   { label: 'AMD loader', test: (rel) => rel === 'loader.js' },
   { label: 'editor stylesheet', test: (rel) => rel === 'editor/editor.main.css' },
   { label: 'editor entry', test: (rel) => rel === 'editor/editor.main.js' },
-  { label: 'core editor worker', test: (rel) => /^assets\/editor\.worker-.*\.js$/.test(rel) },
-  { label: 'default NLS bundle', test: (rel) => rel === 'nls.messages.js.js' },
+  {
+    label: 'core editor worker',
+    test: (rel) => /(^|\/)editor\.worker(-[^.]+)?\.js$/.test(rel),
+  },
 ];
 
 /** True when `relPath` (posix, relative to `min/vs`) should be pruned. */
 export function isExcluded(relPath) {
-  const base = path.posix.basename(relPath);
-  if (path.posix.dirname(relPath) === 'assets' && EXCLUDED_WORKERS.some((re) => re.test(base))) {
-    return true;
-  }
-  return path.posix.dirname(relPath) === '.' && EXCLUDED_NLS.test(base);
+  const dir = path.posix.dirname(relPath);
+  if (EXCLUDED_DIRS.includes(dir.split('/')[0])) return true;
+  return dir === 'assets' && EXCLUDED_WORKER.test(path.posix.basename(relPath));
 }
 
 /** All files under `dir`, as posix paths relative to it. */


### PR DESCRIPTION
Replaces #273, which GitHub auto-closed when its base branch (`refactor/monaco-local-amd`, #272) was deleted on merge. Same commit, replayed onto `main` and re-verified there. Reverses the pin from #266.

#266 held monaco at `~0.55.1` because 0.56 dropped every CSS subpath export and turned `editor.api` into a module that statically pulled the standalone editor and its CSS. None of that reaches the build any more — since #272, `src/` imports monaco **for types only** and the editor is fetched at runtime from `public/monaco/vs`. The reason for the pin is gone, so this lifts it and drops the Dependabot ignore.

## 0.56 did restructure the AMD build — every guard earned its keep

| change | what caught it |
|---|---|
| `nls.messages.js.js` moved into `nls/` | the `REQUIRED` list failed the sync with a pointer to the file to review |
| AMD core renamed `editor.api-<hash>.js` → `editor-<hash>.js` | the bundle budget reported **NO MATCH** instead of passing silently |
| language-service workers now ship **in triplicate** | measured: `min/vs` went 16 MB → 23 MB |

That third one is the notable find: 0.56 ships each of ts/css/html/json worker as a hashed bundle under `assets/`, a ~200-byte stub at the root, **and** a legacy copy under `language/` — `ts.worker` appears at both 6.71 MB and 6.43 MB.

## Pruning

Now drops the `assets/` worker bundles plus the whole `language/` and `nls/` trees: **23.3 MB → 5.3 MB**.

The root worker stubs are **kept**. They load eagerly at editor boot, so dropping them 404s and the editor never initializes — a first pass at this did exactly that, and e2e caught it. The multi-MB bundles they point at stay lazy and are still never fetched (asserted by `monaco-origin.spec.ts`).

## Budgets made rename-proof

`monaco AMD core` (one hashed file) → `monaco AMD payload` tracking `monaco/vs/*.js` as a whole, so a hash rename no longer forces a budgets edit. CSS budget 120 → 140 KB gzip for 0.56's larger stylesheet.

## Size

| | precache | entries |
|---|---|---|
| before #272 | 23.07 MB | 56 |
| #272 (0.55.1, local) | 25.20 MB | 157 |
| **this PR (0.56.0)** | **25.80 MB** | 166 |

+0.60 MB. Unpruned 0.56 would be ~43 MB.

## Verification (re-run on this branch, against current `main`)

- **706 unit tests pass**, including the constants drift test against 0.56's `monaco.d.ts` — the eleven enum values are unchanged
- **editor e2e passes** — `paste.spec.ts` and `monaco-origin.spec.ts`, 4/4
- typecheck, prettier, budgets all clean; `monaco AMD payload` 1204.0 / 1450 KB gzip
- earlier on the pre-rebase branch: full 37 e2e passing, viewer/session carrying no monaco, and `build:publish` verified from a **nested relocatable mount** (17 same-origin monaco requests, 0 CDN)

The stub finding was **negative-tested**: pruning the root stubs on a clean harness reproducibly fails `monaco-origin.spec.ts`.

## Note on Dependabot

With the ignore removed, monaco minors resume. `^0.56.0` allows 0.56.x only, so 0.57 arrives as its own PR — and the `REQUIRED` list plus the budgets will surface any layout change the same way they did here.