### PR TITLE
fix(build): type-check every root-level build and runner config

### DIFF
--- a/scripts/__tests__/tests-typecheck-program.test.mjs
+++ b/scripts/__tests__/tests-typecheck-program.test.mjs
@@ -97,11 +97,15 @@ describe('tests type-check program (#286)', () => {
     expect(step?.[1]?.trim()).toBe('npm run typecheck');
   });
 
-  it('type-checks the runner configs', () => {
-    // A mistyped option here changes runtime behaviour without failing anything.
-    for (const config of ['playwright.config.ts', 'vitest.config.ts', 'vitest.setup.ts']) {
-      expect(program).toContain(config);
-    }
+  it('type-checks every root-level build and runner config', () => {
+    // Asserted exhaustively rather than by naming known files: a NEW config was
+    // silently unchecked until someone remembered to list it (#297), and a
+    // guard that only checks the files you remembered has the same gap.
+    const rootTs = readdirSync(repoRoot, { withFileTypes: true })
+      .filter((entry) => entry.isFile() && entry.name.endsWith('.ts'))
+      .map((entry) => entry.name);
+    expect(rootTs.length).toBeGreaterThan(0);
+    expect(rootTs.filter((file) => !program.includes(file))).toEqual([]);
   });
 
   it('is actually run by the typecheck script', () => {

--- a/scripts/sync-monaco-assets.mjs
+++ b/scripts/sync-monaco-assets.mjs
@@ -90,6 +90,19 @@ function resolveMonacoVsDir() {
   return path.join(root, 'min', 'vs');
 }
 
+/**
+ * Copy the Monaco AMD build into `destDir`.
+ *
+ * The options are annotated because `vite.shared.ts` calls this from
+ * TypeScript: without it, `destDir` has no default and no annotation, so the
+ * inferred parameter type omits it entirely and the (correct) call site fails
+ * to type-check (#295).
+ *
+ * @param {object} [options]
+ * @param {string} options.destDir Directory to populate; replaced wholesale.
+ * @param {(message: string) => void} [options.log] Progress sink.
+ * @returns {{ copied: number, skipped: number }}
+ */
 export function syncMonacoAssets({ destDir, log = console.log } = {}) {
   const srcDir = resolveMonacoVsDir();
   if (!existsSync(srcDir)) {

--- a/tsconfig.tests.json
+++ b/tsconfig.tests.json
@@ -16,8 +16,13 @@
     // which files are admitted; this config emits nothing.
     "rootDir": "."
   },
-  // The runner configs are included deliberately: they are the part of the test
-  // tooling most likely to break silently, since a mistyped option changes
-  // runtime behaviour without failing anything.
-  "include": ["tests/**/*.ts", "playwright.config.ts", "vitest.config.ts", "vitest.setup.ts"]
+  // Every root-level authored .ts, not a hand-maintained list of three. Those
+  // are the build and runner configs, where a mistyped option changes runtime
+  // behaviour without failing anything -- and a NEW one stayed silently
+  // unchecked until someone remembered to add it here (#297). A glob cannot be
+  // forgotten.
+  //
+  // Reaching all of them depended on first fixing the two errors in
+  // vite.shared.ts that no gate caught (#295).
+  "include": ["tests/**/*.ts", "*.ts"]
 }

--- a/vite.shared.ts
+++ b/vite.shared.ts
@@ -3,7 +3,9 @@ import { fileURLToPath } from 'node:url';
 
 import type { Plugin, UserConfig } from 'vite';
 
-// @ts-expect-error -- plain .mjs build script, no type declarations.
+// `allowJs` resolves this .mjs and infers its types, so there is nothing to
+// suppress here -- a directive would be reported as unused, and would mask a
+// real import error if one ever appeared (#295).
 import { syncMonacoAssets } from './scripts/sync-monaco-assets.mjs';
 
 const htmlInput = (name: string) => fileURLToPath(new URL(`./${name}`, import.meta.url));


### PR DESCRIPTION
Closes #295. Closes #297.

## The gap

Five of the eight root-level `.ts` files were in **no type-check program at all** — the four vite configs and `vite.shared.ts`. The three that were covered got there by being named individually in `tsconfig.tests.json`, so a new runner config stayed unchecked until someone remembered to add it.

That is the same shape as the CI aggregator in #298: an invariant maintained by remembering.

## #295 first, because it blocked #297

Widening the program surfaced exactly the two errors #295 describes. Both are fixed at the source rather than suppressed:

- **`vite.shared.ts:6`** — the `@ts-expect-error` on the `sync-monaco-assets.mjs` import suppressed nothing. `allowJs` resolves the `.mjs` and infers its types, so TS reported the directive as *unused*. Worse, a stale directive would have masked a genuine import error if one ever appeared.
- **`vite.shared.ts:24`** — `syncMonacoAssets({ destDir, log = console.log } = {})` destructures `destDir` with no default and no annotation, so the inferred options type omits it and the **correct** call site fails to type-check. Fixed by annotating the function with JSDoc, not by casting at the call site.

## #297: a glob instead of a list

```json
"include": ["tests/**/*.ts", "*.ts"]
```

The program goes from 12 files to 20. A new config is now covered by construction — there is nothing to remember.

The guard in `tests-typecheck-program.test.mjs` is updated to match: it asserts **every** root-level `.ts` is in the program, rather than checking the three files someone thought of. A guard that only checks remembered files has the same gap it exists to close.

## Verification

```
new playwright.session.config.ts in program        -> 1 (auto-admitted)
type error inside that new config                  -> typecheck exit 2
include narrowed back to the old hand-list         -> guard fails, naming all 7 dropped files
stale @ts-expect-error reintroduced                -> typecheck exit 2
clean                                              -> typecheck exit 0, 4 passed
```

`npm run verify` exit 0 — 777 unit, 89 assembly.

## Context

Last of the three gaps left by the gate audit (#298); #296 landed in #299. The remaining open issues are the colour tail — #283, #287, #282 — plus #293 and #294 from the perf work.