### PR TITLE
fix(perf): record verifiable run identity on every capture

### DIFF
--- a/docs/PERFORMANCE.md
+++ b/docs/PERFORMANCE.md
@@ -102,7 +102,23 @@ is the #278 root cause made unrepeatable: the 2026-06-22 baseline was captured
 on a workstation, so the gate compared runner timings against laptop timings
 and could not fail. Artifacts captured before the profile was stamped correctly
 read `local-headless` even on CI; pass `--assume-profile ci-Linux` for those,
-and only those.
+and only those. `ci-unknown` is rejected either way — that is what a
+workstation with `CI=true` and `RUNNER_OS` unset produces, so it is not
+evidence of anything.
+
+A capture also records `environment.runId` and `runAttempt` from
+`GITHUB_RUN_ID` / `GITHUB_RUN_ATTEMPT`. `profile` is derived from environment
+variables, so a capture asserts its own provenance and nothing can check it;
+a run id is issued by Actions and can be verified after the fact:
+
+```sh
+gh api repos/<owner>/<repo>/actions/runs/<runId> --jq '.head_sha, .conclusion'
+```
+
+`notes.inputs` reads those ids out of the payloads, falling back to the input
+directory name only for captures that predate the stamp. `notes.runIdsRecorded`
+says how many inputs carried one — if it is lower than `sampleCount`, that part
+of the baseline's provenance is unverifiable.
 
 Sanity-check a candidate before committing it, by comparing it against each
 harvested run:

