### PR TITLE
fix: show a model's color() in embedded viewers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,27 @@ release (changelog upkeep and tagging had lapsed between `0.1.0` and `0.2.0`).
 
 ## [Unreleased]
 
+### Fixed
+
+- **Colored geometry in embedded viewers** (#258): a model using `color()`
+  rendered in the viewer's default cameo yellow instead of its own colors. OFF
+  already carried the colors — OpenSCAD's Manifold backend writes a per-face RGB
+  suffix, and the compile surfaces already use that backend — but two things
+  dropped them:
+  - the viewer built per-vertex colors only when a model had **more than one**
+    distinct color, so a model with a single `color()` fell back to the default
+    material. It now keys off whether the source declared any color at all.
+  - face colors were fed to Three.js unconverted. Three.js converts
+    `material.color` from sRGB but reads a `color` attribute as already linear,
+    so colored models rendered washed out — visibly paler than the same color
+    applied as a material. They are now converted at the renderer boundary.
+    Multi-color models, which already rendered, therefore look more saturated
+    (and now match their posters). GLB export carried the same skew and is
+    fixed with it.
+
+  A model that declares any `color()` now shows those colors in place of a
+  host-supplied `color` setting, matching how multi-color models already behaved.
+
 ## [0.6.0] - 2026-07-28
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,8 +36,11 @@ release (changelog upkeep and tagging had lapsed between `0.1.0` and `0.2.0`).
   accept the flag at all, 2025.03 accepts it but still defaults to CGAL (so the
   flag is what produces colored geometry there), and 2026.08 already defaults to
   Manifold (so it is a no-op that pins the behavior). The `openscad` package on
-  GitHub's `ubuntu-*` runners is 2021.01 and renders colorless geometry. See
-  [docs/PUBLISHING.md](docs/PUBLISHING.md#colored-geometry).
+  GitHub's `ubuntu-*` runners is 2021.01 and renders colorless geometry. The
+  poster gets the same backend: it is a `--render` pass, not a preview, so it
+  loses `color()` on CGAL exactly as the OFF does — without this the two would
+  disagree on a 2025.03 CLI, pairing colored geometry with a colorless poster.
+  See [docs/PUBLISHING.md](docs/PUBLISHING.md#colored-geometry).
 
 ## [0.6.0] - 2026-07-28
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,15 @@ release (changelog upkeep and tagging had lapsed between `0.1.0` and `0.2.0`).
   A model that declares any `color()` now shows those colors in place of a
   host-supplied `color` setting, matching how multi-color models already behaved.
 
+### Changed
+
+- `scripts/render-geometry.mjs` now renders OFF on the Manifold backend, so the
+  `static` publish surface preserves `color()` too (#258). It probes the CLI for
+  `--backend` and falls back — with a warning on stderr — when it is missing.
+  `--backend` needs OpenSCAD **2025.03 or newer**; the `openscad` package on
+  GitHub's `ubuntu-*` runners is 2021.01 and renders colorless geometry. See
+  [docs/PUBLISHING.md](docs/PUBLISHING.md#colored-geometry).
+
 ## [0.6.0] - 2026-07-28
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,7 +32,10 @@ release (changelog upkeep and tagging had lapsed between `0.1.0` and `0.2.0`).
 - `scripts/render-geometry.mjs` now renders OFF on the Manifold backend, so the
   `static` publish surface preserves `color()` too (#258). It probes the CLI for
   `--backend` and falls back — with a warning on stderr — when it is missing.
-  `--backend` needs OpenSCAD **2025.03 or newer**; the `openscad` package on
+  Which backend you get otherwise depends on the release: 2021.01 does not
+  accept the flag at all, 2025.03 accepts it but still defaults to CGAL (so the
+  flag is what produces colored geometry there), and 2026.08 already defaults to
+  Manifold (so it is a no-op that pins the behavior). The `openscad` package on
   GitHub's `ubuntu-*` runners is 2021.01 and renders colorless geometry. See
   [docs/PUBLISHING.md](docs/PUBLISHING.md#colored-geometry).
 

--- a/docs/EMBEDDING-VSCODE.md
+++ b/docs/EMBEDDING-VSCODE.md
@@ -188,13 +188,23 @@ correlation.
 
 **Host → viewer (inbound):**
 
-| Type                | Payload                                                                      | Notes                                                                                                                   |
-| ------------------- | ---------------------------------------------------------------------------- | ----------------------------------------------------------------------------------------------------------------------- |
-| `setGeometry`       | `{ offText }`                                                                | OFF text (≤ 64 MiB). Acked `geometry-set`; render outcome follows.                                                      |
-| `setViewerSettings` | `{ color?, showAxes?, active?, background?, showControls? }`                 | Only provided fields apply. Acked `viewer-settings-set`.                                                                |
-| `setCamera`         | `{ camera: { position:[x,y,z], target:[x,y,z], zoom } }`                     | Raw pose. Acked `camera-set`.                                                                                           |
-| `setNamedView`      | `{ view }` (`VIEWER_NAMED_VIEWS`: Diagonal/Front/Right/Back/Left/Top/Bottom) | **Fit-aware** preset — frames the model to its bounds viewer-side (no host-side bounds needed). Acked `named-view-set`. |
-| `dispose`           | `{}`                                                                         | Tears down the viewer. Acked `disposed`.                                                                                |
+| Type                | Payload                                                                      | Notes                                                                                                                            |
+| ------------------- | ---------------------------------------------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------- |
+| `setGeometry`       | `{ offText }`                                                                | OFF text (≤ 64 MiB). Acked `geometry-set`; render outcome follows.                                                               |
+| `setViewerSettings` | `{ color?, showAxes?, active?, background?, showControls? }`                 | Only provided fields apply. Acked `viewer-settings-set`. `color` applies only to geometry with no colors of its own — see below. |
+| `setCamera`         | `{ camera: { position:[x,y,z], target:[x,y,z], zoom } }`                     | Raw pose. Acked `camera-set`.                                                                                                    |
+| `setNamedView`      | `{ view }` (`VIEWER_NAMED_VIEWS`: Diagonal/Front/Right/Back/Left/Top/Bottom) | **Fit-aware** preset — frames the model to its bounds viewer-side (no host-side bounds needed). Acked `named-view-set`.          |
+| `dispose`           | `{}`                                                                         | Tears down the viewer. Acked `disposed`.                                                                                         |
+
+**`color` vs. the model's own colors.** OFF geometry produced on OpenSCAD's
+Manifold backend carries a per-face color for every `color()` in the model. When
+the geometry has colors of its own, the viewer renders those and
+`setViewerSettings { color }` has no visible effect — it still acks
+`viewer-settings-set`, since the setting is stored and applies to any later
+geometry that is colorless. `color` is therefore a default for uncolored
+geometry, not an override. The same holds for the embed URL's `color=`
+parameter. (Before #258 this was true only of models using more than one
+`color()`; a single-`color()` model incorrectly honored the host value.)
 
 **Viewer → host (outbound), all `protocolVersion`-stamped:**
 

--- a/docs/PUBLISHING.md
+++ b/docs/PUBLISHING.md
@@ -174,13 +174,23 @@ artifact, so a consumer workflow drives `openscad` directly as above.)
 ### Colored geometry
 
 A model's `color()` survives into OFF as a per-face RGB suffix, which the static
-viewer renders — but **only on the Manifold backend**. The CGAL backend (still
-the CLI default) drops it, and the viewer then paints the whole model its
-default cameo yellow.
+viewer renders — but **only on the Manifold backend**. The CGAL backend drops
+it, and the viewer then paints the whole model its default cameo yellow.
+
+Which backend you get depends on the version, so the flag is worth passing
+explicitly:
+
+| OpenSCAD | `--backend`  | default backend | `color()` in OFF without the flag |
+| -------- | ------------ | --------------- | --------------------------------- |
+| 2021.01  | not accepted | CGAL            | no                                |
+| 2025.03  | accepted     | CGAL            | **no**                            |
+| 2026.08  | accepted     | Manifold        | yes                               |
 
 `render-geometry.mjs` probes the CLI and passes `--backend=Manifold` when it is
 supported, so colored geometry is the default where the toolchain allows it. It
-warns on stderr and falls back to a colorless render when it is not.
+warns on stderr and falls back to a colorless render when it is not. On a build
+that already defaults to Manifold the flag is a no-op; on 2025.03 it is what
+makes the difference, and passing it pins the behavior either way.
 
 `--backend` requires **OpenSCAD 2025.03 or newer**. `apt-get install -y openscad`
 on GitHub's `ubuntu-*` runners still installs **2021.01**, which predates both

--- a/docs/PUBLISHING.md
+++ b/docs/PUBLISHING.md
@@ -200,19 +200,20 @@ in the render step if your models use `color()`.
 
 The poster degrades the same way. `render-geometry.mjs` renders it with
 `--render` (a full F6 render, not a preview), so it goes through the same
-backend as the OFF and loses `color()` on CGAL just as the geometry does —
-measured on one binary, changing only the backend:
-
-```
---backend=Manifold  ->  #008000 green, #0000BD blue
---backend=CGAL      ->  #FAD82C, #A58F1D  (cameo yellow only)
-2021.01             ->  #FAD82C, #A58F1D  (cameo yellow only)
-```
+backend as the OFF and loses `color()` on CGAL just as the geometry does: on
+Manifold the model's colors appear, while on CGAL — and on 2021.01, which has no
+choice — the poster comes out in cameo yellow alone. Framing is unaffected;
+only the fill colors change.
 
 The helper therefore applies the same backend decision to both, so the OFF and
-the poster always agree. A hand-rolled poster command that omits `--render`
-renders in **preview** mode, which keeps `color()` on any version — that is why
-a workflow doing it by hand can have colored posters beside a colorless model.
+the poster always agree.
+
+A hand-rolled poster command that omits `--render` renders in **preview** mode,
+which keeps `color()` on every version — that is why a workflow doing it by hand
+can end up with colored posters beside a colorless model. Preview is not a
+drop-in substitute, though: it is not a resolved CSG pass and it shades
+differently, so a poster rendered that way will not match the geometry the
+viewer shows for models that lean on `render()` or have coincident faces.
 
 Then publish the pre-rendered files with `surface: static`:
 

--- a/docs/PUBLISHING.md
+++ b/docs/PUBLISHING.md
@@ -164,7 +164,12 @@ node scripts/render-geometry.mjs --source ./models/widget.scad --out-dir ./rende
 ```
 
 (Equivalent by hand: `openscad --backend=Manifold -o widget.off widget.scad` and
-`openscad -o widget.png --viewall --autocenter --render widget.scad`.)
+`openscad -o widget.png --viewall --autocenter --render widget.scad`. Note that
+`--backend` needs OpenSCAD 2025.03 or newer — an older CLI **rejects it and
+exits 1** rather than ignoring it. Drop the flag for an older CLI and read
+[Colored geometry](#colored-geometry) for what that costs. The helper script
+probes for the flag and degrades on its own; it is not part of the publish
+artifact, so a consumer workflow drives `openscad` directly as above.)
 
 ### Colored geometry
 

--- a/docs/PUBLISHING.md
+++ b/docs/PUBLISHING.md
@@ -163,8 +163,26 @@ node scripts/render-geometry.mjs --source ./models/widget.scad --out-dir ./rende
 #    ./rendered/widget.png  (poster; add --no-poster to skip)
 ```
 
-(Equivalent by hand: `openscad -o widget.off widget.scad` and
+(Equivalent by hand: `openscad --backend=Manifold -o widget.off widget.scad` and
 `openscad -o widget.png --viewall --autocenter --render widget.scad`.)
+
+### Colored geometry
+
+A model's `color()` survives into OFF as a per-face RGB suffix, which the static
+viewer renders — but **only on the Manifold backend**. The CGAL backend (still
+the CLI default) drops it, and the viewer then paints the whole model its
+default cameo yellow.
+
+`render-geometry.mjs` probes the CLI and passes `--backend=Manifold` when it is
+supported, so colored geometry is the default where the toolchain allows it. It
+warns on stderr and falls back to a colorless render when it is not.
+
+`--backend` requires **OpenSCAD 2025.03 or newer**. `apt-get install -y openscad`
+on GitHub's `ubuntu-*` runners still installs **2021.01**, which predates both
+the flag and color-in-OFF — so a workflow relying on the distro package renders
+colorless geometry. Install a current release (for example the official AppImage)
+in the render step if your models use `color()`. Posters are unaffected: they are
+a preview-mode render and have always kept their colors.
 
 Then publish the pre-rendered files with `surface: static`:
 
@@ -180,7 +198,8 @@ targets:
 The mount holds `geometry.off`, `poster.png`, a boot config, and the static
 viewer page — no compiler, no `.scad`. The OpenSCAD CLI must be available where
 you run the render step (it is not part of `deploy-configure`, which stays
-dependency-free); GitHub's `ubuntu-*` runners can `apt-get install -y openscad`.
+dependency-free); GitHub's `ubuntu-*` runners can `apt-get install -y openscad`,
+though that package is old enough to render colorless geometry (see above).
 
 Multiple targets:
 

--- a/docs/PUBLISHING.md
+++ b/docs/PUBLISHING.md
@@ -196,8 +196,23 @@ makes the difference, and passing it pins the behavior either way.
 on GitHub's `ubuntu-*` runners still installs **2021.01**, which predates both
 the flag and color-in-OFF — so a workflow relying on the distro package renders
 colorless geometry. Install a current release (for example the official AppImage)
-in the render step if your models use `color()`. Posters are unaffected: they are
-a preview-mode render and have always kept their colors.
+in the render step if your models use `color()`.
+
+The poster degrades the same way. `render-geometry.mjs` renders it with
+`--render` (a full F6 render, not a preview), so it goes through the same
+backend as the OFF and loses `color()` on CGAL just as the geometry does —
+measured on one binary, changing only the backend:
+
+```
+--backend=Manifold  ->  #008000 green, #0000BD blue
+--backend=CGAL      ->  #FAD82C, #A58F1D  (cameo yellow only)
+2021.01             ->  #FAD82C, #A58F1D  (cameo yellow only)
+```
+
+The helper therefore applies the same backend decision to both, so the OFF and
+the poster always agree. A hand-rolled poster command that omits `--render`
+renders in **preview** mode, which keeps `color()` on any version — that is why
+a workflow doing it by hand can have colored posters beside a colorless model.
 
 Then publish the pre-rendered files with `surface: static`:
 

--- a/scripts/__tests__/render-geometry.test.mjs
+++ b/scripts/__tests__/render-geometry.test.mjs
@@ -10,11 +10,21 @@ import {
   buildOffArgs,
   buildPosterArgs,
   renderGeometry,
+  supportsManifoldBackend,
 } from '../render-geometry.mjs';
 
 describe('render-geometry arg builders', () => {
-  it('buildOffArgs exports OFF to the given path', () => {
+  it('buildOffArgs exports OFF on the Manifold backend, which preserves color()', () => {
     expect(buildOffArgs('/m/widget.scad', '/out/widget.off')).toEqual([
+      '/m/widget.scad',
+      '-o',
+      '/out/widget.off',
+      '--backend=Manifold',
+    ]);
+  });
+
+  it('buildOffArgs omits --backend for a CLI too old to know it', () => {
+    expect(buildOffArgs('/m/widget.scad', '/out/widget.off', { manifold: false })).toEqual([
       '/m/widget.scad',
       '-o',
       '/out/widget.off',
@@ -62,28 +72,69 @@ describe('renderGeometry', () => {
     return dir;
   }
 
-  it('invokes the runner for OFF and poster and returns their paths', async () => {
-    const outDir = await makeOutDir();
+  /** A runner whose `--help` reports (or hides) `--backend`, recording all calls. */
+  function fakeOpenScad({ backend }) {
     const calls = [];
     const runner = async (cmd, args) => {
       calls.push({ cmd, args });
+      if (args[0] === '--help') {
+        return { stdout: '', stderr: backend ? '  --backend arg  3D rendering backend\n' : '' };
+      }
+      return { stdout: '', stderr: '' };
     };
+    return { calls, runner, renders: () => calls.filter((c) => c.args[0] !== '--help') };
+  }
+
+  it('invokes the runner for OFF and poster and returns their paths', async () => {
+    const outDir = await makeOutDir();
+    const { runner, renders } = fakeOpenScad({ backend: true });
 
     const result = await renderGeometry({ entryPath: '/m/widget.scad', outDir, runner });
 
     expect(result.off).toBe(path.join(outDir, 'widget.off'));
     expect(result.poster).toBe(path.join(outDir, 'widget.png'));
-    expect(calls).toHaveLength(2);
-    expect(calls[0].args).toEqual(['/m/widget.scad', '-o', path.join(outDir, 'widget.off')]);
-    expect(calls[1].args).toContain('--render');
+    expect(renders()).toHaveLength(2);
+    expect(renders()[0].args).toEqual([
+      '/m/widget.scad',
+      '-o',
+      path.join(outDir, 'widget.off'),
+      '--backend=Manifold',
+    ]);
+    expect(renders()[1].args).toContain('--render');
+  });
+
+  /** Run `fn` with process.stderr captured, so the fallback warning does not
+   *  scribble over the test reporter's output. Returns what was written. */
+  async function captureStderr(fn) {
+    const written = [];
+    const write = process.stderr.write;
+    process.stderr.write = (chunk) => {
+      written.push(String(chunk));
+      return true;
+    };
+    try {
+      await fn();
+    } finally {
+      process.stderr.write = write;
+    }
+    return written.join('');
+  }
+
+  it('drops --backend, and warns, when the CLI does not advertise it (#258)', async () => {
+    const outDir = await makeOutDir();
+    const { runner, renders } = fakeOpenScad({ backend: false });
+
+    const warning = await captureStderr(() =>
+      renderGeometry({ entryPath: '/m/widget.scad', outDir, poster: false, runner }),
+    );
+
+    expect(renders()[0].args).toEqual(['/m/widget.scad', '-o', path.join(outDir, 'widget.off')]);
+    expect(warning).toMatch(/no color\(\) data/);
   });
 
   it('skips the poster when poster is false and honors an explicit name', async () => {
     const outDir = await makeOutDir();
-    const calls = [];
-    const runner = async (_cmd, args) => {
-      calls.push(args);
-    };
+    const { runner, renders } = fakeOpenScad({ backend: true });
 
     const result = await renderGeometry({
       entryPath: '/m/widget.scad',
@@ -95,6 +146,32 @@ describe('renderGeometry', () => {
 
     expect(result.poster).toBeNull();
     expect(result.off).toBe(path.join(outDir, 'thing.off'));
-    expect(calls).toHaveLength(1);
+    expect(renders()).toHaveLength(1);
+  });
+});
+
+describe('supportsManifoldBackend', () => {
+  it('detects --backend in help output on stderr', async () => {
+    const runner = async () => ({ stdout: '', stderr: '  --backend arg   backend to use' });
+    expect(await supportsManifoldBackend('openscad', runner)).toBe(true);
+  });
+
+  it('reports no support when help never mentions it (OpenSCAD 2021.01)', async () => {
+    const runner = async () => ({ stdout: 'Usage: openscad [options] file.scad', stderr: '' });
+    expect(await supportsManifoldBackend('openscad', runner)).toBe(false);
+  });
+
+  it('still reads help output when the CLI exits non-zero', async () => {
+    const runner = async () => {
+      throw Object.assign(new Error('exit 1'), { stdout: '', stderr: '--backend arg' });
+    };
+    expect(await supportsManifoldBackend('openscad', runner)).toBe(true);
+  });
+
+  it('reports no support when the binary cannot be run at all', async () => {
+    const runner = async () => {
+      throw new Error('ENOENT');
+    };
+    expect(await supportsManifoldBackend('openscad', runner)).toBe(false);
   });
 });

--- a/scripts/__tests__/render-geometry.test.mjs
+++ b/scripts/__tests__/render-geometry.test.mjs
@@ -40,7 +40,14 @@ describe('render-geometry arg builders', () => {
       '--viewall',
       '--autocenter',
       '--render',
+      '--backend=Manifold',
     ]);
+  });
+
+  it('buildPosterArgs omits --backend for a CLI too old to know it', () => {
+    expect(buildPosterArgs('/m/widget.scad', '/out/widget.png', { manifold: false })).not.toContain(
+      '--backend=Manifold',
+    );
   });
 
   it('buildPosterArgs honors imgsize + colorscheme', () => {
@@ -54,6 +61,7 @@ describe('render-geometry arg builders', () => {
       '--viewall',
       '--autocenter',
       '--render',
+      '--backend=Manifold',
       '--colorscheme=Tomorrow',
     ]);
   });
@@ -101,6 +109,20 @@ describe('renderGeometry', () => {
       '--backend=Manifold',
     ]);
     expect(renders()[1].args).toContain('--render');
+    // The poster is a --render pass through the same backend, so it loses
+    // color() on CGAL exactly as the OFF does. Both sides must agree, or a
+    // 2025.03-era CLI pairs colored geometry with a colorless poster (#258).
+    expect(renders()[1].args).toContain('--backend=Manifold');
+  });
+
+  it('keeps the poster on the same backend as the OFF when falling back (#258)', async () => {
+    const outDir = await makeOutDir();
+    const { runner, renders } = fakeOpenScad({ backend: false });
+
+    await captureStderr(() => renderGeometry({ entryPath: '/m/widget.scad', outDir, runner }));
+
+    expect(renders()).toHaveLength(2);
+    for (const call of renders()) expect(call.args).not.toContain('--backend=Manifold');
   });
 
   /** Run `fn` with process.stderr captured, so the fallback warning does not
@@ -129,7 +151,7 @@ describe('renderGeometry', () => {
     );
 
     expect(renders()[0].args).toEqual(['/m/widget.scad', '-o', path.join(outDir, 'widget.off')]);
-    expect(warning).toMatch(/no color\(\) data/);
+    expect(warning).toMatch(/neither the OFF geometry nor the poster will carry color\(\) data/);
   });
 
   it('skips the poster when poster is false and honors an explicit name', async () => {

--- a/scripts/render-geometry.mjs
+++ b/scripts/render-geometry.mjs
@@ -55,11 +55,18 @@ export async function supportsManifoldBackend(openscad, runner = execFileAsync) 
   }
 }
 
-/** OpenSCAD CLI args to render a PNG poster (full CGAL render, framed to bounds). */
+/**
+ * OpenSCAD CLI args to render a PNG poster (full render, framed to bounds).
+ *
+ * This is a `--render` (F6) pass, not a preview, so it goes through the same
+ * backend as the OFF export and loses `color()` on CGAL exactly as OFF does.
+ * It therefore takes the same `manifold` decision — otherwise a 2025.03-era CLI
+ * would pair a colored `geometry.off` with a colorless `poster.png` (#258).
+ */
 export function buildPosterArgs(
   entryPath,
   pngPath,
-  { imgsize = DEFAULT_POSTER_SIZE, colorscheme } = {},
+  { imgsize = DEFAULT_POSTER_SIZE, colorscheme, manifold = true } = {},
 ) {
   const args = [
     entryPath,
@@ -70,6 +77,7 @@ export function buildPosterArgs(
     '--autocenter',
     '--render',
   ];
+  if (manifold) args.push('--backend=Manifold');
   if (typeof colorscheme === 'string' && colorscheme !== '') {
     args.push(`--colorscheme=${colorscheme}`);
   }
@@ -97,9 +105,9 @@ export async function renderGeometry({
   const manifold = await supportsManifoldBackend(openscad, runner);
   if (!manifold) {
     process.stderr.write(
-      `${openscad} does not support --backend, so OFF geometry will carry no color() data ` +
-        `and the static viewer will render the model in its default color. ` +
-        `Use OpenSCAD 2025.03 or newer for colored geometry.\n`,
+      `${openscad} does not support --backend, so neither the OFF geometry nor the ` +
+        `poster will carry color() data — the static viewer will render the model in ` +
+        `its default color. Use OpenSCAD 2025.03 or newer for colored geometry.\n`,
     );
   }
   await runner(openscad, buildOffArgs(entryPath, offPath, { manifold }));
@@ -107,7 +115,10 @@ export async function renderGeometry({
   let posterPath = null;
   if (poster) {
     posterPath = path.join(outDir, `${modelName}.png`);
-    await runner(openscad, buildPosterArgs(entryPath, posterPath, { imgsize, colorscheme }));
+    await runner(
+      openscad,
+      buildPosterArgs(entryPath, posterPath, { imgsize, colorscheme, manifold }),
+    );
   }
 
   return { off: offPath, poster: posterPath };

--- a/scripts/render-geometry.mjs
+++ b/scripts/render-geometry.mjs
@@ -22,9 +22,35 @@ const execFileAsync = promisify(execFile);
 
 export const DEFAULT_POSTER_SIZE = [1000, 750];
 
-/** OpenSCAD CLI args to export OFF geometry from an entry `.scad`. */
-export function buildOffArgs(entryPath, offPath) {
-  return [entryPath, '-o', offPath];
+/**
+ * OpenSCAD CLI args to export OFF geometry from an entry `.scad`.
+ *
+ * `color()` survives into OFF as a per-face RGB(A) suffix only on the Manifold
+ * backend; CGAL — still the CLI default — drops it, and the static viewer then
+ * paints the whole model its default cameo yellow (#258). Pass
+ * `manifold: false` for a CLI too old to know the flag (`--backend` landed
+ * after 2021.01, which is what `apt-get install openscad` still gives).
+ */
+export function buildOffArgs(entryPath, offPath, { manifold = true } = {}) {
+  const args = [entryPath, '-o', offPath];
+  if (manifold) args.push('--backend=Manifold');
+  return args;
+}
+
+/**
+ * Whether `openscad` understands `--backend`. Probed from `--help` rather than
+ * parsed out of `--version`, so it tracks the actual capability instead of a
+ * version-number guess. OpenSCAD writes both to stderr, hence the merge.
+ */
+export async function supportsManifoldBackend(openscad, runner = execFileAsync) {
+  try {
+    const { stdout = '', stderr = '' } = (await runner(openscad, ['--help'])) ?? {};
+    return `${stdout}${stderr}`.includes('--backend');
+  } catch (error) {
+    // `--help` exits non-zero on some builds; the output is still on the error.
+    const { stdout = '', stderr = '' } = error ?? {};
+    return `${stdout}${stderr}`.includes('--backend');
+  }
 }
 
 /** OpenSCAD CLI args to render a PNG poster (full CGAL render, framed to bounds). */
@@ -66,7 +92,15 @@ export async function renderGeometry({
   await mkdir(outDir, { recursive: true });
 
   const offPath = path.join(outDir, `${modelName}.off`);
-  await runner(openscad, buildOffArgs(entryPath, offPath));
+  const manifold = await supportsManifoldBackend(openscad, runner);
+  if (!manifold) {
+    process.stderr.write(
+      `${openscad} does not support --backend, so OFF geometry will carry no color() data ` +
+        `and the static viewer will render the model in its default color. ` +
+        `Use OpenSCAD 2025.03 or newer for colored geometry.\n`,
+    );
+  }
+  await runner(openscad, buildOffArgs(entryPath, offPath, { manifold }));
 
   let posterPath = null;
   if (poster) {

--- a/scripts/render-geometry.mjs
+++ b/scripts/render-geometry.mjs
@@ -26,10 +26,12 @@ export const DEFAULT_POSTER_SIZE = [1000, 750];
  * OpenSCAD CLI args to export OFF geometry from an entry `.scad`.
  *
  * `color()` survives into OFF as a per-face RGB(A) suffix only on the Manifold
- * backend; CGAL — still the CLI default — drops it, and the static viewer then
- * paints the whole model its default cameo yellow (#258). Pass
- * `manifold: false` for a CLI too old to know the flag (`--backend` landed
- * after 2021.01, which is what `apt-get install openscad` still gives).
+ * backend; CGAL drops it, and the static viewer then paints the whole model its
+ * default cameo yellow (#258). Which backend is the default depends on the
+ * release — 2025.03 still defaults to CGAL, 2026.08 defaults to Manifold — so
+ * pass it explicitly rather than relying on the default. Pass `manifold: false`
+ * for a CLI too old to know the flag (`--backend` landed after 2021.01, which is
+ * what `apt-get install openscad` still gives).
  */
 export function buildOffArgs(entryPath, offPath, { manifold = true } = {}) {
   const args = [entryPath, '-o', offPath];

--- a/src/__tests__/export-3mf.test.ts
+++ b/src/__tests__/export-3mf.test.ts
@@ -12,6 +12,7 @@ describe('export3MF', () => {
     ],
     faces: [{ vertices: [0, 1, 2], colorIndex: 0 }],
     colors: [[1, 0, 0, 1] as [number, number, number, number]],
+    hasSourceColors: true,
   };
 
   const readBlobAsArrayBuffer = (blob: Blob): Promise<ArrayBuffer> =>

--- a/src/components/viewer/ThreeScene.ts
+++ b/src/components/viewer/ThreeScene.ts
@@ -228,7 +228,8 @@ export class ThreeScene {
       this.modelMesh = null;
     }
 
-    // Use per-vertex colors when the OFF loader generated them (multi-material model).
+    // Use per-vertex colors when the OFF loader generated them, i.e. the model
+    // used color(). A colorless model has none and takes the single material.
     const hasVertexColors = geometry.hasAttribute('color');
     const material = new THREE.MeshPhongMaterial({
       color: hasVertexColors ? 0xffffff : color,
@@ -369,7 +370,9 @@ export class ThreeScene {
   setModelColor(color: THREE.ColorRepresentation): void {
     if (this.modelMesh) {
       const mat = this.modelMesh.material as THREE.MeshPhongMaterial;
-      // Don't override per-vertex colors from a multi-material model.
+      // A model that declared its own color() wins over a host-supplied color:
+      // per-vertex colors are already baked into the geometry, so this is a no-op
+      // for it. See docs/EMBEDDING-VSCODE.md on setViewerSettings.
       if (!mat.vertexColors) mat.color.set(color);
       this.requestRender();
     }

--- a/src/components/viewer/__tests__/off-loader.test.ts
+++ b/src/components/viewer/__tests__/off-loader.test.ts
@@ -1,0 +1,55 @@
+import { describe, expect, it } from 'vitest';
+
+import { parseOff } from '../../../io/import_off.ts';
+import { offToBufferGeometry } from '../off-loader.ts';
+
+const VERTS = ['0 0 0', '1 0 0', '0 1 0', '0 0 1'].join('\n');
+const twoFaces = (a: string, b: string) => `OFF 4 2 0\n${VERTS}\n${a}\n${b}\n`;
+
+/** The sRGB electro-optical transfer function, written out independently of
+ *  Three.js so the test checks the conversion rather than restating the call. */
+const srgbToLinear = (c: number) => (c <= 0.04045 ? c / 12.92 : ((c + 0.055) / 1.055) ** 2.4);
+
+const load = (off: string) => offToBufferGeometry(parseOff(off));
+
+describe('offToBufferGeometry', () => {
+  it('emits no color attribute for a colorless model', () => {
+    // The viewer then paints it with its single default material.
+    expect(load(twoFaces('3 0 1 2', '3 0 1 3')).getAttribute('color')).toBeUndefined();
+  });
+
+  it('emits a color attribute when the model used ONE color() (#258 regression)', () => {
+    const geometry = load(twoFaces('3 0 1 2 0 128 0', '3 0 1 3 0 128 0'));
+    expect(geometry.getAttribute('color')).toBeDefined();
+  });
+
+  it('emits a color attribute for a multi-color model', () => {
+    const geometry = load(twoFaces('3 0 1 2 0 128 0', '3 0 1 3 0 0 255'));
+    expect(geometry.getAttribute('color')).toBeDefined();
+  });
+
+  it('converts sRGB face colors into the renderer working space (#258)', () => {
+    // Three.js converts `material.color` from sRGB for us but reads a `color`
+    // attribute as already linear, so an unconverted attribute rendered washed
+    // out next to the same color applied as a material.
+    const color = load(twoFaces('3 0 1 2 0 128 0', '3 0 1 3 0 128 0')).getAttribute('color')!;
+    expect(color.getX(0)).toBeCloseTo(0, 5);
+    expect(color.getY(0)).toBeCloseTo(srgbToLinear(128 / 255), 5);
+    expect(color.getZ(0)).toBeCloseTo(0, 5);
+    // Guard against a silent regression to passing sRGB straight through.
+    expect(color.getY(0)).not.toBeCloseTo(128 / 255, 3);
+  });
+
+  it('gives every vertex of a face that face color', () => {
+    const color = load(twoFaces('3 0 1 2 0 128 0', '3 0 1 3 0 0 255'))!.getAttribute('color')!;
+    const green = srgbToLinear(128 / 255);
+    for (const i of [0, 1, 2]) expect(color.getY(i)).toBeCloseTo(green, 5);
+    for (const i of [3, 4, 5]) expect(color.getZ(i)).toBeCloseTo(1, 5);
+  });
+
+  it('always emits position and normal attributes', () => {
+    const geometry = load(twoFaces('3 0 1 2', '3 0 1 3'));
+    expect(geometry.getAttribute('position').count).toBe(6);
+    expect(geometry.getAttribute('normal').count).toBe(6);
+  });
+});

--- a/src/components/viewer/off-loader.ts
+++ b/src/components/viewer/off-loader.ts
@@ -56,7 +56,7 @@ export function offToBufferGeometry(data: IndexedPolyhedron): THREE.BufferGeomet
 }
 
 /** sRGB (0..1) → the renderer's linear working space. Alpha is not carried by
- *  the `color` attribute, so it is dropped here. */
+ *  the `color` attribute, so it is dropped here (#282). */
 function toLinear([r, g, b]: Color): [number, number, number] {
   const c = new THREE.Color().setRGB(r, g, b, THREE.SRGBColorSpace);
   return [c.r, c.g, c.b];

--- a/src/components/viewer/off-loader.ts
+++ b/src/components/viewer/off-loader.ts
@@ -9,16 +9,22 @@ import { IndexedPolyhedron, Color } from '../../io/common.ts';
  * Faces are already triangulated by parseOff(); we just flatten them into
  * position / normal / color attribute arrays.
  *
- * Returns a geometry with per-face flat normals and (if the model uses
- * multiple face colors) per-vertex color attributes.
+ * Returns a geometry with per-face flat normals and, when the model used
+ * `color()` at all, per-vertex color attributes. Color is keyed off
+ * `hasSourceColors` rather than the number of distinct colors: a model that is
+ * entirely one `color()` has exactly one, and gating on `colors.length > 1`
+ * dropped it back to the viewer's default material (#258).
  */
 export function offToBufferGeometry(data: IndexedPolyhedron): THREE.BufferGeometry {
-  const { vertices, faces, colors } = data;
-  const hasMultiColor = colors.length > 1;
+  const { vertices, faces, colors, hasSourceColors } = data;
 
   const positions: number[] = [];
   const normals: number[] = [];
   const vertColors: number[] = [];
+  // OFF face colors are sRGB; Three.js reads a `color` attribute as already
+  // being in the renderer's linear working space (unlike `material.color`,
+  // which it converts for us). Convert here or colors render washed out.
+  const linear = hasSourceColors ? colors.map(toLinear) : [];
 
   for (const face of faces) {
     const [i0, i1, i2] = face.vertices;
@@ -34,9 +40,8 @@ export function offToBufferGeometry(data: IndexedPolyhedron): THREE.BufferGeomet
     positions.push(a.x, a.y, a.z, b.x, b.y, b.z, c.x, c.y, c.z);
     normals.push(n.x, n.y, n.z, n.x, n.y, n.z, n.x, n.y, n.z);
 
-    if (hasMultiColor) {
-      const col: Color = colors[face.colorIndex] ?? colors[0];
-      const [r, g, b_] = col;
+    if (hasSourceColors) {
+      const [r, g, b_] = linear[face.colorIndex] ?? linear[0];
       vertColors.push(r, g, b_, r, g, b_, r, g, b_);
     }
   }
@@ -44,8 +49,15 @@ export function offToBufferGeometry(data: IndexedPolyhedron): THREE.BufferGeomet
   const geometry = new THREE.BufferGeometry();
   geometry.setAttribute('position', new THREE.Float32BufferAttribute(positions, 3));
   geometry.setAttribute('normal', new THREE.Float32BufferAttribute(normals, 3));
-  if (hasMultiColor) {
+  if (hasSourceColors) {
     geometry.setAttribute('color', new THREE.Float32BufferAttribute(vertColors, 3));
   }
   return geometry;
+}
+
+/** sRGB (0..1) → the renderer's linear working space. Alpha is not carried by
+ *  the `color` attribute, so it is dropped here. */
+function toLinear([r, g, b]: Color): [number, number, number] {
+  const c = new THREE.Color().setRGB(r, g, b, THREE.SRGBColorSpace);
+  return [c.r, c.g, c.b];
 }

--- a/src/io/__tests__/export_glb.test.ts
+++ b/src/io/__tests__/export_glb.test.ts
@@ -1,10 +1,18 @@
 import { describe, expect, it } from 'vitest';
 
 import { exportGLB } from '../export_glb.ts';
-import type { IndexedPolyhedron } from '../common.ts';
+import { DEFAULT_FACE_COLOR, type IndexedPolyhedron } from '../common.ts';
 
-// A unit tetrahedron: 4 vertices, 4 triangular faces.
-function tetrahedron(colors: IndexedPolyhedron['colors']): IndexedPolyhedron {
+/** The sRGB transfer function, written out rather than restating the Three.js call. */
+const srgbToLinear = (c: number) => (c <= 0.04045 ? c / 12.92 : ((c + 0.055) / 1.055) ** 2.4);
+
+// A unit tetrahedron: 4 vertices, 4 triangular faces. `hasSourceColors` mirrors
+// what parseOff would report: true when the OFF declared a color(), false when
+// `colors` holds only the fabricated DEFAULT_FACE_COLOR entry.
+function tetrahedron(
+  colors: IndexedPolyhedron['colors'],
+  hasSourceColors = true,
+): IndexedPolyhedron {
   return {
     vertices: [
       { x: 0, y: 0, z: 0 },
@@ -19,7 +27,7 @@ function tetrahedron(colors: IndexedPolyhedron['colors']): IndexedPolyhedron {
       { vertices: [1, 2, 3], colorIndex: 0 },
     ],
     colors,
-    hasSourceColors: true,
+    hasSourceColors,
   };
 }
 
@@ -27,6 +35,8 @@ function tetrahedron(colors: IndexedPolyhedron['colors']): IndexedPolyhedron {
 // Layout: 12-byte header, then [uint32 chunkLength][uint32 chunkType='JSON'][bytes].
 function readGlbJson(buffer: ArrayBuffer): {
   nodes: Array<{ rotation?: number[]; matrix?: number[] }>;
+  materials?: Array<{ pbrMetallicRoughness?: { baseColorFactor?: number[] } }>;
+  meshes?: Array<{ primitives: Array<{ attributes: Record<string, number> }> }>;
 } {
   const view = new DataView(buffer);
   const jsonLength = view.getUint32(12, true);
@@ -67,6 +77,35 @@ describe('exportGLB', () => {
     expect(header.magic).toBe('glTF');
     expect(header.version).toBe(2);
     expect(glb.byteLength).toBeGreaterThan(12);
+  });
+
+  // #258: these pin which branch of the color handling runs. Both were
+  // previously unpinned -- the fixture always claimed source colors, and no
+  // assertion read `materials` or the mesh attributes, so reverting the fix
+  // left this suite green.
+  it('a colorless model carries its color as a linear baseColorFactor, not COLOR_0', async () => {
+    const glb = await exportGLB(tetrahedron([DEFAULT_FACE_COLOR], false));
+    const { materials, meshes } = readGlbJson(glb);
+
+    expect(Object.keys(meshes![0].primitives[0].attributes)).not.toContain('COLOR_0');
+    // glTF's baseColorFactor is linear; the sRGB #f9d72c must be converted, not
+    // passed through. Unconverted it would read [0.976, 0.843, 0.173].
+    const factor = materials![0].pbrMetallicRoughness!.baseColorFactor!;
+    expect(factor[0]).toBeCloseTo(srgbToLinear(0xf9 / 255), 4);
+    expect(factor[1]).toBeCloseTo(srgbToLinear(0xd7 / 255), 4);
+    expect(factor[2]).toBeCloseTo(srgbToLinear(0x2c / 255), 4);
+    expect(factor[0]).not.toBeCloseTo(0xf9 / 255, 2);
+  });
+
+  it('a model that used color() carries COLOR_0 instead of a base color', async () => {
+    const glb = await exportGLB(tetrahedron([[0, 128 / 255, 0, 1]], true));
+    const { materials, meshes } = readGlbJson(glb);
+
+    expect(Object.keys(meshes![0].primitives[0].attributes)).toContain('COLOR_0');
+    // White base color, so the vertex colors are not tinted by it. GLTFExporter
+    // omits baseColorFactor entirely when the material color is white.
+    const factor = materials![0].pbrMetallicRoughness?.baseColorFactor;
+    if (factor) for (const c of factor.slice(0, 3)) expect(c).toBeCloseTo(1, 5);
   });
 
   it('rotates Z-up OpenSCAD geometry to glTF Y-up via the node transform', async () => {

--- a/src/io/__tests__/export_glb.test.ts
+++ b/src/io/__tests__/export_glb.test.ts
@@ -19,6 +19,7 @@ function tetrahedron(colors: IndexedPolyhedron['colors']): IndexedPolyhedron {
       { vertices: [1, 2, 3], colorIndex: 0 },
     ],
     colors,
+    hasSourceColors: true,
   };
 }
 

--- a/src/io/__tests__/import_off.test.ts
+++ b/src/io/__tests__/import_off.test.ts
@@ -94,6 +94,16 @@ describe('parseOff face colors', () => {
     expect(poly.colors).toHaveLength(2);
   });
 
+  it('ignores a non-numeric trailing field instead of emitting NaN colors', () => {
+    // Third-party OFF only -- our own compiler never writes this. Before the
+    // guard, `.map(Number)` made these NaN and the viewer built a color
+    // attribute full of NaN, which reaches the GPU as garbage.
+    const poly = parseOff(twoFaces('3 0 1 2 foo bar baz', '3 0 1 3'));
+    expect(poly.hasSourceColors).toBe(false);
+    expect(poly.colors).toEqual([DEFAULT_FACE_COLOR]);
+    expect(poly.colors.flat().some(Number.isNaN)).toBe(false);
+  });
+
   it('reads a color suffix on a triangulated quad face', () => {
     const poly = parseOff(`OFF 4 1 0\n${TRI_VERTS}\n4 0 1 2 3 0 128 0\n`);
     expect(poly.faces).toHaveLength(2); // fan-triangulated

--- a/src/io/__tests__/import_off.test.ts
+++ b/src/io/__tests__/import_off.test.ts
@@ -94,14 +94,28 @@ describe('parseOff face colors', () => {
     expect(poly.colors).toHaveLength(2);
   });
 
-  it('ignores a non-numeric trailing field instead of emitting NaN colors', () => {
-    // Third-party OFF only -- our own compiler never writes this. Before the
-    // guard, `.map(Number)` made these NaN and the viewer built a color
-    // attribute full of NaN, which reaches the GPU as garbage.
+  it('ignores non-numeric color fields instead of emitting NaN colors', () => {
+    // Third-party OFF only -- our own compiler never writes this. Unguarded,
+    // `.map(Number)` made these NaN and the viewer built a color attribute full
+    // of NaN, which reaches the GPU as garbage.
     const poly = parseOff(twoFaces('3 0 1 2 foo bar baz', '3 0 1 3'));
     expect(poly.hasSourceColors).toBe(false);
     expect(poly.colors).toEqual([DEFAULT_FACE_COLOR]);
-    expect(poly.colors.flat().some(Number.isNaN)).toBe(false);
+    expect(poly.colors.flat().every(Number.isFinite)).toBe(true);
+  });
+
+  it('rejects a non-finite color channel, which isNaN alone would let through', () => {
+    const poly = parseOff(twoFaces('3 0 1 2 1e999 0 0', '3 0 1 3'));
+    expect(poly.hasSourceColors).toBe(false);
+    expect(poly.colors.flat().every(Number.isFinite)).toBe(true);
+  });
+
+  it('keeps an RGB triple whose 4th field is not a number (trailing comment)', () => {
+    // Judging alpha separately keeps the color; an all-or-nothing check over
+    // four fields would drop a valid green here and render cameo yellow.
+    const poly = parseOff(twoFaces('3 0 1 2 0 128 0 # green', '3 0 1 3 0 128 0'));
+    expect(poly.hasSourceColors).toBe(true);
+    expect(poly.colors).toEqual([[0, 128 / 255, 0, 1]]);
   });
 
   it('reads a color suffix on a triangulated quad face', () => {

--- a/src/io/__tests__/import_off.test.ts
+++ b/src/io/__tests__/import_off.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from 'vitest';
 
+import { DEFAULT_FACE_COLOR } from '../common.ts';
 import { parseOff } from '../import_off.ts';
 
 // A unit cube: 8 vertices, 6 quad faces (each fan-triangulated to 2 triangles).
@@ -47,5 +48,56 @@ describe('parseOff', () => {
   it('rejects a missing header and malformed counts', () => {
     expect(() => parseOff('8 6 12\n0 0 0\n')).toThrow(/missing OFF header/);
     expect(() => parseOff('OFF\nnot counts\n')).toThrow(/invalid vertex or face counts/);
+  });
+});
+
+// Face colors as OpenSCAD's Manifold backend actually emits them: an RGB (or
+// RGBA, for `color(c, alpha)`) suffix on the face line, 0-255 per channel. The
+// CGAL backend emits no suffix at all.
+const TRI_VERTS = ['0 0 0', '1 0 0', '0 1 0', '0 0 1'].join('\n');
+const twoFaces = (a: string, b: string) => `OFF 4 2 0\n${TRI_VERTS}\n${a}\n${b}\n`;
+
+describe('parseOff face colors', () => {
+  it('reads an RGB face color and normalizes it to 0..1', () => {
+    const poly = parseOff(twoFaces('3 0 1 2 0 128 0', '3 0 1 3 0 0 255'));
+    expect(poly.hasSourceColors).toBe(true);
+    expect(poly.colors).toEqual([
+      [0, 128 / 255, 0, 1],
+      [0, 0, 1, 1],
+    ]);
+    expect(poly.faces.map((f) => f.colorIndex)).toEqual([0, 1]);
+  });
+
+  it('carries the alpha channel of an RGBA face color', () => {
+    const poly = parseOff(twoFaces('3 0 1 2 0 128 0 127', '3 0 1 3 0 0 255'));
+    expect(poly.colors[0]).toEqual([0, 128 / 255, 0, 127 / 255]);
+    expect(poly.colors[1]).toEqual([0, 0, 1, 1]);
+  });
+
+  it('flags a model whose faces are all ONE explicit color (#258 regression)', () => {
+    // The viewer used to gate per-vertex colors on `colors.length > 1`, so a
+    // model with a single `color()` fell back to the default cameo yellow.
+    const poly = parseOff(twoFaces('3 0 1 2 0 128 0', '3 0 1 3 0 128 0'));
+    expect(poly.colors).toHaveLength(1);
+    expect(poly.hasSourceColors).toBe(true);
+  });
+
+  it('does not flag a colorless model, and defaults its faces', () => {
+    const poly = parseOff(twoFaces('3 0 1 2', '3 0 1 3'));
+    expect(poly.hasSourceColors).toBe(false);
+    expect(poly.colors).toEqual([DEFAULT_FACE_COLOR]);
+  });
+
+  it('flags a partly-colored model (OpenSCAD fills the rest with its default)', () => {
+    const poly = parseOff(twoFaces('3 0 1 2 0 128 0', '3 0 1 3 249 215 44'));
+    expect(poly.hasSourceColors).toBe(true);
+    expect(poly.colors).toHaveLength(2);
+  });
+
+  it('reads a color suffix on a triangulated quad face', () => {
+    const poly = parseOff(`OFF 4 1 0\n${TRI_VERTS}\n4 0 1 2 3 0 128 0\n`);
+    expect(poly.faces).toHaveLength(2); // fan-triangulated
+    expect(poly.hasSourceColors).toBe(true);
+    expect(poly.faces.every((f) => f.colorIndex === 0)).toBe(true);
   });
 });

--- a/src/io/common.ts
+++ b/src/io/common.ts
@@ -4,6 +4,10 @@ export type Vertex = {
   z: number;
 };
 
+/** Face color as sRGB + alpha, each channel normalized to 0..1.
+ *  sRGB is the space OFF face colors and 3MF `displaycolor` are written in;
+ *  converting to Three.js' linear working space happens at the renderer
+ *  boundary (see `off-loader.ts`), not here. */
 export type Color = [number, number, number, number];
 
 export type Face = {
@@ -15,6 +19,14 @@ export type IndexedPolyhedron = {
   vertices: Vertex[];
   faces: Face[];
   colors: Color[];
+  /**
+   * True when at least one face in the source carried an explicit color, i.e.
+   * the model used `color()`. `colors` is never empty — a face with no color
+   * gets `DEFAULT_FACE_COLOR`, and `export_3mf.ts` relies on that entry existing
+   * — so `colors.length` cannot answer this: a model that is entirely one
+   * `color()` yields exactly one entry, indistinguishable from a colorless one.
+   */
+  hasSourceColors: boolean;
 };
 
 export const DEFAULT_FACE_COLOR: Color = [0xf9 / 255, 0xd7 / 255, 0x2c / 255, 1];

--- a/src/io/export_glb.ts
+++ b/src/io/export_glb.ts
@@ -15,20 +15,24 @@ import { offToBufferGeometry } from '../components/viewer/off-loader.ts';
 /**
  * Serialize a parsed OFF polyhedron to a binary glTF (.glb) byte array.
  *
- * Colors: a multi-color model carries per-vertex colors (the geometry's `color`
- * attribute); a single-color model has none, so the material's base color is set
- * from the model's one face color. The geometry is rotated −90° about X so the
+ * Colors: a model that used `color()` carries per-vertex colors (the geometry's
+ * `color` attribute, already converted to linear by the shared OFF loader); a
+ * colorless model has none, so the material's base color is set from the OFF
+ * loader's default face color. The geometry is rotated −90° about X so the
  * OpenSCAD Z-up model becomes glTF's Y-up convention, i.e. it stands upright in
  * standard glTF viewers (Blender, model-viewer, three.js loaders).
  */
 export async function exportGLB(data: IndexedPolyhedron): Promise<ArrayBuffer> {
   const geometry = offToBufferGeometry(data);
-  const hasMultiColor = data.colors.length > 1;
+  const { hasSourceColors } = data;
 
   const [r, g, b] = data.colors[0] ?? DEFAULT_FACE_COLOR;
   const material = new THREE.MeshStandardMaterial({
-    vertexColors: hasMultiColor,
-    color: hasMultiColor ? 0xffffff : new THREE.Color(r, g, b),
+    vertexColors: hasSourceColors,
+    // glTF's baseColorFactor is linear, and so is Three.js' working space, so
+    // the sRGB face color has to be converted — `new THREE.Color(r, g, b)`
+    // would take these as linear values and skew the exported color.
+    color: hasSourceColors ? 0xffffff : new THREE.Color().setRGB(r, g, b, THREE.SRGBColorSpace),
     metalness: 0,
     roughness: 1,
     side: THREE.DoubleSide,

--- a/src/io/import_off.ts
+++ b/src/io/import_off.ts
@@ -50,15 +50,25 @@ export function parseOff(content: string): IndexedPolyhedron {
     // A face line may carry a trailing color: RGB (numVerts + 4 fields) or
     // RGBA (numVerts + 5). OpenSCAD's Manifold backend emits RGB for `color(c)`
     // and RGBA for `color(c, alpha)`; the CGAL backend emits none.
-    // Non-numeric trailing fields are ignored rather than trusted: `.map(Number)`
-    // turns them into NaN, and a NaN color attribute reaches the GPU as garbage.
-    // Vertex lines are already validated this way below. Float 0..1 colors,
-    // which the OFF spec also permits, are still read as 0-255 (#287).
-    const channels = parts.slice(numVerts + 1, numVerts + 5);
-    const hasFaceColor = parts.length >= numVerts + 4 && !channels.some(isNaN);
+    // Only finite channels are trusted: `.map(Number)` turns a trailing comment
+    // or junk into NaN and `1e999` into Infinity, either of which would reach the
+    // GPU as a broken color attribute. Vertex lines are validated the same way
+    // below. Float 0..1 colors, which the OFF spec also permits, are still read
+    // as 0-255 (#287).
+    const rgb = parts.slice(numVerts + 1, numVerts + 4);
+    const hasFaceColor = rgb.length === 3 && rgb.every(Number.isFinite);
     if (hasFaceColor) hasSourceColors = true;
+    // Alpha is judged separately so a non-numeric 4th field (e.g. a Geomview
+    // trailing comment after an RGB triple) means "no alpha" rather than
+    // discarding an otherwise valid color.
+    const alpha = parts[numVerts + 4];
     const color = hasFaceColor
-      ? (channels.map((c) => c / 255) as [number, number, number, number])
+      ? ([...rgb, Number.isFinite(alpha) ? alpha : 255].map((c) => c / 255) as [
+          number,
+          number,
+          number,
+          number,
+        ])
       : DEFAULT_FACE_COLOR;
     if (vertices.length < 3)
       throw new Error(

--- a/src/io/import_off.ts
+++ b/src/io/import_off.ts
@@ -40,21 +40,26 @@ export function parseOff(content: string): IndexedPolyhedron {
 
   const colors: Color[] = [];
   const colorMap = new Map<string, number>();
+  let hasSourceColors = false;
 
   const faces: Face[] = [];
   for (let i = 0; i < numFaces; i++) {
     const parts = lines[currentLine + i].split(/\s+/).map(Number);
     const numVerts = parts[0];
     const vertices = parts.slice(1, numVerts + 1);
-    const color =
-      parts.length >= numVerts + 4
-        ? (parts.slice(numVerts + 1, numVerts + 5).map((c) => c / 255) as [
-            number,
-            number,
-            number,
-            number,
-          ])
-        : DEFAULT_FACE_COLOR;
+    // A face line may carry a trailing color: RGB (numVerts + 4 fields) or
+    // RGBA (numVerts + 5). OpenSCAD's Manifold backend emits RGB for `color(c)`
+    // and RGBA for `color(c, alpha)`; the CGAL backend emits none.
+    const hasFaceColor = parts.length >= numVerts + 4;
+    if (hasFaceColor) hasSourceColors = true;
+    const color = hasFaceColor
+      ? (parts.slice(numVerts + 1, numVerts + 5).map((c) => c / 255) as [
+          number,
+          number,
+          number,
+          number,
+        ])
+      : DEFAULT_FACE_COLOR;
     if (vertices.length < 3)
       throw new Error(
         `Invalid OFF file: face at line ${currentLine + i + 1} must have at least 3 vertices`,
@@ -85,5 +90,5 @@ export function parseOff(content: string): IndexedPolyhedron {
     }
   }
 
-  return { vertices, faces, colors };
+  return { vertices, faces, colors, hasSourceColors };
 }

--- a/src/io/import_off.ts
+++ b/src/io/import_off.ts
@@ -50,15 +50,15 @@ export function parseOff(content: string): IndexedPolyhedron {
     // A face line may carry a trailing color: RGB (numVerts + 4 fields) or
     // RGBA (numVerts + 5). OpenSCAD's Manifold backend emits RGB for `color(c)`
     // and RGBA for `color(c, alpha)`; the CGAL backend emits none.
-    const hasFaceColor = parts.length >= numVerts + 4;
+    // Non-numeric trailing fields are ignored rather than trusted: `.map(Number)`
+    // turns them into NaN, and a NaN color attribute reaches the GPU as garbage.
+    // Vertex lines are already validated this way below. Float 0..1 colors,
+    // which the OFF spec also permits, are still read as 0-255 (#287).
+    const channels = parts.slice(numVerts + 1, numVerts + 5);
+    const hasFaceColor = parts.length >= numVerts + 4 && !channels.some(isNaN);
     if (hasFaceColor) hasSourceColors = true;
     const color = hasFaceColor
-      ? (parts.slice(numVerts + 1, numVerts + 5).map((c) => c / 255) as [
-          number,
-          number,
-          number,
-          number,
-        ])
+      ? (channels.map((c) => c / 255) as [number, number, number, number])
       : DEFAULT_FACE_COLOR;
     if (vertices.length < 3)
       throw new Error(

--- a/tests/e2e.spec.ts
+++ b/tests/e2e.spec.ts
@@ -473,15 +473,18 @@ test.describe('e2e', () => {
   // reliably (`preserveDrawingBuffer` is off) and which varies with headless GL.
   async function readModelMaterial(page: Page) {
     return page.evaluate(() => {
+      type ColorAttribute = {
+        getX(i: number): number;
+        getY(i: number): number;
+        getZ(i: number): number;
+      };
+      type ModelMesh = {
+        material?: { vertexColors?: boolean };
+        geometry?: { getAttribute(name: string): ColorAttribute | undefined };
+      };
       const viewer = document.querySelector('osc-geometry-viewer') as
-        | (Element & {
-            offText?: string | null;
-            _scene?: { modelMesh?: { material?: { vertexColors?: boolean } } };
-          })
-        | null;
-      const geometry = viewer?._scene?.modelMesh?.geometry as
-        { getAttribute(name: string): { getX(i: number): number } | undefined } | undefined;
-      const color = geometry?.getAttribute('color');
+        (Element & { offText?: string | null; _scene?: { modelMesh?: ModelMesh } }) | null;
+      const color = viewer?._scene?.modelMesh?.geometry?.getAttribute('color');
       return {
         offText: viewer?.offText ?? '',
         vertexColors: Boolean(viewer?._scene?.modelMesh?.material?.vertexColors),
@@ -496,7 +499,7 @@ test.describe('e2e', () => {
    * 0-255 channels when the face carries a color. Face arity is not fixed — the
    * app enables `lazy-union`, under which the compiler emits quads.
    */
-  function offFaceColors(offText: string): string[] {
+  function offFaceLines(offText: string): string[] {
     const lines = offText
       .split('\n')
       .map((line) => line.trim())
@@ -505,10 +508,18 @@ test.describe('e2e', () => {
     const counts = sameLineHeader ? lines[0].slice(3).trim() : lines[1];
     const [vertexCount, faceCount] = counts.split(/\s+/).map(Number);
     const firstFace = (sameLineHeader ? 1 : 2) + vertexCount;
-    return lines.slice(firstFace, firstFace + faceCount).flatMap((line) => {
+    return lines.slice(firstFace, firstFace + faceCount);
+  }
+
+  const offFaceCount = (offText: string) => offFaceLines(offText).length;
+
+  function offFaceColors(offText: string): string[] {
+    return offFaceLines(offText).flatMap((line) => {
       const parts = line.split(/\s+/);
       const arity = Number(parts[0]);
-      return parts.length >= arity + 4 ? [parts.slice(arity + 1).join(',')] : [];
+      // Take exactly the channels parseOff would take, so a 5th trailing field
+      // shows up as a mismatch here rather than being quietly folded in.
+      return parts.length >= arity + 4 ? [parts.slice(arity + 1, arity + 5).join(',')] : [];
     });
   }
 
@@ -548,6 +559,9 @@ test.describe('e2e', () => {
     await waitForViewer(page);
 
     const { offText, vertexColors, firstColor } = await readModelMaterial(page);
+    // Assert the OFF was actually parsed before asserting the absence of color,
+    // otherwise a helper that silently stopped parsing would satisfy this for free.
+    expect(offFaceCount(offText)).toBeGreaterThan(0);
     expect(offFaceColors(offText)).toHaveLength(0);
     expect(vertexColors).toBe(false);
     expect(firstColor).toBeNull();

--- a/tests/e2e.spec.ts
+++ b/tests/e2e.spec.ts
@@ -466,6 +466,93 @@ test.describe('e2e', () => {
     await expectValidOffOutput(page);
   });
 
+  // #258: `color()` reaches the viewer as a per-face RGB suffix on the OFF the
+  // WASM compiler emits (Manifold backend only). These assert both halves — that
+  // the compiler emits it, and that the viewer builds a per-vertex-colored mesh
+  // from it — rather than sampling pixels, which the renderer cannot read back
+  // reliably (`preserveDrawingBuffer` is off) and which varies with headless GL.
+  async function readModelMaterial(page: Page) {
+    return page.evaluate(() => {
+      const viewer = document.querySelector('osc-geometry-viewer') as
+        | (Element & {
+            offText?: string | null;
+            _scene?: { modelMesh?: { material?: { vertexColors?: boolean } } };
+          })
+        | null;
+      const geometry = viewer?._scene?.modelMesh?.geometry as
+        { getAttribute(name: string): { getX(i: number): number } | undefined } | undefined;
+      const color = geometry?.getAttribute('color');
+      return {
+        offText: viewer?.offText ?? '',
+        vertexColors: Boolean(viewer?._scene?.modelMesh?.material?.vertexColors),
+        firstColor: color ? [color.getX(0), color.getY(0), color.getZ(0)] : null,
+      };
+    });
+  }
+
+  /**
+   * The color suffix of each colored face in an OFF, as OpenSCAD writes it: a
+   * face line is `<n> <i0> … <in-1>`, followed by 3 (RGB) or 4 (RGBA) trailing
+   * 0-255 channels when the face carries a color. Face arity is not fixed — the
+   * app enables `lazy-union`, under which the compiler emits quads.
+   */
+  function offFaceColors(offText: string): string[] {
+    const lines = offText
+      .split('\n')
+      .map((line) => line.trim())
+      .filter((line) => line !== '' && !line.startsWith('#'));
+    const sameLineHeader = /^OFF\s+\S/.test(lines[0]);
+    const counts = sameLineHeader ? lines[0].slice(3).trim() : lines[1];
+    const [vertexCount, faceCount] = counts.split(/\s+/).map(Number);
+    const firstFace = (sameLineHeader ? 1 : 2) + vertexCount;
+    return lines.slice(firstFace, firstFace + faceCount).flatMap((line) => {
+      const parts = line.split(/\s+/);
+      const arity = Number(parts[0]);
+      return parts.length >= arity + 4 ? [parts.slice(arity + 1).join(',')] : [];
+    });
+  }
+
+  test('a single color() model renders in that color, not the default (#258)', async ({ page }) => {
+    await loadSrc(page, 'color("green") cube(10);');
+    await waitForViewer(page);
+
+    const { offText, vertexColors, firstColor } = await readModelMaterial(page);
+    // The compiler must emit the color in the first place. CSS "green" is
+    // sRGB(0, 128, 0); the CGAL backend would emit no suffix at all.
+    expect(new Set(offFaceColors(offText))).toEqual(new Set(['0,128,0']));
+    // And the viewer must use it. Before #258 a one-color model failed the
+    // `colors.length > 1` gate here and fell back to the cameo-yellow material.
+    expect(vertexColors).toBe(true);
+    // sRGB "green" (0,128,0) converted into the renderer's linear space: green
+    // channel well above zero, red and blue at zero. Unconverted sRGB would put
+    // green at ~0.50 rather than ~0.22.
+    expect(firstColor).not.toBeNull();
+    const [r, g, b] = firstColor!;
+    expect(r).toBeCloseTo(0, 4);
+    expect(b).toBeCloseTo(0, 4);
+    expect(g).toBeGreaterThan(0.15);
+    expect(g).toBeLessThan(0.3);
+  });
+
+  test('a multi-color model keeps every color() (#258)', async ({ page }) => {
+    await loadSrc(page, 'color("green") cube(10);\ncolor("blue") translate([12,0,0]) cube(10);');
+    await waitForViewer(page);
+
+    const { vertexColors, offText } = await readModelMaterial(page);
+    expect(vertexColors).toBe(true);
+    expect(new Set(offFaceColors(offText))).toEqual(new Set(['0,128,0', '0,0,255']));
+  });
+
+  test('a colorless model still uses the single default material (#258)', async ({ page }) => {
+    await loadSrc(page, 'cube(10);');
+    await waitForViewer(page);
+
+    const { offText, vertexColors, firstColor } = await readModelMaterial(page);
+    expect(offFaceColors(offText)).toHaveLength(0);
+    expect(vertexColors).toBe(false);
+    expect(firstColor).toBeNull();
+  });
+
   test('use BOSL2', async ({ page }) => {
     await loadSrc(
       page,


### PR DESCRIPTION
Closes #258.

## What was wrong

The issue was filed on the premise that `color()` is preview-only, that OFF carries no color, and that colored 3MF from the 2025 WASM was the way in. All three turned out to be false — [full correction on #258](https://github.com/CameronBrooks11/openscad-web/issues/258#issuecomment-5434057941). The short version:

- OpenSCAD's **Manifold** backend already writes a per-face RGB(A) suffix into OFF, and the compile surfaces already run that backend. CGAL does not, which is where "colors are lost" came from.
- The shipped WASM has **no 3MF export compiled in at all** (`Export to 3MF format was not enabled when building the application`), so that route was blocked anyway — and would have bought nothing, since `color()` is an RGBA on a subtree, exactly what OFF carries.

So no new format, no protocol change, no viewer-bundle growth. Three real defects:

1. **Single-color models rendered yellow.** `off-loader.ts` gated the color attribute on `colors.length > 1`. One `color()` produces one distinct color, so the gate failed and the mesh fell back to the cameo-yellow default. `export_glb.ts` had the same predicate.
2. **The vertex-color path was not color-managed.** Three.js converts `material.color` from sRGB but reads a `color` attribute as already linear, so colored geometry rendered visibly paler than the same color as a material.
3. **The static tier never asked for Manifold.** `render-geometry.mjs` ran plain `openscad -o x.off`, and CGAL is still the CLI default — so every static mount was colorless regardless of the binary. This is the half the iLOX embeds actually hit.

## What changed

**Viewer** — `parseOff` records whether the source declared any color, and both the loader and the GLB exporter read that instead of each re-deriving `colors.length > 1` wrongly. `colors.length` can't answer the question: `parseOff` fabricates a `DEFAULT_FACE_COLOR` entry for uncolored faces, and `export_3mf.ts` depends on that entry existing. Face colors are converted sRGB to linear at the Three.js boundary; `IndexedPolyhedron.colors` stays sRGB, which is what OFF and 3MF speak.

**Static tier** — `render-geometry.mjs` renders OFF on Manifold. The flag can't be passed unconditionally: `--backend` needs OpenSCAD 2025.03+, and `apt-get install -y openscad` on GitHub's ubuntu runners still gives 2021.01, which rejects it (exit 1). So it probes `--help` for the flag rather than parsing a version, and falls back with a warning on stderr so a stale toolchain explains itself.

## Verification

`color("green") cube(10)` in the live embed, before → after: cameo yellow → CSS green.

Color-management parity, same cube, same `#f9d72c`, same camera:

```
                    before              after
material path   rgb(163,140,25)    rgb(163,140,25)
vertex   path   rgb(166,155,73)    rgb(163,140,25)   <- now pixel-identical
```

The OFF color path had **no test coverage at all**. Added parser cases, loader gating, an independent sRGB-conversion check (the transfer function written out rather than restating the Three.js call), arg-builder and capability-probe tests, and E2E tests that assert both halves against the real vendored WASM — that the compiler emits the color, and that the viewer consumes it.

I checked these actually catch the bug rather than just passing: reverting the gate alone fails the single-color E2E; reverting the sRGB conversion alone fails 2 unit tests *and* the E2E.

`npm run verify` exits 0. `test:e2e` 45 passed / 4 skipped, `test:e2e:publish` 3, `test:e2e:session` 1.

## Behavior change worth flagging

A model declaring any `color()` now shows those colors in place of a host-supplied `color` setting. That already matched multi-color behavior; single-color models used to honor the host override.

Multi-color embeds that already rendered will look **more saturated** after the color-management fix. That is the correction — they now match their posters — but it is a visible change to already-published sites.

## Not in scope

- #282 — `color(c, alpha)` renders opaque. Alpha is parsed and kept in the data model, then dropped by the loader and the opaque material; correct translucency needs depth sorting.
- #283 — switching to the CGAL backend silently drops colors.

## Native CLI verified

Confirmed against a real native binary (OpenSCAD **2026.08.19** AppImage), driven through the changed script rather than by hand:

```
$ OPENSCAD=~/Applications/openscad/OpenSCAD-nightly.AppImage \
    node scripts/render-geometry.mjs --source two.scad --out-dir out --no-poster
  vertices=16 faces=24
  0,128,0: 12 faces
  0,0,255: 12 faces

$ node scripts/render-geometry.mjs --source two.scad --out-dir out --no-poster   # apt 2021.01
openscad does not support --backend, so OFF geometry will carry no color() data [...]
  face lines: "3 0 1 2"   <- no suffix, as expected
```

Both outputs then through the real parser + loader:

```
native 2026.08.19    hasSourceColors=true   colors=2   colorAttr=true
apt 2021.01          hasSourceColors=false  colors=1   colorAttr=false
```

So the native build behaves like the vendored WASM (Manifold is compiled into both), the capability probe reads a real `--help` correctly, and the fallback degrades exactly as intended.
