### PR TITLE
test: enforce that every CI job is gated by the ok aggregator

### DIFF
--- a/scripts/__tests__/ci-gate-aggregation.test.mjs
+++ b/scripts/__tests__/ci-gate-aggregation.test.mjs
@@ -1,0 +1,58 @@
+// @vitest-environment node
+
+import { readFileSync } from 'node:fs';
+import path from 'node:path';
+
+import { describe, expect, it } from 'vitest';
+
+// Guards the one check branch protection requires. `ok` gates a merge only for
+// the jobs named in its `needs:`, and that list was kept correct by a comment
+// asking the next person to remember. A job added without updating it can fail
+// while merges proceed -- the whole pipeline green because the aggregator was
+// never told to look.
+//
+// Found by auditing every gate in the verify chain against broken input: 14
+// checked, this was the only invariant with nothing enforcing it.
+
+const workflowPath = path.join(
+  path.resolve(import.meta.dirname, '..', '..'),
+  '.github/workflows/ci.yml',
+);
+
+function readCiJobs() {
+  const workflow = readFileSync(workflowPath, 'utf8');
+  const body = workflow.split('\njobs:\n')[1] ?? '';
+  const jobs = [...body.matchAll(/^ {2}([A-Za-z0-9_-]+):$/gm)].map((match) => match[1]);
+  const needs = body
+    .match(/^ {2}ok:\n(?:.*\n)*?\s*needs: \[([^\]]+)\]/m)?.[1]
+    .split(',')
+    .map((name) => name.trim());
+  return { jobs, needs };
+}
+
+describe('ci.yml gate aggregation', () => {
+  const { jobs, needs } = readCiJobs();
+
+  it('parses the workflow', () => {
+    // If the shape changes and this stops finding jobs, the checks below would
+    // pass over an empty list rather than failing.
+    expect(jobs.length).toBeGreaterThan(1);
+    expect(needs).toBeDefined();
+  });
+
+  it('gates every job through ok', () => {
+    expect(jobs).toContain('ok');
+    expect(jobs.filter((job) => job !== 'ok' && !needs.includes(job))).toEqual([]);
+  });
+
+  it('names no job that does not exist', () => {
+    // A typo in `needs:` is silently satisfiable and would gate nothing.
+    expect(needs.filter((name) => !jobs.includes(name))).toEqual([]);
+  });
+
+  it('fails the build when an upstream job failed or was cancelled', () => {
+    const workflow = readFileSync(workflowPath, 'utf8');
+    expect(workflow).toContain("contains(needs.*.result, 'failure')");
+    expect(workflow).toContain("contains(needs.*.result, 'cancelled')");
+  });
+});


### PR DESCRIPTION
Output of a gate audit: every check in the verify chain fed broken or empty input, to see which stay green when they shouldn't.

## Audit result: 14 gates, 13 correct

| gate | fed | result |
| --- | --- | --- |
| `verify-production-build` | empty dir | exit 1 |
| `verify-viewer-bundle` | empty dir | exit 1 |
| `verify-session-bundle` | empty dir | exit 1 |
| `verify-publish-archive` | empty zip / missing zip | exit 1 |
| `verify-protocol-emit` | corrupted emit | exit 1 |
| `verify-session-protocol-emit` | corrupted emit | exit 1 |
| `check:budgets` | forced overage / empty file list | exit 1 |
| `format:check` | unformatted file | exit 1 |
| `lint` | unused var | exit 1 |
| `typecheck` | type error in src | exit 2 |
| `test:unit` | failing assertion | exit 1 |
| `test:assembly` | failing assertion | exit 1 |
| `build` | syntax error in src | exit 1 |
| **`ok` needs-completeness** | — | **unenforced** |

Notably `check-bundle-budgets` already treats "pattern matched no file" as a failure *deliberately* — its config comment says so. The artifact-verification layer is in good shape and was built by someone who understood this failure mode.

## The finding

`ok` is the only job branch protection requires, and it gates a merge only for the jobs in its `needs:`. The list is complete today. Nothing enforces it — the invariant is held by a comment:

```yaml
# Unified gate — the ONLY job required by branch protection. Add every job to
# `needs:` here; never add individual jobs to the branch-protection rule.
```

A job added to `ci.yml` without updating that list can fail while merges proceed, and the pipeline reads green because the aggregator was never told to look at it. That is the highest-stakes instance of the class this audit was looking for: not a check that lies, but a check whose *scope* can drift silently.

## The guard

Asserts the `needs:` list covers every job in the workflow, names no job that doesn't exist (a typo is silently satisfiable and gates nothing), and that `ok` still fails on an upstream `failure` or `cancelled`. The parse is guarded too — if the workflow shape changes and the matcher stops finding jobs, the other checks would pass over an empty list.

Verified against each regression:

```
new job not in needs   -> expected [ 'brand-new-job' ] to deeply equal []
typo in needs          -> expected [ 'performance' ] to deeply equal []
                          expected [ 'perfomance' ] to deeply equal []
ok's failure condition deleted -> expected workflow to contain "contains(needs.*.result, 'failure')"
clean                  -> 4 passed
```

## Context

This closes out the question of whether the silent-gate problem is systemic. It mostly isn't — one unenforced invariant across the whole chain, now enforced. The remaining known gaps are already filed: #296 (perf baseline provenance is self-asserted), #295 and #297 (build files and new runner configs outside every type-check program).