--- a/perf-baseline.json
+++ b/perf-baseline.json
@@ -1,6 +1,6 @@
 {
   "version": 1,
-  "capturedAt": "2026-08-28T01:25:32.925Z",
+  "capturedAt": "2026-08-28T02:54:14.883Z",
   "environment": {
     "mode": "production",
     "browser": "chrome",
@@ -55,6 +55,7 @@
       "33046013950",
       "33046630768"
     ],
+    "runIdsRecorded": 0,
     "profileAssumed": {
       "assumed": "ci-Linux",
       "observed": ["local-headless"]

--- a/scripts/__tests__/refresh-baseline.test.mjs
+++ b/scripts/__tests__/refresh-baseline.test.mjs
@@ -187,10 +187,20 @@ describe('assertCiProfiles', () => {
   it('will not let --assume-profile launder a local capture', () => {
     // Without this the flag fully inverts the guard it is attached to.
     expect(() => assertCiProfiles(local, { assumeProfile: 'local-headless' })).toThrow(
-      /must name a CI profile/,
+      /must name a specific CI profile/,
     );
     expect(() => assertCiProfiles(local, { assumeProfile: 'my-laptop' })).toThrow(
-      /must name a CI profile/,
+      /must name a specific CI profile/,
+    );
+  });
+
+  it("rejects 'ci-unknown', which a workstation can produce", () => {
+    // capture-baseline.mjs yields ci-unknown for CI=true with RUNNER_OS unset,
+    // so it passes a bare ci-* prefix check while being no evidence at all.
+    const unknown = [{ environment: { profile: 'ci-unknown' } }];
+    expect(() => assertCiProfiles(unknown)).toThrow(/non-CI captures/);
+    expect(() => assertCiProfiles(local, { assumeProfile: 'ci-unknown' })).toThrow(
+      /not ci-unknown/,
     );
   });
 

--- a/scripts/perf/aggregate-baseline.mjs
+++ b/scripts/perf/aggregate-baseline.mjs
@@ -78,9 +78,12 @@ async function main() {
       mode: 'production',
       browser: 'chrome',
       // Mirrors capture-baseline.mjs: a baseline that gates CI must record
-      // whether it was measured on a runner or a workstation (#278).
+      // whether it was measured on a runner or a workstation (#278), and carry
+      // a run id that can be checked against the Actions API (#296).
       profile:
         process.env.CI === 'true' ? `ci-${process.env.RUNNER_OS ?? 'unknown'}` : 'local-headless',
+      runId: process.env.GITHUB_RUN_ID ?? null,
+      runAttempt: process.env.GITHUB_RUN_ATTEMPT ?? null,
     },
     metrics: aggregateMetricSection(runs, 'metrics'),
     warmMetrics: aggregateMetricSection(runs, 'warmMetrics'),

--- a/scripts/perf/capture-baseline.mjs
+++ b/scripts/perf/capture-baseline.mjs
@@ -335,6 +335,14 @@ async function main() {
             process.env.CI === 'true'
               ? `ci-${process.env.RUNNER_OS ?? 'unknown'}`
               : 'local-headless',
+          // `profile` is derived from env vars, so a capture asserts its own
+          // provenance and nothing can check it -- `CI=true` on a workstation
+          // with RUNNER_OS unset yields 'ci-unknown', which looks like CI. The
+          // run id is issued by Actions and can be verified against the API
+          // after the fact, which is what makes a committed baseline auditable
+          // rather than merely self-described (#296).
+          runId: process.env.GITHUB_RUN_ID ?? null,
+          runAttempt: process.env.GITHUB_RUN_ATTEMPT ?? null,
         },
         metrics: cold.metrics,
         warmMetrics: warm.metrics,

--- a/scripts/perf/refresh-baseline.mjs
+++ b/scripts/perf/refresh-baseline.mjs
@@ -114,15 +114,20 @@ export function assertCiProfiles(runs, { assumeProfile } = {}) {
     // The flag exists for artifacts captured before the profile was stamped
     // correctly -- not to relabel a workstation capture as CI. Without this it
     // fully inverts the guard it is attached to.
-    if (!/^ci-/.test(assumeProfile)) {
+    if (!/^ci-/.test(assumeProfile) || assumeProfile === 'ci-unknown') {
       throw new Error(
-        `--assume-profile must name a CI profile (ci-*); got '${assumeProfile}'.\n` +
-          'It cannot be used to record a local capture as a CI one.',
+        `--assume-profile must name a specific CI profile (ci-*, not ci-unknown); ` +
+          `got '${assumeProfile}'.\n` +
+          'It cannot be used to record a local capture as a CI one. ' +
+          "'ci-unknown' is what a workstation with CI=true and RUNNER_OS unset " +
+          'produces, so it is not evidence of anything.',
       );
     }
     return [assumeProfile];
   }
-  const local = profiles.filter((profile) => !profile.startsWith('ci-'));
+  const local = profiles.filter(
+    (profile) => !profile.startsWith('ci-') || profile === 'ci-unknown',
+  );
   if (local.length > 0) {
     throw new Error(
       `Refusing to build a CI baseline from non-CI captures: ${local.join(', ')}.\n` +
@@ -215,7 +220,16 @@ async function main() {
       aggregation: `p${percentile} (nearest rank) of per-run medians`,
       sampleCount: runs.length,
       generatedBy: 'scripts/perf/refresh-baseline.mjs',
-      inputs: inputs.map((input) => path.basename(path.dirname(path.resolve(repoRoot, input)))),
+      // Read from the payload where present, so provenance comes from the
+      // artifact rather than from whatever the containing directory happened to
+      // be called. Falls back to the directory name for captures made before
+      // runId was stamped (#296).
+      inputs: runs.map(
+        (run, index) =>
+          run.environment?.runId ??
+          path.basename(path.dirname(path.resolve(repoRoot, inputs[index]))),
+      ),
+      runIdsRecorded: runs.filter((run) => run.environment?.runId != null).length,
       // Recorded so a reader can audit the file's provenance. `profile` alone
       // would claim a CI capture with nothing saying the label was asserted
       // rather than measured.


### PR DESCRIPTION
Closes #296.

## The problem

`environment.profile` is derived entirely from environment variables:

```js
profile: process.env.CI === 'true' ? `ci-${process.env.RUNNER_OS ?? 'unknown'}` : 'local-headless'
```

So a capture asserts its own provenance and nothing can check it. Concretely: a workstation with `CI=true` and `RUNNER_OS` unset stamps **`ci-unknown`**, which satisfies `refresh-baseline.mjs`'s `ci-*` guard with **no `--assume-profile`**, and therefore leaves no `profileAssumed` trace at all. The guard added in #291 rested on a value the capture makes up about itself.

## Changes

- **`capture-baseline.mjs`, `aggregate-baseline.mjs`** — stamp `environment.runId` and `runAttempt` from `GITHUB_RUN_ID` / `GITHUB_RUN_ATTEMPT`. Those are issued by Actions, so a baseline's provenance becomes checkable rather than trusted:

  ```sh
  gh api repos/<owner>/<repo>/actions/runs/<runId> --jq '.head_sha, .conclusion'
  ```

- **`refresh-baseline.mjs`** — `notes.inputs` now reads run ids out of the payloads instead of the containing directory names. Those names were only meaningful under the `harvest/<id>` layout the docs prescribe; pointed at `coverage/perf/current-perf-baseline.json`, the provenance field would have recorded `"perf"` while still looking authoritative. Falls back to the directory name only for captures predating the stamp.

- **`notes.runIdsRecorded`** — how many inputs carried a run id. If it is below `sampleCount`, that much of the baseline's provenance is unverifiable, and the file now says so.

- **`ci-unknown` rejected in both directions** — as an input profile and as an `--assume-profile` value.

## Honest about the current file

The committed baseline is regenerated and reports:

```json
"profileAssumed": { "assumed": "ci-Linux", "observed": ["local-headless"] },
"runIdsRecorded": 0
```

Its 15 inputs were captured before this stamp existed, so none carry a run id. That is recorded rather than papered over — the file claims exactly as much as it can support, and the next refresh will report 15.

**Metric values are unchanged.**

## Verification

- `ci-unknown` refused with no flag (exit 1) and as `--assume-profile` (exit 1)
- a run id is read from the payload even when the containing directory is misleadingly named
- 0 failures across 16 current-code runs; exit 1 on all 10 pre-refactor runs
- `npm run verify` exit 0; tests 26 -> 27

## Context

This was the last of the three gaps left by the gate audit (#298). The remaining two are type-check coverage, not provenance: #295 and #297.