### PR TITLE
fix(perf): re-baseline the perf gate from CI-measured runs

### DIFF
--- a/docs/PERFORMANCE.md
+++ b/docs/PERFORMANCE.md
@@ -69,6 +69,38 @@ To create or refresh your ignored local baseline from the current local capture:
 npm run perf:accept:local
 ```
 
+### Refreshing from many CI runs
+
+`perf:accept` takes a single run. That is fine after a deliberate,
+perf-impacting change, but it anchors the baseline to one sample of a noisy
+population — and one unlucky sample sets budgets the next run cannot meet.
+
+For a periodic refresh, take the p90 across many CI runs instead. The
+`performance` job uploads `perf-baseline-candidate` on every run, so the
+samples already exist:
+
+```sh
+gh run download <run-id> -n perf-baseline-candidate -D run-<run-id>
+```
+
+Collect a dozen or more from runs on current code, then set each metric to the
+**p90 of the per-run medians**. p90 rather than the median because the budget
+is a flat +20%: anchoring at the median makes that budget narrower than
+observed CI variance for the noisier submetrics, so they WARN on nothing and
+the warnings stop meaning anything.
+
+Sanity-check a candidate baseline before committing it, by comparing it
+against each harvested run:
+
+```sh
+cp run-<id>/current-perf-baseline.json coverage/perf/current-perf-baseline.json
+node scripts/perf/compare-baseline.mjs --strict
+```
+
+It should be silent on every run of current code. Then confirm it still has
+teeth by comparing against runs from before a known improvement — those should
+fail. A baseline that passes everything is not a gate.
+
 ## Rules
 
 - Compare is automatic.
@@ -80,3 +112,7 @@ npm run perf:accept:local
 - Local compare against `perf-baseline.local.json` is enforcing.
 - CI perf uses median aggregation across three runs, not a single sample or best-of-N.
 - CI compare is enforcing only for headline startup metrics; submetrics are diagnostic.
+- Check `environment.profile` before trusting a baseline: `ci-*` was measured on
+  a runner, `local-headless` on someone's workstation. A locally captured
+  baseline sets budgets against the wrong hardware — that is how the
+  2026-06-22 baseline came to be unfailable (#278).

--- a/docs/PERFORMANCE.md
+++ b/docs/PERFORMANCE.md
@@ -71,35 +71,62 @@ npm run perf:accept:local
 
 ### Refreshing from many CI runs
 
-`perf:accept` takes a single run. That is fine after a deliberate,
-perf-impacting change, but it anchors the baseline to one sample of a noisy
-population — and one unlucky sample sets budgets the next run cannot meet.
+`perf:accept` takes a single run. That is right after a deliberate,
+perf-impacting change, but it is wrong for a periodic refresh: one sample of a
+noisy population sets budgets the next run may not meet.
 
-For a periodic refresh, take the p90 across many CI runs instead. The
-`performance` job uploads `perf-baseline-candidate` on every run, so the
-samples already exist:
+The `performance` job uploads `perf-baseline-candidate` on every run, so the
+samples already exist. Harvest a dozen or more from runs on current code and
+aggregate them:
 
 ```sh
