### PR TITLE
fix: close the four open code-scanning alerts

### DIFF
--- a/src/fs/__tests__/library-delivery.test.ts
+++ b/src/fs/__tests__/library-delivery.test.ts
@@ -45,4 +45,32 @@ describe('library-delivery policy', () => {
     expect(prefetchLinks).toHaveLength(1);
     expect(prefetchLinks[0]!.href).toContain('/libraries/MCAD.zip');
   });
+
+  it('refuses to prefetch script-bearing URL schemes', () => {
+    document.head.innerHTML = '';
+
+    injectBootstrapPrefetchHints([
+      'javascript:alert(1)',
+      'data:text/html,<script>alert(1)</script>',
+      './libraries/MCAD.zip',
+    ]);
+
+    const prefetchLinks = [
+      ...document.head.querySelectorAll<HTMLLinkElement>('link[rel="prefetch"]'),
+    ];
+    expect(prefetchLinks).toHaveLength(1);
+    expect(prefetchLinks[0]!.href).toContain('/libraries/MCAD.zip');
+  });
+
+  it('still prefetches blob: assets used by webview embedding', () => {
+    document.head.innerHTML = '';
+
+    injectBootstrapPrefetchHints(['blob:https://example.invalid/9f2c-libraries']);
+
+    const prefetchLinks = [
+      ...document.head.querySelectorAll<HTMLLinkElement>('link[rel="prefetch"]'),
+    ];
+    expect(prefetchLinks).toHaveLength(1);
+    expect(prefetchLinks[0]!.href).toContain('blob:');
+  });
 });

--- a/src/fs/library-delivery.ts
+++ b/src/fs/library-delivery.ts
@@ -7,6 +7,8 @@ export const LIBRARY_DELIVERY_POLICY =
 
 const CORE_PREFETCH_SPECIFIERS = ['libraries/fonts.zip'];
 
+const UNSAFE_URL_PROTOCOLS = new Set(['javascript:', 'data:', 'vbscript:']);
+
 export function getPrefetchedArchives(archives: ZipArchive[] = zipArchives): ZipArchive[] {
   return archives.filter((archive) => archive.prefetch === true);
 }
@@ -39,8 +41,14 @@ export function injectBootstrapPrefetchHints(
     const href = resolveRuntimeAssetUrl(specifier);
     if (existingHrefs.has(href)) continue;
 
+    const { pathname, protocol } = new URL(href);
+    // Asset URLs resolve against document.baseURI or a host-supplied override,
+    // so refuse script-bearing schemes before they reach a link href. A denylist
+    // rather than an allowlist: webview embedding legitimately delivers assets
+    // over blob: and vscode-resource: (#196, #203).
+    if (UNSAFE_URL_PROTOCOLS.has(protocol)) continue;
+
     const link = document.createElement('link');
-    const { pathname } = new URL(href);
     link.rel = 'prefetch';
     link.href = href;
     if (pathname.endsWith('.js')) {

--- a/src/language/__tests__/openscad-pseudoparser.test.ts
+++ b/src/language/__tests__/openscad-pseudoparser.test.ts
@@ -24,6 +24,16 @@ describe('stripComments', () => {
   it('handles source with no comments unchanged', () => {
     expect(stripComments('cube(1);')).toBe('cube(1);');
   });
+
+  it('returns promptly on a long unterminated block comment', () => {
+    // Regression: the old /\/\*(.|[\s\S])*?\*\// alternation matched every
+    // non-newline character two ways, so an unterminated /* backtracked
+    // exponentially. Linear now — this completes in milliseconds.
+    const src = `/* ${'a'.repeat(50_000)}`;
+    const started = performance.now();
+    expect(stripComments(src)).toBe(src);
+    expect(performance.now() - started).toBeLessThan(1_000);
+  });
 });
 
 // ---------------------------------------------------------------------------
@@ -86,6 +96,35 @@ describe('openscad-pseudoparser — module extraction', () => {
     const paramNames = params.map((p) => p.name);
     expect(paramNames).toContain('w');
     expect(paramNames).toContain('h');
+  });
+
+  it('records no params for an empty parameter list', () => {
+    const result = parseOpenSCAD('/test.scad', 'module box() { cube(1); }', false);
+    expect(result.modules['box']?.params).toEqual([]);
+  });
+
+  it('records no params for a whitespace-only parameter list', () => {
+    const result = parseOpenSCAD('/test.scad', 'module box(   ) { cube(1); }', false);
+    expect(result.modules['box']?.params).toEqual([]);
+  });
+
+  it('discards the whole list when one param is malformed', () => {
+    const result = parseOpenSCAD('/test.scad', 'module box(w=10, , h=5) { cube(1); }', false);
+    expect(result.modules['box']?.params).toEqual([]);
+  });
+
+  it('discards the whole list for a bracketed default value', () => {
+    const result = parseOpenSCAD('/test.scad', 'module box(v=[1,2]) { cube(1); }', false);
+    expect(result.modules['box']?.params).toEqual([]);
+  });
+
+  it('returns promptly on a long malformed parameter list', () => {
+    // Regression: the old whole-list gate nested ambiguous quantifiers and
+    // backtracked catastrophically when the list did not match.
+    const src = `module box(${'a='.repeat(2_000)}) { cube(1); }`;
+    const started = performance.now();
+    parseOpenSCAD('/test.scad', src, false);
+    expect(performance.now() - started).toBeLessThan(1_000);
   });
 });
 

