### PR TITLE
chore(release): 0.7.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@ release (changelog upkeep and tagging had lapsed between `0.1.0` and `0.2.0`).
 
 ## [Unreleased]
 
+## [0.7.0] - 2026-08-27
+
+Models now render in their own `color()` across every viewer surface, and the
+`static` publish path preserves those colors end to end. See #258.
+
 ### Fixed
 
 - **Colored geometry in embedded viewers** (#258): a model using `color()`

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "openscad-web",
-  "version": "0.6.0",
+  "version": "0.7.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "openscad-web",
-      "version": "0.6.0",
+      "version": "0.7.0",
       "dependencies": {
         "@monaco-editor/loader": "^1.4.0",
         "blurhash": "^2.0.5",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "openscad-web",
-  "version": "0.6.0",
+  "version": "0.7.0",
   "private": true,
   "type": "module",
   "homepage": "https://cameronbrooks11.github.io/openscad-web/",


### PR DESCRIPTION
Minor release. Version bump + changelog only.

## What ships

**#258 / #284 — colored geometry in embedded viewers.** A model using `color()` rendered in the viewer's default cameo yellow. OFF already carried the colors (OpenSCAD's Manifold backend writes a per-face RGB(A) suffix, and the compile surfaces already ran that backend); the viewer gated per-vertex colors on *more than one* distinct color, so a single `color()` fell back to the default material, and face colors were fed to Three.js unconverted, so colored geometry rendered washed out. Both fixed; the static publish path now renders geometry **and** poster on the Manifold backend so `color()` survives there too.

**#285 / #288 — 3MF displaycolor.** Every base material was written near-black (0..1 components passed to `chroma.rgb()`, which wants 0..255). Pre-existing, but only reachable in practice once `color()` started rendering — so it lands in the same release rather than chasing it with a 0.7.1.

## Why minor, not patch

Two things beyond a bugfix:

- **Behavior change for embedders**: a model declaring any `color()` now shows those colors in place of a host-supplied `color` setting (`setViewerSettings { color }`, embed `?color=`). That already matched how multi-color models behaved; single-color models used to honor the host value. Documented in `docs/EMBEDDING-VSCODE.md`.
- **Publish output changes shape**: posters now render on the same backend as the geometry, so the two can no longer disagree.

Multi-color embeds that already rendered will look **more saturated** after the color-management fix — that is the correction (they now match their posters), but it is a visible change to already-published sites.

## After merge

Tag `v0.7.0`. `release.yml` publishes `openscad-web-publish.zip` and force-moves the `v0` alias, so consumers pinned at `@v0` pick it up on their next build.

That unblocks the openscad-web half of iLOX#16; their side still needs a 2025.03+ OpenSCAD CLI, since `apt-get install openscad` on the ubuntu runners is 2021.01 and emits no color at all.

`npm run verify` exits 0; viewer and session manifests stamp v0.7.0.