-gh run download <run-id> -n perf-baseline-candidate -D run-<run-id>
+for id in <run-ids>; do
+  gh run download "$id" -n perf-baseline-candidate -D "harvest/$id"
+done
+npm run perf:refresh -- harvest/*/current-perf-baseline.json
 ```
 
-Collect a dozen or more from runs on current code, then set each metric to the
-**p90 of the per-run medians**. p90 rather than the median because the budget
-is a flat +20%: anchoring at the median makes that budget narrower than
-observed CI variance for the noisier submetrics, so they WARN on nothing and
-the warnings stop meaning anything.
+Each input is one CI run's median-of-3. `refresh-baseline.mjs` takes the **p90
+(nearest rank)** of those per-run medians for every metric, and records the
+sample count and contributing run IDs in `notes` so the file says where its
+numbers came from.
 
-Sanity-check a candidate baseline before committing it, by comparing it
-against each harvested run:
+p90 rather than the median because the budget is a flat +20%: anchoring at the
+median makes that budget narrower than observed CI variance for the noisier
+submetrics, so they WARN on nothing and the warnings stop meaning anything.
+Nearest rank rather than an interpolated percentile so every baseline value is
+a number the app actually produced on a runner.
+
+The script **refuses** inputs whose `environment.profile` is not `ci-*`. That
+is the #278 root cause made unrepeatable: the 2026-06-22 baseline was captured
+on a workstation, so the gate compared runner timings against laptop timings
+and could not fail. Artifacts captured before the profile was stamped correctly
+read `local-headless` even on CI; pass `--assume-profile ci-Linux` for those,
+and only those.
+
+Sanity-check a candidate before committing it, by comparing it against each
+harvested run:
 
 ```sh
-cp run-<id>/current-perf-baseline.json coverage/perf/current-perf-baseline.json
+cp harvest/<id>/current-perf-baseline.json coverage/perf/current-perf-baseline.json
 node scripts/perf/compare-baseline.mjs --strict
 ```
 
 It should be silent on every run of current code. Then confirm it still has
 teeth by comparing against runs from before a known improvement — those should
 fail. A baseline that passes everything is not a gate.
+
+Two cautions when reading the results:
+
+- **Harvest by run, not by outcome.** A perf-gate failure sets the whole run's
+  conclusion to `failure`, so collecting only successful runs censors exactly
+  the slow tail you are trying to measure. Re-run attempts each keep their own
+  artifact; `gh api repos/<owner>/<repo>/actions/runs/<id>/artifacts` lists all
+  of them.
+- **A refresh ratifies whatever it measures.** Compare the new values against
+  the old before committing: any metric that got _slower_ is a regression you
+  are baselining in, and it should be a conscious decision rather than a side
+  effect.
 
 ## Rules
 

--- a/package.json
+++ b/package.json
@@ -56,6 +56,7 @@
     "perf:compare": "node scripts/perf/compare-baseline.mjs",
     "perf:compare:local": "node scripts/perf/compare-baseline.mjs --baseline perf-baseline.local.json --strict",
     "perf:accept": "node scripts/perf/accept-baseline.mjs",
+    "perf:refresh": "node scripts/perf/refresh-baseline.mjs",
     "perf:accept:local": "node scripts/perf/accept-baseline.mjs --baseline perf-baseline.local.json",
     "perf:ci": "npm run perf:capture:series && npm run perf:compare",
     "security:check-install-scripts": "node ./scripts/security/check-install-scripts.mjs",

--- a/perf-baseline.json
+++ b/perf-baseline.json
@@ -1,46 +1,67 @@
 {
   "version": 1,
-  "capturedAt": "2026-06-22T15:12:05.450Z",
+  "capturedAt": "2026-08-28T00:00:00.000Z",
   "environment": {
     "mode": "production",
     "browser": "chrome",
-    "profile": "local-headless"
+    "profile": "ci-Linux"
   },
   "metrics": {
-    "firstContentfulPaintMillis": 864,
-    "appBootstrapMillis": 520.2,
-    "mainFsInitMillis": 129.4,
-    "librariesPreloadMillis": 154.1,
-    "languageRegisterMillis": 701.4,
-    "editorMountMillis": 93.9,
-    "firstCompileFromBootstrapMillis": 2022.9,
-    "firstCompileRoundtripMillis": 1503,
-    "workerFsInitMillis": 52.4,
+    "firstContentfulPaintMillis": 692,
+    "appBootstrapMillis": 304.8,
+    "mainFsInitMillis": 89.4,
+    "librariesPreloadMillis": 106.3,
+    "languageRegisterMillis": 777.2,
+    "editorMountMillis": 107.6,
+    "firstCompileFromBootstrapMillis": 2000.7,
+    "firstCompileRoundtripMillis": 1563,
+    "workerFsInitMillis": 90.2,
     "workerLibraryMountMillis": 0.2,
-    "workerWasmInitMillis": 499.1,
-    "workerJobTotalMillis": 1072.7
+    "workerWasmInitMillis": 433.1,
+    "workerJobTotalMillis": 1118.4
   },
   "warmMetrics": {
-    "firstContentfulPaintMillis": 364,
-    "appBootstrapMillis": 192,
-    "mainFsInitMillis": 58.9,
-    "librariesPreloadMillis": 116.7,
-    "languageRegisterMillis": 298.3,
-    "editorMountMillis": 33.9,
-    "firstCompileFromBootstrapMillis": 1016.4,
-    "firstCompileRoundtripMillis": 824.4,
-    "workerFsInitMillis": 30.3,
-    "workerLibraryMountMillis": 0.1,
-    "workerWasmInitMillis": 88.7,
-    "workerJobTotalMillis": 604.6
+    "firstContentfulPaintMillis": 284,
+    "appBootstrapMillis": 115.4,
+    "mainFsInitMillis": 51,
+    "librariesPreloadMillis": 55.4,
+    "languageRegisterMillis": 190.7,
+    "editorMountMillis": 26,
+    "firstCompileFromBootstrapMillis": 934.2,
+    "firstCompileRoundtripMillis": 780.1,
+    "workerFsInitMillis": 38.7,
+    "workerLibraryMountMillis": 0.2,
+    "workerWasmInitMillis": 95.8,
+    "workerJobTotalMillis": 568
   },
   "notes": {
-    "aggregation": "median",
-    "sampleCount": 3,
-    "inputs": [
-      "coverage/perf/runs/run-1.json",
-      "coverage/perf/runs/run-2.json",
-      "coverage/perf/runs/run-3.json"
-    ]
+    "aggregation": "p90 of per-run medians",
+    "sampleCount": 15,
+    "source": "GitHub Actions ci.yml `performance` job, ubuntu-24.04",
+    "rationale": "Each input is one CI run's median-of-3 (perf:capture:series). The previous baseline was captured locally on 2026-06-22 and never re-measured on CI, so it encoded laptop timings; after the Monaco local-AMD refactor (#254/#267) landed on 2026-08-08 the app got ~43% faster to bootstrap and the gate could no longer fail. Anchored at p90 rather than the median because a median-anchored baseline makes the 20% budget narrower than observed CI variance for four diagnostic metrics, producing WARNs that carry no signal. p90 trips none of the 22 metrics across the sampled runs while still flagging pre-refactor timings (#278).",
+    "observedVarianceMaxOverMedian": {
+      "metrics.appBootstrapMillis": 1.1,
+      "metrics.firstCompileFromBootstrapMillis": 1.03,
+      "warmMetrics.appBootstrapMillis": 1.04,
+      "warmMetrics.firstCompileFromBootstrapMillis": 1.04
+    },
+    "inputRunIds": [
+      "31240563284",
+      "31263280230",
+      "31263747855",
+      "31800971767",
+      "32482499131",
+      "32760084362",
+      "32766959624",
+      "33037657636",
+      "33040858838",
+      "33041848689",
+      "33042354995",
+      "33045378331",
+      "33045911597",
+      "33046013950",
+      "33046630768"
+    ],
+    "inputRange": ["2026-08-08T04:56:04Z", "2026-08-27T06:38:58Z"]
   }
 }

--- a/perf-baseline.json
+++ b/perf-baseline.json
@@ -1,6 +1,6 @@
 {
   "version": 1,
-  "capturedAt": "2026-08-28T01:01:32.772Z",
+  "capturedAt": "2026-08-28T01:13:54.636Z",
   "environment": {
     "mode": "production",
     "browser": "chrome",
@@ -54,6 +54,10 @@
       "33045911597",
       "33046013950",
       "33046630768"
-    ]
+    ],
+    "profileAssumed": {
+      "assumed": "ci-Linux",
+      "observed": ["local-headless"]
+    }
   }
 }

--- a/perf-baseline.json
+++ b/perf-baseline.json
@@ -1,6 +1,6 @@
 {
   "version": 1,
-  "capturedAt": "2026-08-28T01:13:54.636Z",
+  "capturedAt": "2026-08-28T01:25:32.925Z",
   "environment": {
     "mode": "production",
     "browser": "chrome",

--- a/perf-baseline.json
+++ b/perf-baseline.json
@@ -1,51 +1,44 @@
 {
   "version": 1,
-  "capturedAt": "2026-08-28T00:00:00.000Z",
+  "capturedAt": "2026-08-28T01:01:32.772Z",
   "environment": {
     "mode": "production",
     "browser": "chrome",
     "profile": "ci-Linux"
   },
   "metrics": {
-    "firstContentfulPaintMillis": 692,
-    "appBootstrapMillis": 304.8,
-    "mainFsInitMillis": 89.4,
-    "librariesPreloadMillis": 106.3,
-    "languageRegisterMillis": 777.2,
-    "editorMountMillis": 107.6,
-    "firstCompileFromBootstrapMillis": 2000.7,
-    "firstCompileRoundtripMillis": 1563,
-    "workerFsInitMillis": 90.2,
+    "firstContentfulPaintMillis": 704,
+    "appBootstrapMillis": 305.7,
+    "mainFsInitMillis": 91.7,
+    "librariesPreloadMillis": 109.1,
+    "languageRegisterMillis": 837.1,
+    "editorMountMillis": 110.4,
+    "firstCompileFromBootstrapMillis": 2010.6,
+    "firstCompileRoundtripMillis": 1563.7,
+    "workerFsInitMillis": 94.3,
     "workerLibraryMountMillis": 0.2,
-    "workerWasmInitMillis": 433.1,
-    "workerJobTotalMillis": 1118.4
+    "workerWasmInitMillis": 436.8,
+    "workerJobTotalMillis": 1118.5
   },
   "warmMetrics": {
-    "firstContentfulPaintMillis": 284,
+    "firstContentfulPaintMillis": 288,
     "appBootstrapMillis": 115.4,
-    "mainFsInitMillis": 51,
-    "librariesPreloadMillis": 55.4,
-    "languageRegisterMillis": 190.7,
-    "editorMountMillis": 26,
-    "firstCompileFromBootstrapMillis": 934.2,
-    "firstCompileRoundtripMillis": 780.1,
-    "workerFsInitMillis": 38.7,
+    "mainFsInitMillis": 51.1,
+    "librariesPreloadMillis": 57.7,
+    "languageRegisterMillis": 193.7,
+    "editorMountMillis": 26.7,
+    "firstCompileFromBootstrapMillis": 938.4,
+    "firstCompileRoundtripMillis": 786.5,
+    "workerFsInitMillis": 41.3,
     "workerLibraryMountMillis": 0.2,
-    "workerWasmInitMillis": 95.8,
-    "workerJobTotalMillis": 568
+    "workerWasmInitMillis": 96.7,
+    "workerJobTotalMillis": 568.9
   },
   "notes": {
-    "aggregation": "p90 of per-run medians",
+    "aggregation": "p90 (nearest rank) of per-run medians",
     "sampleCount": 15,
-    "source": "GitHub Actions ci.yml `performance` job, ubuntu-24.04",
-    "rationale": "Each input is one CI run's median-of-3 (perf:capture:series). The previous baseline was captured locally on 2026-06-22 and never re-measured on CI, so it encoded laptop timings; after the Monaco local-AMD refactor (#254/#267) landed on 2026-08-08 the app got ~43% faster to bootstrap and the gate could no longer fail. Anchored at p90 rather than the median because a median-anchored baseline makes the 20% budget narrower than observed CI variance for four diagnostic metrics, producing WARNs that carry no signal. p90 trips none of the 22 metrics across the sampled runs while still flagging pre-refactor timings (#278).",
-    "observedVarianceMaxOverMedian": {
-      "metrics.appBootstrapMillis": 1.1,
-      "metrics.firstCompileFromBootstrapMillis": 1.03,
-      "warmMetrics.appBootstrapMillis": 1.04,
-      "warmMetrics.firstCompileFromBootstrapMillis": 1.04
-    },
-    "inputRunIds": [
+    "generatedBy": "scripts/perf/refresh-baseline.mjs",
+    "inputs": [
       "31240563284",
       "31263280230",
       "31263747855",
@@ -61,7 +54,6 @@
       "33045911597",
       "33046013950",
       "33046630768"
-    ],
-    "inputRange": ["2026-08-08T04:56:04Z", "2026-08-27T06:38:58Z"]
+    ]
   }
 }

--- a/scripts/__tests__/refresh-baseline.test.mjs
+++ b/scripts/__tests__/refresh-baseline.test.mjs
@@ -6,7 +6,7 @@ import {
   nearestRankPercentile,
   aggregateSection,
   assertCiProfiles,
-  assertNoGatedDrops,
+  assertGatedMetricsPresent,
 } from '../perf/refresh-baseline.mjs';
 
 describe('nearestRankPercentile', () => {
@@ -96,21 +96,47 @@ describe('aggregateSection', () => {
   });
 });
 
-describe('assertNoGatedDrops', () => {
-  it('refuses to drop a gated metric — that silently un-gates CI', () => {
-    expect(() => assertNoGatedDrops('metrics', ['appBootstrapMillis'])).toThrow(/gated metric/);
-    expect(() => assertNoGatedDrops('warmMetrics', ['firstCompileFromBootstrapMillis'])).toThrow(
+describe('assertGatedMetricsPresent', () => {
+  const complete = {
+    metrics: { appBootstrapMillis: 1, firstCompileFromBootstrapMillis: 1 },
+    warmMetrics: { appBootstrapMillis: 1, firstCompileFromBootstrapMillis: 1 },
+  };
+
+  it('accepts a baseline carrying every gated metric', () => {
+    expect(() => assertGatedMetricsPresent(complete)).not.toThrow();
+  });
+
+  it('refuses a baseline missing a gated metric', () => {
+    expect(() =>
+      assertGatedMetricsPresent({
+        ...complete,
+        metrics: { firstCompileFromBootstrapMillis: 1 },
+      }),
+    ).toThrow(/metrics\.appBootstrapMillis/);
+  });
+
+  it('refuses when a gated metric is absent from EVERY input', () => {
+    // The earlier negative form ("nothing dropped was gated") missed this: a
+    // name absent from every run never enters the dropped set, so it vanished
+    // silently and the gate stopped checking it.
+    expect(() => assertGatedMetricsPresent({ metrics: {}, warmMetrics: {} })).toThrow(
       /gated metric/,
     );
   });
 
-  it('allows a diagnostic metric to drop', () => {
-    expect(() => assertNoGatedDrops('metrics', ['editorMountMillis'])).not.toThrow();
+  it('refuses a wholly empty baseline', () => {
+    expect(() => assertGatedMetricsPresent({})).toThrow(/gated metric/);
   });
 
-  it('is section-aware — the same name is gated in one section only where listed', () => {
-    expect(() => assertNoGatedDrops('metrics', ['appBootstrapMillis'])).toThrow();
-    expect(() => assertNoGatedDrops('notASection', ['appBootstrapMillis'])).not.toThrow();
+  it('is section-aware', () => {
+    // warmMetrics carries its own gated copies; a cold-only baseline is not enough.
+    expect(() => assertGatedMetricsPresent({ metrics: complete.metrics, warmMetrics: {} })).toThrow(
+      /warmMetrics/,
+    );
+  });
+
+  it('does not care about diagnostic metrics', () => {
+    expect(() => assertGatedMetricsPresent(complete)).not.toThrow();
   });
 });
 

--- a/scripts/__tests__/refresh-baseline.test.mjs
+++ b/scripts/__tests__/refresh-baseline.test.mjs
@@ -6,6 +6,7 @@ import {
   nearestRankPercentile,
   aggregateSection,
   assertCiProfiles,
+  assertNoGatedDrops,
 } from '../perf/refresh-baseline.mjs';
 
 describe('nearestRankPercentile', () => {
@@ -27,9 +28,31 @@ describe('nearestRankPercentile', () => {
     );
   });
 
-  it('clamps to the ends rather than reading out of bounds', () => {
+  it('returns the extremes at the extremes', () => {
     expect(nearestRankPercentile([4, 8], 100)).toBe(8);
     expect(nearestRankPercentile([4, 8], 1)).toBe(4);
+  });
+
+  it('handles a single-element sample', () => {
+    expect(nearestRankPercentile([7], 90)).toBe(7);
+    expect(nearestRankPercentile([7], 1)).toBe(7);
+  });
+
+  it('is exact for non-integer percentiles', () => {
+    // Math.ceil((p / 100) * n) drifts here because p/100 is not representable
+    // in binary; the integer form must not.
+    expect(
+      nearestRankPercentile(
+        Array.from({ length: 50 }, (_, i) => i),
+        14,
+      ),
+    ).toBe(6);
+    expect(
+      nearestRankPercentile(
+        Array.from({ length: 25 }, (_, i) => i),
+        28,
+      ),
+    ).toBe(6);
   });
 
   it('throws on an empty sample instead of returning undefined', () => {
@@ -40,20 +63,54 @@ describe('nearestRankPercentile', () => {
 describe('aggregateSection', () => {
   const runs = [{ metrics: { a: 10, b: 1 } }, { metrics: { a: 20, b: 2 } }, { metrics: { a: 30 } }];
 
-  it('drops a metric that is missing from any run', () => {
-    // Averaging over the runs that do have it would set a budget from a
-    // different population; treating it as 0 would pin the budget to the 5ms
-    // floor and fail every later run.
-    expect(aggregateSection(runs, 'metrics', 90)).not.toHaveProperty('b');
+  it('keeps a metric present in every run', () => {
+    expect(aggregateSection(runs, 'metrics', 90).metrics.a).toBe(30);
   });
 
-  it('keeps a metric present in every run', () => {
-    expect(aggregateSection(runs, 'metrics', 90).a).toBe(30);
+  it('reports a dropped metric rather than dropping it silently', () => {
+    // A dropped metric is never compared again, because compare-baseline.mjs
+    // iterates baseline metrics. Silence here is how a metric stops being
+    // gated with nothing on screen to say so.
+    const result = aggregateSection(runs, 'metrics', 90);
+    expect(result.metrics).not.toHaveProperty('b');
+    expect(result.dropped).toEqual(['b']);
+  });
+
+  it('treats an explicit null as absent — aggregate-baseline.mjs writes null', () => {
+    const withNull = [{ m: { x: 1 } }, { m: { x: null } }];
+    const result = aggregateSection(withNull, 'm', 90);
+    expect(result.metrics).not.toHaveProperty('x');
+    expect(result.dropped).toEqual(['x']);
+  });
+
+  it('treats NaN and Infinity as absent', () => {
+    expect(aggregateSection([{ m: { x: Number.NaN } }], 'm', 90).dropped).toEqual(['x']);
+    expect(aggregateSection([{ m: { x: Number.POSITIVE_INFINITY } }], 'm', 90).dropped).toEqual([
+      'x',
+    ]);
   });
 
   it('rounds to one decimal, matching the capture pipeline', () => {
     const r = [{ m: { x: 1.234 } }, { m: { x: 1.235 } }];
-    expect(aggregateSection(r, 'm', 50).x).toBe(1.2);
+    expect(aggregateSection(r, 'm', 50).metrics.x).toBe(1.2);
+  });
+});
+
+describe('assertNoGatedDrops', () => {
+  it('refuses to drop a gated metric — that silently un-gates CI', () => {
+    expect(() => assertNoGatedDrops('metrics', ['appBootstrapMillis'])).toThrow(/gated metric/);
+    expect(() => assertNoGatedDrops('warmMetrics', ['firstCompileFromBootstrapMillis'])).toThrow(
+      /gated metric/,
+    );
+  });
+
+  it('allows a diagnostic metric to drop', () => {
+    expect(() => assertNoGatedDrops('metrics', ['editorMountMillis'])).not.toThrow();
+  });
+
+  it('is section-aware — the same name is gated in one section only where listed', () => {
+    expect(() => assertNoGatedDrops('metrics', ['appBootstrapMillis'])).toThrow();
+    expect(() => assertNoGatedDrops('notASection', ['appBootstrapMillis'])).not.toThrow();
   });
 });
 
@@ -75,6 +132,16 @@ describe('assertCiProfiles', () => {
 
   it('honours an explicit assumed profile for pre-fix artifacts', () => {
     expect(assertCiProfiles(local, { assumeProfile: 'ci-Linux' })).toEqual(['ci-Linux']);
+  });
+
+  it('will not let --assume-profile launder a local capture', () => {
+    // Without this the flag fully inverts the guard it is attached to.
+    expect(() => assertCiProfiles(local, { assumeProfile: 'local-headless' })).toThrow(
+      /must name a CI profile/,
+    );
+    expect(() => assertCiProfiles(local, { assumeProfile: 'my-laptop' })).toThrow(
+      /must name a CI profile/,
+    );
   });
 
   it('treats a missing profile as non-CI', () => {

--- a/scripts/__tests__/refresh-baseline.test.mjs
+++ b/scripts/__tests__/refresh-baseline.test.mjs
@@ -138,6 +138,30 @@ describe('assertGatedMetricsPresent', () => {
   it('does not care about diagnostic metrics', () => {
     expect(() => assertGatedMetricsPresent(complete)).not.toThrow();
   });
+
+  it('refuses a gated metric that is present but unusable', () => {
+    // compare-baseline.mjs skips a negative or non-finite metric, so presence
+    // alone is not enough -- a negative baseline would silently stop gating.
+    for (const bad of [-42, Number.NaN, Number.POSITIVE_INFINITY, '295.7', null]) {
+      expect(() =>
+        assertGatedMetricsPresent({
+          ...complete,
+          metrics: { ...complete.metrics, appBootstrapMillis: bad },
+        }),
+      ).toThrow(/metrics\.appBootstrapMillis/);
+    }
+  });
+
+  it('accepts a legitimate zero', () => {
+    // workerLibraryMount really does measure ~0.1ms; the 5ms budget floor
+    // covers it, so zero must not be mistaken for missing.
+    expect(() =>
+      assertGatedMetricsPresent({
+        ...complete,
+        metrics: { ...complete.metrics, appBootstrapMillis: 0 },
+      }),
+    ).not.toThrow();
+  });
 });
 
 describe('assertCiProfiles', () => {

--- a/scripts/__tests__/refresh-baseline.test.mjs
+++ b/scripts/__tests__/refresh-baseline.test.mjs
@@ -1,0 +1,83 @@
+// @vitest-environment node
+
+import { describe, expect, it } from 'vitest';
+
+import {
+  nearestRankPercentile,
+  aggregateSection,
+  assertCiProfiles,
+} from '../perf/refresh-baseline.mjs';
+
+describe('nearestRankPercentile', () => {
+  it('returns an observed value, never an interpolation', () => {
+    const values = [1, 2, 3, 4, 5, 6, 7, 8, 9, 10];
+    expect(values).toContain(nearestRankPercentile(values, 90));
+    expect(values).toContain(nearestRankPercentile(values, 37));
+  });
+
+  it('uses ceil(p/100 * n) as the rank', () => {
+    // n=15, p90 -> ceil(13.5) = 14th smallest = index 13.
+    const values = Array.from({ length: 15 }, (_, i) => i);
+    expect(nearestRankPercentile(values, 90)).toBe(13);
+  });
+
+  it('is order independent', () => {
+    expect(nearestRankPercentile([9, 1, 5, 3, 7], 90)).toBe(
+      nearestRankPercentile([1, 3, 5, 7, 9], 90),
+    );
+  });
+
+  it('clamps to the ends rather than reading out of bounds', () => {
+    expect(nearestRankPercentile([4, 8], 100)).toBe(8);
+    expect(nearestRankPercentile([4, 8], 1)).toBe(4);
+  });
+
+  it('throws on an empty sample instead of returning undefined', () => {
+    expect(() => nearestRankPercentile([], 90)).toThrow(/empty sample/);
+  });
+});
+
+describe('aggregateSection', () => {
+  const runs = [{ metrics: { a: 10, b: 1 } }, { metrics: { a: 20, b: 2 } }, { metrics: { a: 30 } }];
+
+  it('drops a metric that is missing from any run', () => {
+    // Averaging over the runs that do have it would set a budget from a
+    // different population; treating it as 0 would pin the budget to the 5ms
+    // floor and fail every later run.
+    expect(aggregateSection(runs, 'metrics', 90)).not.toHaveProperty('b');
+  });
+
+  it('keeps a metric present in every run', () => {
+    expect(aggregateSection(runs, 'metrics', 90).a).toBe(30);
+  });
+
+  it('rounds to one decimal, matching the capture pipeline', () => {
+    const r = [{ m: { x: 1.234 } }, { m: { x: 1.235 } }];
+    expect(aggregateSection(r, 'm', 50).x).toBe(1.2);
+  });
+});
+
+describe('assertCiProfiles', () => {
+  const ci = [{ environment: { profile: 'ci-Linux' } }];
+  const local = [{ environment: { profile: 'local-headless' } }];
+
+  it('accepts CI captures', () => {
+    expect(assertCiProfiles(ci)).toEqual(['ci-Linux']);
+  });
+
+  it('refuses a workstation capture — the #278 root cause', () => {
+    expect(() => assertCiProfiles(local)).toThrow(/non-CI captures/);
+  });
+
+  it('refuses a mixed set', () => {
+    expect(() => assertCiProfiles([...ci, ...local])).toThrow(/local-headless/);
+  });
+
+  it('honours an explicit assumed profile for pre-fix artifacts', () => {
+    expect(assertCiProfiles(local, { assumeProfile: 'ci-Linux' })).toEqual(['ci-Linux']);
+  });
+
+  it('treats a missing profile as non-CI', () => {
+    expect(() => assertCiProfiles([{}])).toThrow(/unknown/);
+  });
+});

--- a/scripts/perf/aggregate-baseline.mjs
+++ b/scripts/perf/aggregate-baseline.mjs
@@ -77,7 +77,10 @@ async function main() {
     environment: runs[0]?.environment ?? {
       mode: 'production',
       browser: 'chrome',
-      profile: 'local-headless',
+      // Mirrors capture-baseline.mjs: a baseline that gates CI must record
+      // whether it was measured on a runner or a workstation (#278).
+      profile:
+        process.env.CI === 'true' ? `ci-${process.env.RUNNER_OS ?? 'unknown'}` : 'local-headless',
     },
     metrics: aggregateMetricSection(runs, 'metrics'),
     warmMetrics: aggregateMetricSection(runs, 'warmMetrics'),

--- a/scripts/perf/capture-baseline.mjs
+++ b/scripts/perf/capture-baseline.mjs
@@ -326,7 +326,15 @@ async function main() {
         environment: {
           mode: 'production',
           browser: 'chrome',
-          profile: 'local-headless',
+          // The committed baseline is compared against CI runs, so which of the
+          // two this was measured on is load-bearing -- a laptop-captured
+          // baseline silently sets budgets CI cannot meet (or trivially beats).
+          // This was hardcoded to 'local-headless' even on CI, so the file gave
+          // no way to tell them apart (#278).
+          profile:
+            process.env.CI === 'true'
+              ? `ci-${process.env.RUNNER_OS ?? 'unknown'}`
+              : 'local-headless',
         },
         metrics: cold.metrics,
         warmMetrics: warm.metrics,

--- a/scripts/perf/compare-baseline.mjs
+++ b/scripts/perf/compare-baseline.mjs
@@ -116,7 +116,14 @@ async function main() {
     isConfiguredMetric(entry.value),
   );
   if (configuredBaselineMetrics.length === 0) {
-    console.log(`No populated baseline metrics found in ${baselinePath}; skipping perf gate.`);
+    const message =
+      `No populated baseline metrics found in ${baselinePath}. ` +
+      'The perf gate would compare nothing and report success.';
+    // Under --strict this is a hard error: a malformed or emptied baseline is
+    // indistinguishable from a passing one otherwise, so the one job whose
+    // purpose is to go red would go green instead (#278).
+    if (strict) throw new Error(message);
+    console.log(`${message} Skipping perf gate.`);
     return;
   }
 

--- a/scripts/perf/compare-baseline.mjs
+++ b/scripts/perf/compare-baseline.mjs
@@ -39,7 +39,7 @@ function parseArgs(argv) {
 const budgetPct = Number.parseFloat(process.env.PERF_BUDGET_PCT ?? '20');
 const budgetMultiplier = 1 + budgetPct / 100;
 const minimumBudgetMs = Number.parseFloat(process.env.PERF_MIN_BUDGET_MS ?? '5');
-const gatedMetricKeys = new Set([
+export const gatedMetricKeys = new Set([
   // firstContentfulPaintMillis is excluded from gating: in CI headless mode it
   // measures at 60-80ms where 20% budget (~12-16ms) is smaller than run-to-run
   // scheduler jitter. Real FCP regressions are covered by appBootstrapMillis
@@ -176,7 +176,12 @@ async function main() {
   }
 }
 
-main().catch((error) => {
-  console.error(error);
-  process.exitCode = 1;
-});
+// Guarded so `gatedMetricKeys` can be imported without running the comparison
+// (refresh-baseline.mjs needs it to refuse dropping a gated metric). Matches
+// the pattern in check-bundle-budgets.mjs and render-geometry.mjs.
+if (process.argv[1] && fileURLToPath(import.meta.url) === path.resolve(process.argv[1])) {
+  main().catch((error) => {
+    console.error(error);
+    process.exitCode = 1;
+  });
+}

--- a/scripts/perf/compare-baseline.mjs
+++ b/scripts/perf/compare-baseline.mjs
@@ -50,7 +50,13 @@ export const gatedMetricKeys = new Set([
   'warmMetrics.firstCompileFromBootstrapMillis',
 ]);
 
-function isConfiguredMetric(value) {
+/**
+ * What this gate treats as a usable metric. Exported so a producer of baselines
+ * asserts against the consumer's own definition rather than a lookalike -- a
+ * baseline value can otherwise be present but unusable (e.g. negative), pass
+ * the writer's check, and be silently skipped here.
+ */
+export function isConfiguredMetric(value) {
   return typeof value === 'number' && Number.isFinite(value) && value >= 0;
 }
 

