### PR TITLE
ci: type-check the Playwright specs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -70,7 +70,11 @@ jobs:
         run: npm run build:libs
 
       - name: Type check
-        run: npx tsc --noEmit
+        # Deliberately the npm script, not an inlined `tsc` call: it covers both
+        # the src program and tsconfig.tests.json. Inlining one of them here is
+        # how tests/ went unchecked in CI even after the script grew a second
+        # program (#286).
+        run: npm run typecheck
 
       - name: Build app
         run: npm run build

--- a/package.json
+++ b/package.json
@@ -47,7 +47,7 @@
     "build:libs:libraries": "cross-env LIBS_BUILD_MODE=libs node ./scripts/build-assets/cli.mjs",
     "build:all": "npm run build:libs && npm run build",
     "lint": "eslint .",
-    "typecheck": "npx tsc --noEmit",
+    "typecheck": "npx tsc --noEmit && npx tsc -p tsconfig.tests.json",
     "format": "prettier --write .",
     "format:check": "prettier --check .",
     "perf:capture": "node scripts/perf/capture-baseline.mjs",

--- a/scripts/__tests__/tests-typecheck-program.test.mjs
+++ b/scripts/__tests__/tests-typecheck-program.test.mjs
@@ -1,0 +1,96 @@
+// @vitest-environment node
+
+import { execFileSync } from 'node:child_process';
+import { readdirSync, readFileSync } from 'node:fs';
+import path from 'node:path';
+
+import { describe, expect, it } from 'vitest';
+
+// Guards #286: tests/ was outside every type-check program for the life of the
+// repo, so a type-broken spec could not fail any gate.
+//
+// This asserts on the PROGRAM tsc actually builds, not on the text of
+// tsconfig.tests.json. Checking the config text is what an earlier version of
+// this guard did, and it was bypassable three ways: adding an `exclude`
+// silently removed the three largest specs while every text assertion still
+// passed; narrowing `include`; or splitting the typecheck script into two
+// sub-scripts, which is behaviour-preserving but fails a substring match.
+// Asking tsc what it is checking is immune to all of them.
+
+const repoRoot = path.resolve(import.meta.dirname, '..', '..');
+
+const SKIP_DIRS = new Set([
+  'node_modules',
+  '.git',
+  'coverage',
+  'libs',
+  'public',
+  'dist',
+  'dist-viewer',
+  'dist-session',
+  'dist-publish',
+  'playwright-report',
+  'test-results',
+]);
+
+/** Every `*.spec.ts` anywhere in the repo, repo-relative. */
+function findSpecs(dir = repoRoot) {
+  return readdirSync(dir, { withFileTypes: true }).flatMap((entry) => {
+    const full = path.join(dir, entry.name);
+    if (entry.isDirectory()) {
+      return SKIP_DIRS.has(entry.name) || entry.name.startsWith('.') ? [] : findSpecs(full);
+    }
+    return entry.name.endsWith('.spec.ts') ? [path.relative(repoRoot, full)] : [];
+  });
+}
+
+/**
+ * The npm script body with `npm run <name>` references expanded, so a
+ * behaviour-preserving split into sub-scripts does not read as a regression.
+ */
+function expandScript(scripts, name, seen = new Set()) {
+  if (seen.has(name)) return '';
+  seen.add(name);
+  return (scripts[name] ?? '').replace(/npm run ([\w:-]+)/g, (_, ref) =>
+    expandScript(scripts, ref, seen),
+  );
+}
+
+describe('tests type-check program (#286)', () => {
+  // tsc exits non-zero when the program has type errors, but still prints the
+  // file list. Read stdout either way: throwing here would surface a real
+  // regression as an unreadable collection error instead of a failed assertion.
+  let stdout;
+  try {
+    stdout = execFileSync('npx', ['tsc', '-p', 'tsconfig.tests.json', '--listFiles', '--noEmit'], {
+      cwd: repoRoot,
+      encoding: 'utf8',
+    });
+  } catch (error) {
+    stdout = error.stdout ?? '';
+  }
+  const program = stdout
+    .split('\n')
+    .filter((line) => line.startsWith('/') && !line.includes('node_modules'))
+    .map((line) => path.relative(repoRoot, line.trim()));
+
+  it('type-checks every spec in the repo', () => {
+    const specs = findSpecs();
+    expect(specs.length).toBeGreaterThan(0);
+    // A spec outside the program is unchecked, and nothing else would say so.
+    expect(specs.filter((spec) => !program.includes(spec))).toEqual([]);
+  });
+
+  it('type-checks the runner configs', () => {
+    // A mistyped option here changes runtime behaviour without failing anything.
+    for (const config of ['playwright.config.ts', 'vitest.config.ts', 'vitest.setup.ts']) {
+      expect(program).toContain(config);
+    }
+  });
+
+  it('is actually run by the typecheck script', () => {
+    // The program can be correct and still never execute.
+    const { scripts } = JSON.parse(readFileSync(path.join(repoRoot, 'package.json'), 'utf8'));
+    expect(expandScript(scripts, 'typecheck')).toContain('tsconfig.tests.json');
+  });
+});