--- a/src/language/openscad-pseudoparser.ts
+++ b/src/language/openscad-pseudoparser.ts
@@ -20,7 +20,7 @@ export type ParsedFile = {
   uses: string[];
 };
 
-export const stripComments = (src: string) => src.replaceAll(/\/\*(.|[\s\S])*?\*\/|\/\/.*?$/gm, '');
+export const stripComments = (src: string) => src.replaceAll(/\/\*[\s\S]*?\*\/|\/\/.*?$/gm, '');
 
 export function parseOpenSCAD(path: string, src: string, skipPrivates: boolean): ParsedFile {
   const withoutComments = stripComments(src);
@@ -46,17 +46,22 @@ export function parseOpenSCAD(path: string, src: string, skipPrivates: boolean):
     const paramsStr = m[3];
     const optBody = m[4];
     const params = [];
-    if (/^(\s*([$\w]+(\s*=[^,()[]+)?(\s*,\s*[$\w]+(\s*=[^,()[]+)?)*)?\s*)$/m.test(paramsStr)) {
-      for (const paramStr of paramsStr.split(',')) {
-        const am = /^\s*([$\w]+)(?:\s*=([^,()[]+))?\s*$/.exec(paramStr);
-        if (am) {
-          const paramName = am[1];
-          const defaultValue = am[2];
-          params.push({
-            name: paramName,
-            defaultValue,
-          });
-        }
+    // Validate each comma-separated param on its own rather than gating on a
+    // whole-list regex: the combined pattern nested ambiguous quantifiers and
+    // backtracked catastrophically on long malformed lists. Semantics are
+    // unchanged — a single bad param still discards the whole list.
+    const paramParts = paramsStr.trim() === '' ? [] : paramsStr.split(',');
+    const paramMatches = paramParts.map((paramStr) =>
+      /^\s*([$\w]+)(?:\s*=([^,()[]+))?\s*$/.exec(paramStr),
+    );
+    if (paramMatches.every((am) => am != null)) {
+      for (const am of paramMatches) {
+        const paramName = am[1];
+        const defaultValue = am[2];
+        params.push({
+          name: paramName,
+          defaultValue,
+        });
       }
     }
     (type == 'function' ? functions : modules)[name] = {


### PR DESCRIPTION
Closes the four open CodeQL alerts, the only open security alerts left on the account.

## The two ReDoS (`js/redos`) — real

`stripComments` matched block comments with `/\*(.|[\s\S])*?\*\/`. `.` is a strict subset of `[\s\S]`, so every non-newline character was matchable two ways and an unterminated `/*` backtracked exponentially. `[\s\S]*?` is equivalent and linear.

The parameter-list gate nested ambiguous quantifiers the same way — `[^,()[]+` can match whitespace, sits beside `\s*`, and the whole group repeats. Replaced with a split-then-validate-each pass using the linear per-parameter pattern the loop already applied.

Both were reachable from any `.scad` source the editor opens, so a crafted file could hang the tab.

**Confirmed, not inferred.** Reverting only the source fixes and keeping the new tests, the suite hangs past 180s on a 50k-character unterminated block comment. With the fixes restored the same 30 tests pass in 776ms.

Parameter extraction is unchanged: a single malformed parameter still discards the whole list. Empty, whitespace-only, malformed and bracketed-default lists all behave as before and are now covered by tests.

## The two at `library-delivery.ts:45` — most likely false positives

The sink is `<link rel="prefetch">`, which does not execute a `javascript:` URL, and the taint path runs through `document.baseURI` / `self.location.origin` — reaching it needs the markup injection it would supposedly enable.

Added a scheme guard anyway, as cheap insurance. A **denylist** (`javascript:`, `data:`, `vbscript:`) rather than an allowlist, because webview embedding legitimately delivers assets over `blob:` and `vscode-resource:` (#196, #203) and an allowlist would break those paths silently. A test covers both directions.

CodeQL may not recognise the guard as a sanitizer. If these two survive the next scan they should be dismissed with the reasoning above rather than the code reshaped to satisfy the scanner.

## Verification

`npm run verify` passes end to end (format, lint, typecheck, unit, assembly, production build, publish/viewer/session builds).

`check:budgets` reports `monaco AMD payload` OVER at 1464.7 vs 1450 KB gzip. This is pre-existing — clean `main` produces the identical 1464.7 — and is tracked separately.

## Upstream

`openscad-pseudoparser.ts` carries a `Copyright 2021 Google LLC, GPL2+` header and derives from openscad-playground. The `stripComments` fix is worth carrying upstream.