### PR TITLE
fix(ui): say why colors disappear on the CGAL backend

### DIFF
--- a/src/components/elements/osc-settings-menu.test.ts
+++ b/src/components/elements/osc-settings-menu.test.ts
@@ -1,0 +1,59 @@
+// @vitest-environment jsdom
+import { render } from 'lit';
+import { beforeAll, describe, expect, it } from 'vitest';
+
+import { OscSettingsMenu } from './osc-settings-menu.ts';
+
+// Guards #283: only the Manifold backend emits per-face colors, so on CGAL a
+// model using color() silently reverts to the viewer's default cameo yellow
+// with nothing on screen explaining why. The limitation is deliberate; the
+// silence was the bug.
+
+// jsdom implements neither matchMedia nor navigator.standalone, and the menu
+// calls isInStandaloneMode() while rendering. Stub the query rather than mock
+// the module, so the real render path runs.
+beforeAll(() => {
+  window.matchMedia ??= ((query: string) =>
+    ({
+      matches: false,
+      media: query,
+      addEventListener: () => {},
+      removeEventListener: () => {},
+    }) as unknown as MediaQueryList) as typeof window.matchMedia;
+});
+
+function renderMenu(backend: 'manifold' | 'cgal') {
+  const el = new OscSettingsMenu();
+  // The element renders from the last `state` event it saw; feed it directly
+  // rather than standing up a Model.
+  (el as unknown as { _st: unknown })._st = {
+    params: { backend },
+    view: { layout: { mode: 'single' }, customizerGroupsCollapsed: false },
+  };
+  const host = document.createElement('div');
+  render(el.render(), host);
+  return host;
+}
+
+describe('osc-settings-menu backend notice (#283)', () => {
+  it('explains the colour cost while CGAL is selected', () => {
+    const note = renderMenu('cgal').querySelector('.note');
+    expect(note).not.toBeNull();
+    expect(note?.textContent).toMatch(/colors are unavailable/i);
+    expect(note?.textContent).toMatch(/CGAL/);
+  });
+
+  it('shows no notice on Manifold, which does carry colours', () => {
+    expect(renderMenu('manifold').querySelector('.note')).toBeNull();
+  });
+
+  it('names the consequence on the toggle itself, in both directions', () => {
+    // The tooltip has to say what switching costs, not just what it switches
+    // to -- the menu is where someone goes *after* their colours vanished.
+    const onManifold = renderMenu('manifold').querySelector('button.item[title]');
+    expect(onManifold?.getAttribute('title')).toMatch(/CGAL does not carry color\(\)/);
+
+    const onCgal = renderMenu('cgal').querySelector('button.item[title]');
+    expect(onCgal?.getAttribute('title')).toMatch(/Manifold carries color\(\)/);
+  });
+});

--- a/src/components/elements/osc-settings-menu.ts
+++ b/src/components/elements/osc-settings-menu.ts
@@ -70,6 +70,17 @@ export class OscSettingsMenu extends LitElement {
     button.item.danger {
       color: var(--osc-error);
     }
+    /* A consequence of the adjacent setting, not an action. Indented to the
+       same text column as the buttons so it reads as attached to one. */
+    .note {
+      padding: 0 16px 8px;
+      margin: 0;
+      font-size: 0.8rem;
+      color: var(--osc-fg-muted, var(--osc-fg));
+      opacity: 0.75;
+      max-width: 260px;
+      white-space: normal;
+    }
   `;
 
   @state() private _st: State | null = null;
@@ -176,6 +187,11 @@ export class OscSettingsMenu extends LitElement {
           <button
             class="item"
             role="menuitem"
+            title=${
+              backend === 'manifold'
+                ? 'CGAL does not carry color() into the rendered geometry.'
+                : 'Manifold carries color() into the rendered geometry.'
+            }
             @click=${() =>
               this._model.mutate((s) => {
                 s.params.backend = s.params.backend === 'cgal' ? 'manifold' : 'cgal';
@@ -183,6 +199,18 @@ export class OscSettingsMenu extends LitElement {
           >
             ${backend === 'manifold' ? 'Switch to CGAL backend' : 'Switch to Manifold backend'}
           </button>
+          ${
+            // Only the Manifold backend emits per-face colors, so on CGAL a
+            // model that uses color() silently reverts to the viewer's default
+            // and nothing on screen explains why (#283). The limitation is
+            // fine -- CGAL is a deliberate escape hatch -- the silence is not.
+            backend === 'cgal'
+              ? html`<p class="note" role="note">
+                  Model colors are unavailable on CGAL: <code>color()</code> is not carried into the
+                  rendered geometry.
+                </p>`
+              : ''
+          }
           ${
             isInStandaloneMode()
               ? html`


### PR DESCRIPTION
Closes #283.

## What

Only the Manifold backend writes per-face colors into OFF:

```
--backend=manifold   3 3 0 1 0 128 0     <- colored
--backend=cgal       3 0 2 3             <- no suffix
```

So flipping the settings toggle to CGAL makes a `color()`-using model revert to the viewer's default cameo yellow, with nothing on screen explaining why. Post-#258 that is a more visible cliff, because more models now render in color at all.

The limitation is fine — CGAL is a deliberate escape hatch. **The silence was the bug.**

## Change

- A note under the toggle while CGAL is selected: *"Model colors are unavailable on CGAL: `color()` is not carried into the rendered geometry."*
- A `title` on the toggle naming the consequence in **both** directions.

The tooltip matters more than it looks: the settings menu is where someone goes *after* their colors vanished, so the label has to answer the question they arrived with, not just describe what the button switches to.

## Tests

Render the element in jsdom, assert the note appears on CGAL and not on Manifold, and that both tooltips name the consequence.

Each was verified to fail without the fix:

```
notice condition stubbed to false -> × explains the colour cost while CGAL is selected
tooltip text softened             -> × names the consequence on the toggle itself
```

Worth noting the first mutation attempt was a false negative — a substring replace hit `s.params.backend === 'cgal'` in the click handler instead of the notice condition, and the tests kept passing. Retargeted by line, they fail correctly. A mutation test that doesn't mutate what you think proves nothing.

`npm run verify` exit 0 — 780 unit, 89 assembly.