--- a/scripts/__tests__/tests-typecheck-program.test.mjs
+++ b/scripts/__tests__/tests-typecheck-program.test.mjs
@@ -33,14 +33,21 @@ const SKIP_DIRS = new Set([
   'test-results',
 ]);
 
-/** Every `*.spec.ts` anywhere in the repo, repo-relative. */
-function findSpecs(dir = repoRoot) {
+/**
+ * Authored test TypeScript, repo-relative: every `*.spec.ts` anywhere (to catch
+ * a spec parked outside tests/) plus every `.ts` under tests/ (mocks and
+ * helpers, which an `exclude` could otherwise drop while the specs stay).
+ */
+function findTestSources(dir = repoRoot) {
   return readdirSync(dir, { withFileTypes: true }).flatMap((entry) => {
     const full = path.join(dir, entry.name);
+    const rel = path.relative(repoRoot, full);
     if (entry.isDirectory()) {
-      return SKIP_DIRS.has(entry.name) || entry.name.startsWith('.') ? [] : findSpecs(full);
+      return SKIP_DIRS.has(entry.name) ? [] : findTestSources(full);
     }
-    return entry.name.endsWith('.spec.ts') ? [path.relative(repoRoot, full)] : [];
+    if (!entry.name.endsWith('.ts')) return [];
+    const isTestTree = rel === 'tests' || rel.startsWith(`tests${path.sep}`);
+    return entry.name.endsWith('.spec.ts') || isTestTree ? [rel] : [];
   });
 }
 
@@ -71,14 +78,23 @@ describe('tests type-check program (#286)', () => {
   }
   const program = stdout
     .split('\n')
-    .filter((line) => line.startsWith('/') && !line.includes('node_modules'))
+    .filter((line) => path.isAbsolute(line.trim()) && !line.includes('node_modules'))
     .map((line) => path.relative(repoRoot, line.trim()));
 
-  it('type-checks every spec in the repo', () => {
-    const specs = findSpecs();
-    expect(specs.length).toBeGreaterThan(0);
-    // A spec outside the program is unchecked, and nothing else would say so.
-    expect(specs.filter((spec) => !program.includes(spec))).toEqual([]);
+  it('type-checks every authored test source', () => {
+    const sources = findTestSources();
+    expect(sources.length).toBeGreaterThan(0);
+    // Anything outside the program is unchecked, and nothing else would say so.
+    expect(sources.filter((file) => !program.includes(file))).toEqual([]);
+  });
+
+  it('is actually run by CI', () => {
+    // The config can be right and the script can run it, and CI can still
+    // inline its own `tsc` call -- which is exactly how tests/ stayed
+    // unchecked in the pipeline. That is the last unguarded link.
+    const workflow = readFileSync(path.join(repoRoot, '.github/workflows/ci.yml'), 'utf8');
+    const step = workflow.match(/- name: Type check\n(?:.*\n)*?\s*run: (.+)/);
+    expect(step?.[1]?.trim()).toBe('npm run typecheck');
   });
 
   it('type-checks the runner configs', () => {

--- a/src/__tests__/tsconfig-coverage.test.ts
+++ b/src/__tests__/tsconfig-coverage.test.ts
@@ -1,40 +1,21 @@
-import { readdirSync, readFileSync } from 'node:fs';
+import { readFileSync } from 'node:fs';
 import * as path from 'node:path';
 
 // Guards issue #46: the OpenSCAD worker — and any other authored TypeScript
 // source — must stay in the type-checked program. Excluding a real source file
 // from tsconfig hides type errors in critical code, so fail loudly if it ever
 // creeps back.
-//
-// Also guards #286, which this file could not have caught: that was an
-// include/rootDir gap, not an exclude, and it left tests/ unchecked for the
-// life of the repo. The checks below assert the second program still exists
-// and still admits every spec — because if it silently stops, nothing else
-// fails.
 
-function readJsonWithComments(fileName: string): Record<string, unknown> {
-  const raw = readFileSync(path.join(process.cwd(), fileName), 'utf8');
+function readTsconfigExclude(): string[] {
+  const tsconfigPath = path.join(process.cwd(), 'tsconfig.json');
+  const raw = readFileSync(tsconfigPath, 'utf8');
   // tsconfig.json permits comments; strip whole-line `//` comments before parsing.
   const stripped = raw
     .split('\n')
     .filter((line) => !/^\s*\/\//.test(line))
     .join('\n');
-  return JSON.parse(stripped) as Record<string, unknown>;
-}
-
-function readTsconfigExclude(): string[] {
-  return (readJsonWithComments('tsconfig.json').exclude as string[] | undefined) ?? [];
-}
-
-/** Every authored spec on disk, relative to the repo root. */
-function specFiles(dir = 'tests'): string[] {
-  return readdirSync(path.join(process.cwd(), dir), { withFileTypes: true }).flatMap((entry) =>
-    entry.isDirectory()
-      ? specFiles(path.join(dir, entry.name))
-      : entry.name.endsWith('.ts')
-        ? [path.join(dir, entry.name)]
-        : [],
-  );
+  const parsed = JSON.parse(stripped) as { exclude?: string[] };
+  return parsed.exclude ?? [];
 }
 
 describe('tsconfig type-check coverage', () => {
@@ -47,34 +28,5 @@ describe('tsconfig type-check coverage', () => {
   it('does not exclude any authored .ts source file', () => {
     const excludedTs = exclude.filter((entry) => entry.endsWith('.ts'));
     expect(excludedTs).toEqual([]);
-  });
-});
-
-describe('tests type-check coverage (#286)', () => {
-  it('runs the tests program from the typecheck script', () => {
-    const scripts = (
-      JSON.parse(readFileSync(path.join(process.cwd(), 'package.json'), 'utf8')) as {
-        scripts: Record<string, string>;
-      }
-    ).scripts;
-    // Dropping this leaves tests/ unchecked with every gate still green.
-    expect(scripts.typecheck).toContain('tsconfig.tests.json');
-  });
-
-  it('admits every spec on disk', () => {
-    const include = readJsonWithComments('tsconfig.tests.json').include as string[];
-    expect(include).toContain('tests/**/*.ts');
-    // A spec parked outside tests/ would be silently unchecked; assert there is
-    // no such thing rather than trusting the glob alone.
-    const specs = specFiles();
-    expect(specs.length).toBeGreaterThan(0);
-    expect(specs.every((file) => file.startsWith('tests/'))).toBe(true);
-  });
-
-  it('keeps the runner configs in the program', () => {
-    const include = readJsonWithComments('tsconfig.tests.json').include as string[];
-    for (const config of ['playwright.config.ts', 'vitest.config.ts', 'vitest.setup.ts']) {
-      expect(include).toContain(config);
-    }
   });
 });

--- a/src/__tests__/tsconfig-coverage.test.ts
+++ b/src/__tests__/tsconfig-coverage.test.ts
@@ -1,21 +1,40 @@
-import { readFileSync } from 'node:fs';
+import { readdirSync, readFileSync } from 'node:fs';
 import * as path from 'node:path';
 
 // Guards issue #46: the OpenSCAD worker — and any other authored TypeScript
 // source — must stay in the type-checked program. Excluding a real source file
 // from tsconfig hides type errors in critical code, so fail loudly if it ever
 // creeps back.
+//
+// Also guards #286, which this file could not have caught: that was an
+// include/rootDir gap, not an exclude, and it left tests/ unchecked for the
+// life of the repo. The checks below assert the second program still exists
+// and still admits every spec — because if it silently stops, nothing else
+// fails.
 
-function readTsconfigExclude(): string[] {
-  const tsconfigPath = path.join(process.cwd(), 'tsconfig.json');
-  const raw = readFileSync(tsconfigPath, 'utf8');
+function readJsonWithComments(fileName: string): Record<string, unknown> {
+  const raw = readFileSync(path.join(process.cwd(), fileName), 'utf8');
   // tsconfig.json permits comments; strip whole-line `//` comments before parsing.
   const stripped = raw
     .split('\n')
     .filter((line) => !/^\s*\/\//.test(line))
     .join('\n');
-  const parsed = JSON.parse(stripped) as { exclude?: string[] };
-  return parsed.exclude ?? [];
+  return JSON.parse(stripped) as Record<string, unknown>;
+}
+
+function readTsconfigExclude(): string[] {
+  return (readJsonWithComments('tsconfig.json').exclude as string[] | undefined) ?? [];
+}
+
+/** Every authored spec on disk, relative to the repo root. */
+function specFiles(dir = 'tests'): string[] {
+  return readdirSync(path.join(process.cwd(), dir), { withFileTypes: true }).flatMap((entry) =>
+    entry.isDirectory()
+      ? specFiles(path.join(dir, entry.name))
+      : entry.name.endsWith('.ts')
+        ? [path.join(dir, entry.name)]
+        : [],
+  );
 }
 
 describe('tsconfig type-check coverage', () => {
@@ -28,5 +47,34 @@ describe('tsconfig type-check coverage', () => {
   it('does not exclude any authored .ts source file', () => {
     const excludedTs = exclude.filter((entry) => entry.endsWith('.ts'));
     expect(excludedTs).toEqual([]);
+  });
+});
+
+describe('tests type-check coverage (#286)', () => {
+  it('runs the tests program from the typecheck script', () => {
+    const scripts = (
+      JSON.parse(readFileSync(path.join(process.cwd(), 'package.json'), 'utf8')) as {
+        scripts: Record<string, string>;
+      }
+    ).scripts;
+    // Dropping this leaves tests/ unchecked with every gate still green.
+    expect(scripts.typecheck).toContain('tsconfig.tests.json');
+  });
+
+  it('admits every spec on disk', () => {
+    const include = readJsonWithComments('tsconfig.tests.json').include as string[];
+    expect(include).toContain('tests/**/*.ts');
+    // A spec parked outside tests/ would be silently unchecked; assert there is
+    // no such thing rather than trusting the glob alone.
+    const specs = specFiles();
+    expect(specs.length).toBeGreaterThan(0);
+    expect(specs.every((file) => file.startsWith('tests/'))).toBe(true);
+  });
+
+  it('keeps the runner configs in the program', () => {
+    const include = readJsonWithComments('tsconfig.tests.json').include as string[];
+    for (const config of ['playwright.config.ts', 'vitest.config.ts', 'vitest.setup.ts']) {
+      expect(include).toContain(config);
+    }
   });
 });

--- a/tests/session.spec.ts
+++ b/tests/session.spec.ts
@@ -145,7 +145,10 @@ test.describe('session distributable (#193)', () => {
     const projectRevision = await page.evaluate(
       () =>
         window.__sessionMessages?.find(
-          (m) => m?.type === 'project-ack' && m?.requestId === 'e2e-push-1',
+          (m) =>
+            m?.type === 'project-ack' &&
+            m?.requestId === 'e2e-push-1' &&
+            typeof m?.sourceRevision === 'number',
         )?.sourceRevision,
     );
     // Narrowed rather than asserted with `expect`: every check below compares a
@@ -177,8 +180,7 @@ test.describe('session distributable (#193)', () => {
     const strayEarlyResults = await page.evaluate(
       (rev) =>
         window.__sessionMessages?.filter(
-          (m) =>
-            m?.type === 'operation-result' && ((m?.result?.sourceRevision ?? rev) as number) < rev,
+          (m) => m?.type === 'operation-result' && (m?.result?.sourceRevision ?? rev) < rev,
         ).length,
       projectRevision,
     );

--- a/tests/session.spec.ts
+++ b/tests/session.spec.ts
@@ -148,6 +148,12 @@ test.describe('session distributable (#193)', () => {
           (m) => m?.type === 'project-ack' && m?.requestId === 'e2e-push-1',
         )?.sourceRevision,
     );
+    // Narrowed rather than asserted with `expect`: every check below compares a
+    // revision against this one, so an undefined value would make them compare
+    // against undefined and pass vacuously instead of failing (#286).
+    if (typeof projectRevision !== 'number') {
+      throw new Error('project-ack carried no numeric sourceRevision.');
+    }
 
     // A genuine WASM compile fans out to a success operation-result carrying an
     // OFF artifact, PINNED to the project push's acked revision — a stray

--- a/tsconfig.tests.json
+++ b/tsconfig.tests.json
@@ -1,17 +1,22 @@
 {
-  // The root config sets "rootDir": "src", so `npm run typecheck` cannot see
-  // tests/ at all. Playwright transpiles specs without checking them and eslint
-  // is not type-aware, so before this config a type-broken spec kept CI green
-  // (#286). The specs reach into private internals (`shell._st`, `viewer._scene`)
-  // through inline type literals that nothing else verifies, and a wrong literal
-  // makes an assertion read an always-undefined field — i.e. it passes vacuously.
+  // The root config sets "rootDir": "src" and includes only src/, so
+  // `npm run typecheck` never saw the test tree. Playwright and vitest
+  // transpile without checking, and eslint is not type-aware, so a type-broken
+  // spec could not fail any gate (#286).
+  //
+  // Scope: this catches type errors WITHIN the test tree. It does not verify
+  // the specs against src/ -- no spec imports from src/, so the two programs
+  // are disjoint. The inline type literals the specs use to reach into private
+  // internals (`shell._st`, `viewer._scene`) are self-consistent and still
+  // unverified against the real types; see #292.
   "extends": "./tsconfig.json",
   "compilerOptions": {
-    // Widened from "src" so tests/ is inside the program. Only affects which
-    // files are admitted; this config emits nothing.
+    // Widened from "src" so the test tree is inside the program. Only affects
+    // which files are admitted; this config emits nothing.
     "rootDir": "."
   },
-  // src/ is pulled in by the specs' own imports; naming tests/ alone keeps this
-  // config's job narrow and leaves src/ coverage to the root config.
-  "include": ["tests/**/*.ts"]
+  // The runner configs are included deliberately: they are the part of the test
+  // tooling most likely to break silently, since a mistyped option changes
+  // runtime behaviour without failing anything.
+  "include": ["tests/**/*.ts", "playwright.config.ts", "vitest.config.ts", "vitest.setup.ts"]
 }

--- a/tsconfig.tests.json
+++ b/tsconfig.tests.json
@@ -1,0 +1,17 @@
+{
+  // The root config sets "rootDir": "src", so `npm run typecheck` cannot see
+  // tests/ at all. Playwright transpiles specs without checking them and eslint
+  // is not type-aware, so before this config a type-broken spec kept CI green
+  // (#286). The specs reach into private internals (`shell._st`, `viewer._scene`)
+  // through inline type literals that nothing else verifies, and a wrong literal
+  // makes an assertion read an always-undefined field — i.e. it passes vacuously.
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    // Widened from "src" so tests/ is inside the program. Only affects which
+    // files are admitted; this config emits nothing.
+    "rootDir": "."
+  },
+  // src/ is pulled in by the specs' own imports; naming tests/ alone keeps this
+  // config's job narrow and leaves src/ coverage to the root config.
+  "include": ["tests/**/*.ts"]
+}

--- a/tsconfig.tests.json
+++ b/tsconfig.tests.json
@@ -5,8 +5,9 @@
   // spec could not fail any gate (#286).
   //
   // Scope: this catches type errors WITHIN the test tree. It does not verify
-  // the specs against src/ -- no spec imports from src/, so the two programs
-  // are disjoint. The inline type literals the specs use to reach into private
+  // the specs against src/ -- as of today no spec imports from src/, so the two
+  // programs are disjoint. Acting on #292 would change that, and this comment
+  // with it. The inline type literals the specs use to reach into private
   // internals (`shell._st`, `viewer._scene`) are self-consistent and still
   // unverified against the real types; see #292.
   "extends": "./tsconfig.json",


### PR DESCRIPTION
Closes #286.

`tsconfig.json` sets `"rootDir": "src"`, so `npm run typecheck` never saw the test tree. Playwright and vitest transpile without checking, and eslint uses `recommended` rather than `recommendedTypeChecked`. A type-broken spec therefore could not fail any gate — #284 introduced three such errors, caught only by an out-of-band `tsc` run.

## Changes

- **`tsconfig.tests.json`** — extends the root config, widens `rootDir` to the repo root. Covers `tests/**/*.ts` **plus** `playwright.config.ts`, `vitest.config.ts` and `vitest.setup.ts`, which neither program checked: a mistyped runner option changes behaviour without failing anything. 12 files in the program.
- **`typecheck` script** — runs both programs.
- **`.github/workflows/ci.yml`** — the Type check step inlined `npx tsc --noEmit` rather than calling the script. Widening the script alone would have left CI checking `src` only, so the step now calls `npm run typecheck`. That drift is the same class of bug as the issue itself.
- **`tests/session.spec.ts`** — fixes the one error this exposed, plus two review findings.

## The exposed error was real

`projectRevision` came off an optional chain, so it typed as `number | undefined`. Every later assertion in that test compares a revision against it — an undefined value would have compared against undefined and **passed vacuously**. Exactly the failure mode the issue describes, found on the first run of the new gate.

Narrowed with a `throw` rather than `expect`, because Playwright's `expect` has no assertion signature and cannot narrow (verified: `expect(v).toBeDefined(); const a: number = v;` still errors).

## Scope, stated accurately

This gate catches type errors **within** the test tree. It does **not** verify the specs against `src/` — `--listFiles` confirms the two programs are disjoint, since no spec imports from `src/`. The inline literals the specs use to reach into private internals (`shell._st`, `viewer._scene`) remain unverified against the real types, so they can still drift and make an assertion pass vacuously. Filed as **#292**.

An earlier revision of this PR asserted the opposite in a code comment; adversarial review caught it and the comment now says what the config actually does.

## Verification

The gate fails on an injected error and passes clean:

```
TYPECHECK EXIT WITH INJECTED ERROR = 2
tests/viewer.spec.ts(186,7): error TS2322: Type 'string' is not assignable to type 'number'.
TYPECHECK EXIT CLEAN = 0
```

- `npm run verify` — exit 0
- `npm run test:e2e:session` — 1 passed (the touched spec; `verify` does not cover Playwright)

## Not in scope

Making eslint type-aware (`recommendedTypeChecked`) would flag a lot across `src/` and is a separate decision. Review also surfaced two pre-existing type errors in `vite.shared.ts` that no gate catches — out of scope here.