--- a/scripts/perf/refresh-baseline.mjs
+++ b/scripts/perf/refresh-baseline.mjs
@@ -19,7 +19,7 @@ import fs from 'node:fs/promises';
 import path from 'node:path';
 import { fileURLToPath } from 'node:url';
 
-import { gatedMetricKeys } from './compare-baseline.mjs';
+import { gatedMetricKeys, isConfiguredMetric } from './compare-baseline.mjs';
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const repoRoot = path.resolve(__dirname, '..', '..');
@@ -85,10 +85,14 @@ export function aggregateSection(runs, section, percentile) {
  * regression passed the resulting gate.
  */
 export function assertGatedMetricsPresent({ metrics, warmMetrics }) {
+  // `name in obj` would only prove presence. compare-baseline.mjs skips a
+  // metric that is present but not *usable* (negative, NaN, non-numeric), so
+  // asserting presence alone still lets a gated metric stop being compared.
+  // Reuse the consumer's predicate so the two cannot drift.
   const missing = [...gatedMetricKeys].filter((key) => {
     const [section, name] = key.split('.');
     const values = section === 'warmMetrics' ? warmMetrics : metrics;
-    return !(name in (values ?? {}));
+    return !isConfiguredMetric((values ?? {})[name]);
   });
   if (missing.length > 0) {
     throw new Error(

--- a/scripts/perf/refresh-baseline.mjs
+++ b/scripts/perf/refresh-baseline.mjs
@@ -1,0 +1,165 @@
+#!/usr/bin/env node
+
+// Rebuild `perf-baseline.json` from many harvested CI runs.
+//
+// `perf:accept` takes a single run, which is right after a deliberate,
+// perf-impacting change. It is wrong for a periodic refresh: one sample of a
+// noisy population sets budgets the next run may not meet. This aggregates
+// across runs instead.
+//
+// Usage:
+//   gh run download <id> -n perf-baseline-candidate -D harvest/<id>   # xN
+//   node scripts/perf/refresh-baseline.mjs harvest/*/current-perf-baseline.json
+//
+// Each input is one CI run's median-of-3 (what `perf:capture:series` writes).
+//
+// Emits the new baseline to --out (default perf-baseline.json).
+
+import fs from 'node:fs/promises';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const repoRoot = path.resolve(__dirname, '..', '..');
+
+/**
+ * Nearest-rank percentile: the smallest observed value at or above which `p`
+ * percent of the sample falls. Deliberately an *observed* value, never an
+ * interpolation between two — a baseline should be a number the app actually
+ * produced on a runner.
+ *
+ * Spelled out because the previous refresh was a hand computation described in
+ * prose as "p90"; several defensible estimators disagree by a few percent, so
+ * the next person recomputing it would not have reproduced the file (#278).
+ */
+export function nearestRankPercentile(values, p) {
+  const sorted = [...values].sort((a, b) => a - b);
+  if (sorted.length === 0) throw new Error('nearestRankPercentile: empty sample');
+  const rank = Math.ceil((p / 100) * sorted.length);
+  return sorted[Math.min(Math.max(rank, 1), sorted.length) - 1];
+}
+
+/** Round to one decimal, matching what the capture pipeline writes. */
+const round = (value) => Math.round(value * 10) / 10;
+
+/**
+ * Aggregate one metric section across runs. A metric missing from any run is
+ * dropped rather than treated as zero, which would silently set a budget of
+ * 5ms (the floor) and fail every subsequent run.
+ */
+export function aggregateSection(runs, section, percentile) {
+  const names = new Set(runs.flatMap((run) => Object.keys(run[section] ?? {})));
+  const out = {};
+  for (const name of names) {
+    const values = runs
+      .map((run) => run[section]?.[name])
+      .filter((value) => typeof value === 'number' && Number.isFinite(value));
+    if (values.length !== runs.length) continue;
+    out[name] = round(nearestRankPercentile(values, percentile));
+  }
+  return out;
+}
+
+/**
+ * The committed baseline is compared against CI runs, so it must be built from
+ * CI runs. A workstation-captured baseline is what made the gate unfailable for
+ * two months (#278), and nothing surfaced it — so refuse rather than warn.
+ */
+export function assertCiProfiles(runs, { assumeProfile } = {}) {
+  const profiles = [...new Set(runs.map((run) => run.environment?.profile ?? 'unknown'))];
+  if (assumeProfile) return [assumeProfile];
+  const local = profiles.filter((profile) => !profile.startsWith('ci-'));
+  if (local.length > 0) {
+    throw new Error(
+      `Refusing to build a CI baseline from non-CI captures: ${local.join(', ')}.\n` +
+        'The committed baseline gates CI runs and must be measured on a runner.\n' +
+        "Runs captured before this repo stamped the profile correctly read 'local-headless' " +
+        'even on CI. If you know the inputs are genuinely CI artifacts, re-run with\n' +
+        '  --assume-profile ci-Linux\n' +
+        'which records that profile in the output. Do not use it to launder local captures.',
+    );
+  }
+  return profiles;
+}
+
+function parseArgs(argv) {
+  const inputs = [];
+  let out = 'perf-baseline.json';
+  let percentile = 90;
+  let assumeProfile = null;
+  for (let i = 0; i < argv.length; i += 1) {
+    const arg = argv[i];
+    if (arg === '--out') {
+      out = argv[i + 1];
+      i += 1;
+    } else if (arg === '--percentile') {
+      percentile = Number.parseFloat(argv[i + 1]);
+      i += 1;
+    } else if (arg === '--assume-profile') {
+      assumeProfile = argv[i + 1];
+      i += 1;
+    } else if (arg.startsWith('--')) {
+      throw new Error(`Unknown flag: ${arg}`);
+    } else {
+      inputs.push(arg);
+    }
+  }
+  if (inputs.length === 0) throw new Error('Provide at least one candidate JSON path.');
+  if (!Number.isFinite(percentile) || percentile <= 0 || percentile > 100) {
+    throw new Error(`--percentile must be in (0, 100]; got ${percentile}`);
+  }
+  return { inputs, out, percentile, assumeProfile };
+}
+
+async function main() {
+  const { inputs, out, percentile, assumeProfile } = parseArgs(process.argv.slice(2));
+  const runs = await Promise.all(
+    inputs.map(async (input) =>
+      JSON.parse(await fs.readFile(path.resolve(repoRoot, input), 'utf8')),
+    ),
+  );
+
+  if (runs.length < 5) {
+    process.stderr.write(
+      `Warning: aggregating only ${runs.length} run(s). A dozen or more gives a ` +
+        'usable picture of runner variance; fewer risks anchoring on an outlier.\n',
+    );
+  }
+  const profiles = assertCiProfiles(runs, { assumeProfile });
+  if (assumeProfile) {
+    process.stderr.write(
+      `Recording profile '${assumeProfile}' for inputs stamped ` +
+        `'${[...new Set(runs.map((r) => r.environment?.profile))].join(', ')}'.\n`,
+    );
+  }
+
+  const baseline = {
+    version: 1,
+    capturedAt: new Date().toISOString(),
+    environment: {
+      ...(runs[0].environment ?? {}),
+      profile: profiles.length === 1 ? profiles[0] : profiles.join('+'),
+    },
+    metrics: aggregateSection(runs, 'metrics', percentile),
+    warmMetrics: aggregateSection(runs, 'warmMetrics', percentile),
+    notes: {
+      aggregation: `p${percentile} (nearest rank) of per-run medians`,
+      sampleCount: runs.length,
+      generatedBy: 'scripts/perf/refresh-baseline.mjs',
+      inputs: inputs.map((input) => path.basename(path.dirname(path.resolve(repoRoot, input)))),
+    },
+  };
+
+  await fs.writeFile(path.resolve(repoRoot, out), `${JSON.stringify(baseline, null, 2)}\n`, 'utf8');
+  const count = Object.keys(baseline.metrics).length + Object.keys(baseline.warmMetrics).length;
+  process.stdout.write(
+    `Wrote ${out} from ${runs.length} CI run(s): ${count} metrics at p${percentile}.\n`,
+  );
+}
+
+if (process.argv[1] && fileURLToPath(import.meta.url) === path.resolve(process.argv[1])) {
+  main().catch((error) => {
+    process.stderr.write(`${error instanceof Error ? error.message : String(error)}\n`);
+    process.exitCode = 1;
+  });
+}

--- a/scripts/perf/refresh-baseline.mjs
+++ b/scripts/perf/refresh-baseline.mjs
@@ -19,6 +19,8 @@ import fs from 'node:fs/promises';
 import path from 'node:path';
 import { fileURLToPath } from 'node:url';
 
+import { gatedMetricKeys } from './compare-baseline.mjs';
+
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const repoRoot = path.resolve(__dirname, '..', '..');
 
@@ -35,7 +37,11 @@ const repoRoot = path.resolve(__dirname, '..', '..');
 export function nearestRankPercentile(values, p) {
   const sorted = [...values].sort((a, b) => a - b);
   if (sorted.length === 0) throw new Error('nearestRankPercentile: empty sample');
-  const rank = Math.ceil((p / 100) * sorted.length);
+  // Integer arithmetic: `Math.ceil((p / 100) * n)` disagrees with the exact
+  // rank for some (n, p) pairs because p/100 is not representable in binary.
+  // Not reachable at the default p90, but --percentile is user-facing.
+  const scaled = p * sorted.length;
+  const rank = Math.floor(scaled / 100) + (scaled % 100 === 0 ? 0 : 1);
   return sorted[Math.min(Math.max(rank, 1), sorted.length) - 1];
 }
 
@@ -50,14 +56,40 @@ const round = (value) => Math.round(value * 10) / 10;
 export function aggregateSection(runs, section, percentile) {
   const names = new Set(runs.flatMap((run) => Object.keys(run[section] ?? {})));
   const out = {};
+  const dropped = [];
   for (const name of names) {
     const values = runs
       .map((run) => run[section]?.[name])
       .filter((value) => typeof value === 'number' && Number.isFinite(value));
-    if (values.length !== runs.length) continue;
+    // A metric missing (or null -- aggregate-baseline.mjs writes null when no
+    // run produced it) from any input cannot be aggregated. Treating it as 0
+    // would pin the budget to the 5ms floor and fail every later run.
+    if (values.length !== runs.length) {
+      dropped.push(name);
+      continue;
+    }
     out[name] = round(nearestRankPercentile(values, percentile));
   }
-  return out;
+  return { metrics: out, dropped };
+}
+
+/**
+ * Dropping a metric removes it from the baseline, and `compare-baseline.mjs`
+ * iterates *baseline* metrics -- so a dropped metric is silently never checked
+ * again. For a gated metric that recreates the exact blindness #278 was filed
+ * about, through a new door, so refuse rather than warn.
+ */
+export function assertNoGatedDrops(section, dropped) {
+  const gated = dropped.filter((name) => gatedMetricKeys.has(`${section}.${name}`));
+  if (gated.length > 0) {
+    throw new Error(
+      `Refusing to write a baseline missing gated metric(s): ${gated
+        .map((name) => `${section}.${name}`)
+        .join(', ')}.\n` +
+        'These drive CI pass/fail; a baseline without them silently stops gating.\n' +
+        'At least one input run did not report them -- re-harvest, or drop that run.',
+    );
+  }
 }
 
 /**
@@ -67,7 +99,18 @@ export function aggregateSection(runs, section, percentile) {
  */
 export function assertCiProfiles(runs, { assumeProfile } = {}) {
   const profiles = [...new Set(runs.map((run) => run.environment?.profile ?? 'unknown'))];
-  if (assumeProfile) return [assumeProfile];
+  if (assumeProfile) {
+    // The flag exists for artifacts captured before the profile was stamped
+    // correctly -- not to relabel a workstation capture as CI. Without this it
+    // fully inverts the guard it is attached to.
+    if (!/^ci-/.test(assumeProfile)) {
+      throw new Error(
+        `--assume-profile must name a CI profile (ci-*); got '${assumeProfile}'.\n` +
+          'It cannot be used to record a local capture as a CI one.',
+      );
+    }
+    return [assumeProfile];
+  }
   const local = profiles.filter((profile) => !profile.startsWith('ci-'));
   if (local.length > 0) {
     throw new Error(
@@ -125,11 +168,27 @@ async function main() {
         'usable picture of runner variance; fewer risks anchoring on an outlier.\n',
     );
   }
+  const observedProfiles = [...new Set(runs.map((run) => run.environment?.profile ?? 'unknown'))];
   const profiles = assertCiProfiles(runs, { assumeProfile });
   if (assumeProfile) {
     process.stderr.write(
       `Recording profile '${assumeProfile}' for inputs stamped ` +
-        `'${[...new Set(runs.map((r) => r.environment?.profile))].join(', ')}'.\n`,
+        `'${observedProfiles.join(', ')}'; noted in notes.profileAssumed.\n`,
+    );
+  }
+
+  const cold = aggregateSection(runs, 'metrics', percentile);
+  const warm = aggregateSection(runs, 'warmMetrics', percentile);
+  assertNoGatedDrops('metrics', cold.dropped);
+  assertNoGatedDrops('warmMetrics', warm.dropped);
+  const dropped = [
+    ...cold.dropped.map((name) => `metrics.${name}`),
+    ...warm.dropped.map((name) => `warmMetrics.${name}`),
+  ];
+  if (dropped.length > 0) {
+    process.stderr.write(
+      `Dropped ${dropped.length} metric(s) not reported by every input run: ` +
+        `${dropped.join(', ')}. These will not be compared at all.\n`,
     );
   }
 
@@ -140,13 +199,20 @@ async function main() {
       ...(runs[0].environment ?? {}),
       profile: profiles.length === 1 ? profiles[0] : profiles.join('+'),
     },
-    metrics: aggregateSection(runs, 'metrics', percentile),
-    warmMetrics: aggregateSection(runs, 'warmMetrics', percentile),
+    metrics: cold.metrics,
+    warmMetrics: warm.metrics,
     notes: {
       aggregation: `p${percentile} (nearest rank) of per-run medians`,
       sampleCount: runs.length,
       generatedBy: 'scripts/perf/refresh-baseline.mjs',
       inputs: inputs.map((input) => path.basename(path.dirname(path.resolve(repoRoot, input)))),
+      // Recorded so a reader can audit the file's provenance. `profile` alone
+      // would claim a CI capture with nothing saying the label was asserted
+      // rather than measured.
+      ...(assumeProfile
+        ? { profileAssumed: { assumed: assumeProfile, observed: observedProfiles } }
+        : {}),
+      ...(dropped.length > 0 ? { droppedMetrics: dropped } : {}),
     },
   };
 

--- a/scripts/perf/refresh-baseline.mjs
+++ b/scripts/perf/refresh-baseline.mjs
@@ -74,18 +74,25 @@ export function aggregateSection(runs, section, percentile) {
 }
 
 /**
- * Dropping a metric removes it from the baseline, and `compare-baseline.mjs`
- * iterates *baseline* metrics -- so a dropped metric is silently never checked
- * again. For a gated metric that recreates the exact blindness #278 was filed
- * about, through a new door, so refuse rather than warn.
+ * Every gated metric must survive into the baseline. `compare-baseline.mjs`
+ * iterates *baseline* metrics, so one that is absent is never compared again --
+ * recreating the exact blindness #278 was filed about, through a new door.
+ *
+ * Stated as a positive presence check rather than "nothing dropped was gated".
+ * The negative form missed the worse case: a metric absent from *every* input
+ * never enters the dropped set at all, because that set is built from the union
+ * of observed keys. It would then vanish silently, and a 3.3x bootstrap
+ * regression passed the resulting gate.
  */
-export function assertNoGatedDrops(section, dropped) {
-  const gated = dropped.filter((name) => gatedMetricKeys.has(`${section}.${name}`));
-  if (gated.length > 0) {
+export function assertGatedMetricsPresent({ metrics, warmMetrics }) {
+  const missing = [...gatedMetricKeys].filter((key) => {
+    const [section, name] = key.split('.');
+    const values = section === 'warmMetrics' ? warmMetrics : metrics;
+    return !(name in (values ?? {}));
+  });
+  if (missing.length > 0) {
     throw new Error(
-      `Refusing to write a baseline missing gated metric(s): ${gated
-        .map((name) => `${section}.${name}`)
-        .join(', ')}.\n` +
+      `Refusing to write a baseline missing gated metric(s): ${missing.join(', ')}.\n` +
         'These drive CI pass/fail; a baseline without them silently stops gating.\n' +
         'At least one input run did not report them -- re-harvest, or drop that run.',
     );
@@ -179,8 +186,7 @@ async function main() {
 
   const cold = aggregateSection(runs, 'metrics', percentile);
   const warm = aggregateSection(runs, 'warmMetrics', percentile);
-  assertNoGatedDrops('metrics', cold.dropped);
-  assertNoGatedDrops('warmMetrics', warm.dropped);
+  assertGatedMetricsPresent({ metrics: cold.metrics, warmMetrics: warm.metrics });
   const dropped = [
     ...cold.dropped.map((name) => `metrics.${name}`),
     ...warm.dropped.map((name) => `warmMetrics.${name}`),


### PR DESCRIPTION
Closes #278.

## The gate was blind, not flaky

#278 reports flakiness, and that was accurate **in July**: the v0.6.0 release run took 3 attempts, and its two failed attempts measured `appBootstrap` at **633.8ms and 635.2ms** against the 624.24ms budget.

I harvested `perf-baseline-candidate` from 24 CI runs to check whether that still holds. It does not — the picture inverted on **2026-08-08**, when #272 landed:

```
created               branch                       appBoot   1stComp   libPre
2026-07-28T05:10:50Z  release/0.6.0                  555.0    2189.0    246.6
2026-08-08T03:01:09Z  main                           513.2    2030.5    141.9
2026-08-08T04:56:04Z  refactor/monaco-local-amd      293.5    1932.4    104.0   <-- step change
2026-08-27T06:38:58Z  main                           275.1    1960.3     99.0
```

`appBootstrap` fell ~47%. Against the unchanged 624ms budget the gate has passed **15/15** since. A regression undoing the entire Monaco improvement would not have been reported — the more serious failure, and the opposite of what was filed.

Root cause is in the file: `environment.profile` read `local-headless`. The baseline was captured on a workstation on 2026-06-22 and never re-measured on a runner, while the gate it drives compares CI runs. `docs/PERFORMANCE.md` already said to prefer CI values; nothing enforced or surfaced it.

**Attribution is mechanistic, not just temporal.** #272 deleted a runtime **jsDelivr fetch** — Monaco was being pulled from a third-party CDN on every boot. That explains both the level shift and the variance shift, and rules out a runner-image change: worker-side metrics did *not* improve across the boundary (`workerWasmInit` 0.98x, `languageRegister` 1.00x, `workerFsInit` 1.18x *worse*). A runner upgrade would have lifted everything.

## Changes

- **`scripts/perf/refresh-baseline.mjs`** (new) — rebuild the baseline from many harvested CI runs, at **nearest-rank p90** of the per-run medians. Refuses inputs whose `environment.profile` is not `ci-*`, making the root cause unrepeatable. Unit-tested.
- **`perf-baseline.json`** — regenerated by that script from 15 post-refactor CI runs (each itself a median-of-3, so ~45 underlying samples). Contributing run IDs recorded in `notes`.
- **`scripts/perf/capture-baseline.mjs`** / **`aggregate-baseline.mjs`** — stamp `environment.profile` from the real environment instead of hardcoding `local-headless`.
- **`docs/PERFORMANCE.md`** — document the refresh, and the two ways to misread it (see below).

### Why p90, and why nearest-rank

The budget is a flat +20%. Anchoring at the median makes it *narrower than observed CI variance* for four diagnostic metrics, so they WARN on noise — which is exactly the standing `librariesPreload` WARN #278 asks to clear. Simulated across the 15 runs:

| anchor | gated false failures | diagnostics WARNing on noise |
|---|---|---|
| median | 0 | 4 |
| **p90** | **0** | **0** |
| max | 0 | 0 (most inflated, weakest sensitivity) |

Nearest-rank because `docs` previously said "p90" without defining it; defensible estimators disagree by up to 7.7% on the noisiest metric, so the file could not have been reproduced. Nearest rank also keeps every baseline value a number the app actually produced on a runner.

## Validation

| set | runs | exit | FAIL | WARN |
|---|---|---|---|---|
| in-sample (post-refactor) | 15 | 0 | 0 | 0 |
| held-out (#290's CI run) | 1 | 0 | 0 | 0 |
| this PR's own CI run | 1 | 0 | 0 | 0 |
| pre-refactor, incl. 2 censored attempts | 6 | 1 | 1-2 | 1-7 |

Silent on every current-code run including zero WARNs; loud on every pre-refactor run. `appBootstrap`'s budget tightens **624ms -> 367ms**, leaving 13% headroom over the worst run ever observed.

## Two things the review corrected

An earlier revision of this PR claimed the old gate "would have passed every pre-refactor run too." **That was false.** Run `30330872953` retains one artifact per attempt; attempts 1 and 2 exceed the old budget. The error was **survivorship bias** — a perf failure sets the run's conclusion to `failure`, so harvesting successful runs censors exactly the slow tail being measured. Those three same-SHA attempts are also true same-code repeats, which the earlier revision claimed not to have.

It also justified the headroom by arguing that cross-commit samples "overstate noise". That reasoning is hand-wavy and wrong in general — drift can bias a metric low just as easily. The real argument is the CDN removal above: same-code CV falls **13.2% -> 5.3%** across the refactor.

## Recorded, not hidden

This refresh baselines in four metrics that got **slower** (`editorMount` +17.1%, `warm.workerFsInit` +12.5%, `workerJobTotal` +5.8%, `workerFsInit` +5.5%). All diagnostic, none gated, net effect strongly positive — but #278 warns that this is how regressions get ratified, so they are filed as **#293** rather than absorbed silently. The p90-plus-flat-20% headroom question is **#294**.