### PR TITLE
fix(export): write 3MF displaycolor in sRGB, not scaled-down near-black

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,13 @@ release (changelog upkeep and tagging had lapsed between `0.1.0` and `0.2.0`).
   A model that declares any `color()` now shows those colors in place of a
   host-supplied `color` setting, matching how multi-color models already behaved.
 
+- **3MF export wrote every base material near-black** (#285): `displaycolor` was
+  built by passing `Color`'s normalized 0..1 components straight to
+  `chroma.rgb()`, which expects 0..255, so green became `#000100`. The
+  extruder-matching path in the same file scaled correctly, so the file held two
+  conventions at once; both now share one conversion. Pre-existing, but only
+  reachable in practice once `color()` started rendering.
+
 ### Changed
 
 - `scripts/render-geometry.mjs` now renders OFF on the Manifold backend, so the

--- a/src/__tests__/export-3mf.test.ts
+++ b/src/__tests__/export-3mf.test.ts
@@ -23,6 +23,47 @@ describe('export3MF', () => {
       reader.readAsArrayBuffer(blob);
     });
 
+  const readModelXml = async (data: IndexedPolyhedron = sampleData) => {
+    const zip = UZIP.parse(await readBlobAsArrayBuffer(export3MF(data))) as Record<
+      string,
+      Uint8Array
+    >;
+    return new TextDecoder().decode(zip['3D/3dmodel.model']);
+  };
+
+  it('writes each base material in sRGB, not scaled-down near-black (#285)', async () => {
+    // `Color` is 0..1 per channel and chroma.rgb wants 0..255, so passing the
+    // components straight through turned green (0, 128, 0) into #000100 and made
+    // every material in every export indistinguishably dark.
+    const green: [number, number, number, number] = [0, 128 / 255, 0, 1];
+    const xml = await readModelXml({ ...sampleData, colors: [green] });
+
+    expect(xml).toContain('displaycolor="#008000"');
+    expect(xml).not.toContain('displaycolor="#000100"');
+  });
+
+  it('keeps displaycolor 6-digit for a translucent color', async () => {
+    // chroma emits #RRGGBBAA once alpha < 1. Alpha was always clamped away here
+    // before, so holding the format steady keeps slicers reading what they did.
+    const halfGreen: [number, number, number, number] = [0, 128 / 255, 0, 0.5];
+    const xml = await readModelXml({ ...sampleData, colors: [halfGreen] });
+
+    expect(xml).toContain('displaycolor="#008000"');
+  });
+
+  it('writes one base material per distinct color', async () => {
+    const xml = await readModelXml({
+      ...sampleData,
+      colors: [
+        [0, 128 / 255, 0, 1],
+        [0, 0, 1, 1],
+      ],
+    });
+
+    expect(xml).toContain('displaycolor="#008000"');
+    expect(xml).toContain('displaycolor="#0000ff"');
+  });
+
   it('writes a valid build UUID attribute (no stray brace)', async () => {
     const blob = export3MF(sampleData);
     const zip = UZIP.parse(await readBlobAsArrayBuffer(blob)) as Record<string, Uint8Array>;

--- a/src/io/export_3mf.ts
+++ b/src/io/export_3mf.ts
@@ -1,5 +1,5 @@
 import UZIP from 'uzip';
-import { IndexedPolyhedron } from './common';
+import { Color, IndexedPolyhedron } from './common';
 import { v4 as uuidv4 } from 'uuid';
 import chroma from 'chroma-js';
 
@@ -45,13 +45,21 @@ const PAINT_COLOR_MAP = [
   'DC',
 ];
 
+/**
+ * `Color` is normalized 0..1 per channel; chroma wants RGB in 0..255 and alpha
+ * in 0..1. Both conversions live here so the two call sites below cannot drift —
+ * they previously disagreed, and the one feeding `displaycolor` passed 0..1
+ * straight through, turning every base material near-black (#285).
+ */
+function toChroma([r, g, b, a]: Color): chroma.Color {
+  return chroma.rgb(r * 255, g * 255, b * 255, a);
+}
+
 export function export3MF(data: IndexedPolyhedron, extruderColors?: chroma.Color[]): Blob {
   const objectUuid = uuidv4();
   const buildUuid = uuidv4();
 
-  const dataColors = data.colors.map(([r, g, b, a]) =>
-    chroma.rgb(r * 255, g * 255, b * 255, a * 255),
-  );
+  const dataColors = data.colors.map(toChroma);
   const extruderIndexByColorIndex = extruderColors && getColorMapping(dataColors, extruderColors);
 
   const paintColorByColorIndex = extruderIndexByColorIndex?.map((i) => PAINT_COLOR_MAP[i]);
@@ -67,7 +75,10 @@ export function export3MF(data: IndexedPolyhedron, extruderColors?: chroma.Color
         '<resources>',
         '<basematerials id="2">',
         ...data.colors.map(
-          (color, i) => `<base name="color_${i}" displaycolor="${chroma.rgb(...color).hex()}"/>`,
+          // `hex('rgb')` keeps this 6-digit. Alpha was always clamped away here
+          // before, so a translucent model must not silently start emitting
+          // #RRGGBBAA that a slicer may not expect (see #282 for alpha).
+          (color, i) => `<base name="color_${i}" displaycolor="${toChroma(color).hex('rgb')}"/>`,
         ),
         '</basematerials>',
         `<object id="1" name="OpenSCAD Model" type="model" p:UUID="${objectUuid}" pid="2" pindex="0">`,


### PR DESCRIPTION
Closes #285. Found during the adversarial review of #284.

## What

`src/io/export_3mf.ts` built each base material's `displaycolor` by passing `Color`'s normalized 0..1 components straight to `chroma.rgb()`, which expects 0..255:

```
as written  chroma.rgb(0, 128/255, 0).hex()  ->  #000100
correct     chroma.rgb(0, 128, 0).hex()      ->  #008000
```

So every material in every 3MF export came out near-black and mutually indistinguishable. The per-triangle `pid`/`p1` grouping was always correct — only the displayed color was wrong.

That this is a bug and not a unit choice is settled by the extruder-matching path four lines above, which scales correctly. The file held both conventions at once; they now share one conversion.

## Alpha

The shared helper also corrects the alpha units on the matching path: chroma takes alpha in 0..1, and `a * 255` clamped every color to opaque. Harmless there — only `.lab()` is read, which ignores alpha — but wrong, and it would have bitten the next caller.

`displaycolor` stays **6-digit** via `hex('rgb')`. chroma emits `#RRGGBBAA` once alpha < 1, and alpha was always clamped away here before, so holding the format steady keeps slicers reading what they already read. Whether 3MF export should carry alpha at all is #282's call.

## Why now

Pre-existing, but #284 is what makes it commonly reachable — before it, colored models mostly did not render, so they were rarely exported. This lands ahead of the v0.7.0 release so the release does not ship "colors work now" alongside a color bug.

## Tests

`export-3mf.test.ts` previously asserted only the build UUID and console silence — nothing read `displaycolor`. Three tests added (sRGB value, 6-digit format under alpha, one material per distinct color); all three fail against the old expression.

`npm run verify` exits 0.