### PR TITLE
fix(io): read float 0..1 OFF face colors on their own scale

### DIFF
--- a/src/io/__tests__/import_off.test.ts
+++ b/src/io/__tests__/import_off.test.ts
@@ -125,3 +125,64 @@ describe('parseOff face colors', () => {
     expect(poly.faces.every((f) => f.colorIndex === 0)).toBe(true);
   });
 });
+
+// The OFF spec tells integer 0..255 from float 0..1 by the TOKEN, not the value:
+// "three or four integers | RGB ... 0..255" vs "three or four floating-point
+// numbers | RGB ... 0..1" (Geomview OOGL manual). #287.
+describe('parseOff float 0..1 face colors (#287)', () => {
+  const oneFace = (face: string) => `OFF 4 1 0\n${TRI_VERTS}\n${face}\n`;
+
+  it('reads a float channel on its own scale, not divided by 255', () => {
+    // The filed bug: 0.5 became 0.00196, i.e. near-black.
+    const poly = parseOff(oneFace('3 0 1 2 0.5 0.5 0.5'));
+    expect(poly.colors[0]).toEqual([0.5, 0.5, 0.5, 1]);
+  });
+
+  it('reads 1.0 0.0 0.0 as red, not as 1/255 near-black', () => {
+    // A value-based rule ("any channel has a fractional part") gets this wrong,
+    // and it is the form Geomview's own binary example and Antiprism emit.
+    expect(parseOff(oneFace('3 0 1 2 1.0 0.0 0.0')).colors[0]).toEqual([1, 0, 0, 1]);
+  });
+
+  it('defaults a float color to fully opaque, not to 255', () => {
+    expect(parseOff(oneFace('3 0 1 2 0.25 0.5 0.75')).colors[0][3]).toBe(1);
+  });
+
+  it('reads float alpha on the float scale', () => {
+    expect(parseOff(oneFace('3 0 1 2 0.0 1.0 0.0 0.4')).colors[0]).toEqual([0, 1, 0, 0.4]);
+  });
+
+  it('decides once per file, so one float channel makes the whole file float', () => {
+    // Deciding per face would render two faces of the same encoding differently
+    // depending on their values.
+    const poly = parseOff(twoFaces('3 0 1 2 1 0 0', '3 0 1 3 0.5 0.5 0.5'));
+    expect(poly.colors[0]).toEqual([1, 0, 0, 1]);
+    expect(poly.colors[1]).toEqual([0.5, 0.5, 0.5, 1]);
+  });
+
+  it('keeps a mixed-literal channel set on the float scale', () => {
+    // MeshLab and OpenMesh test only the first channel and would misread this.
+    expect(parseOff(oneFace('3 0 1 2 1 0.5 0')).colors[0]).toEqual([1, 0.5, 0, 1]);
+  });
+
+  it('leaves OpenSCAD integer output exactly as before', () => {
+    const poly = parseOff(twoFaces('3 0 1 2 0 128 0 127', '3 0 1 3 249 215 44'));
+    expect(poly.colors[0]).toEqual([0, 128 / 255, 0, 127 / 255]);
+    expect(poly.colors[1]).toEqual([249 / 255, 215 / 255, 44 / 255, 1]);
+  });
+
+  it('reads an all-0/1 integer file as integer, the predictable reading', () => {
+    // Genuinely undecidable -- `1 0 0` is near-black as integers and red as
+    // floats-without-decimals. Integer keeps behaviour predictable and matches
+    // MeshLab and OpenMesh, which apply the same lexical test. Asserted so the
+    // choice is visible and a change to it is deliberate.
+    expect(parseOff(oneFace('3 0 1 2 1 0 0')).colors[0]).toEqual([1 / 255, 0, 0, 1]);
+  });
+
+  it('does not treat a trailing comment as a float channel', () => {
+    // The #284 behaviour: a non-numeric 4th field means "no alpha", and the
+    // token must not be mistaken for a non-integer literal either.
+    const poly = parseOff(oneFace('3 0 1 2 0 128 0 # green'));
+    expect(poly.colors[0]).toEqual([0, 128 / 255, 0, 1]);
+  });
+});

--- a/src/io/import_off.ts
+++ b/src/io/import_off.ts
@@ -1,5 +1,11 @@
 import { Color, DEFAULT_FACE_COLOR, Face, IndexedPolyhedron, Vertex } from './common';
 
+/** A bare integer token. `0.5`, `1.0` and `1e-3` are float; `128`, `0`, `1` are not. */
+const INTEGER_LITERAL = /^[+-]?\d+$/;
+
+/** A face color as written, before the file's scale is known. */
+type RawColor = { rgb: [number, number, number]; alpha: number | null };
+
 export function parseOff(content: string): IndexedPolyhedron {
   const lines = content
     .split('\n')
@@ -38,13 +44,24 @@ export function parseOff(content: string): IndexedPolyhedron {
   }
   currentLine += numVertices;
 
-  const colors: Color[] = [];
   const colorMap = new Map<string, number>();
   let hasSourceColors = false;
 
+  // Channels are kept on the source scale here and normalized once, after the
+  // last face line, because the scale is a property of the file rather than of
+  // any one face (see `sawFloatChannel` below). `null` marks an entry that is
+  // already normalized (`DEFAULT_FACE_COLOR`) and must not be rescaled.
+  const rawColors: (RawColor | null)[] = [];
+  let sawFloatChannel = false;
+
   const faces: Face[] = [];
   for (let i = 0; i < numFaces; i++) {
-    const parts = lines[currentLine + i].split(/\s+/).map(Number);
+    // The raw tokens are kept alongside the numbers: the OFF spec tells integer
+    // from float colors by the TOKEN, not the value ("three or four integers |
+    // RGB ... 0..255" vs "three or four floating-point numbers | RGB ... 0..1"
+    // -- Geomview OOGL manual), and `Number()` throws that distinction away.
+    const tokens = lines[currentLine + i].split(/\s+/);
+    const parts = tokens.map(Number);
     const numVerts = parts[0];
     const vertices = parts.slice(1, numVerts + 1);
     // A face line may carry a trailing color: RGB (numVerts + 4 fields) or
@@ -53,8 +70,7 @@ export function parseOff(content: string): IndexedPolyhedron {
     // Only finite channels are trusted: `.map(Number)` turns a trailing comment
     // or junk into NaN and `1e999` into Infinity, either of which would reach the
     // GPU as a broken color attribute. Vertex lines are validated the same way
-    // below. Float 0..1 colors, which the OFF spec also permits, are still read
-    // as 0-255 (#287).
+    // below.
     const rgb = parts.slice(numVerts + 1, numVerts + 4);
     const hasFaceColor = rgb.length === 3 && rgb.every(Number.isFinite);
     if (hasFaceColor) hasSourceColors = true;
@@ -62,25 +78,30 @@ export function parseOff(content: string): IndexedPolyhedron {
     // trailing comment after an RGB triple) means "no alpha" rather than
     // discarding an otherwise valid color.
     const alpha = parts[numVerts + 4];
-    const color = hasFaceColor
-      ? ([...rgb, Number.isFinite(alpha) ? alpha : 255].map((c) => c / 255) as [
-          number,
-          number,
-          number,
-          number,
-        ])
-      : DEFAULT_FACE_COLOR;
+    const hasAlpha = Number.isFinite(alpha);
+    if (hasFaceColor) {
+      // Any non-integer literal in any channel makes the whole FILE float --
+      // one producer writes one file, and deciding per face would render two
+      // faces of the same encoding differently depending on their values.
+      const channels = tokens.slice(numVerts + 1, numVerts + (hasAlpha ? 5 : 4));
+      if (channels.some((token) => !INTEGER_LITERAL.test(token))) sawFloatChannel = true;
+    }
+    // A missing alpha is left null rather than defaulted to 255 here: "fully
+    // opaque" is 255 on the integer scale and 1 on the float scale, and which
+    // one applies is not known until the last face line has been read.
+    const color: RawColor | null = hasFaceColor
+      ? { rgb: [rgb[0], rgb[1], rgb[2]], alpha: hasAlpha ? alpha : null }
+      : null;
     if (vertices.length < 3)
       throw new Error(
         `Invalid OFF file: face at line ${currentLine + i + 1} must have at least 3 vertices`,
       );
 
-    const colorKey = color ? color.join(',') : '';
+    const colorKey = color ? `${color.rgb.join(',')},${color.alpha}` : '';
     let colorIndex = colorMap.get(colorKey);
     if (colorIndex == null) {
-      colorIndex = colors.length;
-      const [r, g, b, a] = color;
-      colors.push([r, g, b, a ?? 1]);
+      colorIndex = rawColors.length;
+      rawColors.push(color);
       colorMap.set(colorKey, colorIndex);
     }
 
@@ -99,6 +120,24 @@ export function parseOff(content: string): IndexedPolyhedron {
       }
     }
   }
+
+  // One scale for the file. Integer is the default: it is what OpenSCAD writes,
+  // and a file whose channels are all integer literals is integer per the spec
+  // even when every value happens to be 0 or 1. That last case (`1 0 0` --
+  // near-black, or red written without decimal points?) is genuinely
+  // undecidable; reading it as integer keeps the behaviour predictable and
+  // matches MeshLab and OpenMesh, which apply the same lexical test.
+  const scale = sawFloatChannel ? 1 : 255;
+  const colors: Color[] = rawColors.map((color) =>
+    color === null
+      ? DEFAULT_FACE_COLOR
+      : ([
+          color.rgb[0] / scale,
+          color.rgb[1] / scale,
+          color.rgb[2] / scale,
+          color.alpha === null ? 1 : color.alpha / scale,
+        ] as Color),
+  );
 
   return { vertices, faces, colors, hasSourceColors };
 }


### PR DESCRIPTION
Closes #287.

`parseOff` divided every face-color channel by 255, so a file using the OFF format's float convention rendered near-black — `0.5` became `0.00196`.

## The fix is not a value-range heuristic

The issue frames this as ambiguous ("`0` and `1` are valid in both"). Research turned up that the spec is less ambiguous than it looks — the **Geomview OOGL manual** distinguishes the encodings by **token type**, not by value:

```
nothing:                        default
one integer:                    index into "the" colormap
three or four integers:         RGB and possibly alpha values in the range 0..255
three or four floating-point:   RGB and possibly alpha values in the range 0..1
```

(verified at <https://man.freebsd.org/cgi/man.cgi?query=oogl&sektion=5>, which mirrors the Geomview manual verbatim)

So `1 0 0` is unambiguously *integer* near-black and `1.0 0.0 0.0` is unambiguously *float* red. **`parts.map(Number)` threw that distinction away before the decision was made** — which is what made the problem look undecidable from inside our parser.

The fix keeps the raw tokens alongside the numbers and tests them: any channel that is not a bare integer literal makes the file float.

## Why per-file, and why not a value rule

**Per-file, not per-face.** One producer writes one file. A per-face rule renders two faces of the same encoding differently depending on their values — an int file with `0 128 0` and `1 1 1` would show one green face and one white one. This also beats the first-channel-only shortcut MeshLab and OpenMesh use, which misreads `1 0.5 0`.

**Not a value rule.** "Any channel has a fractional part" — which is what CGAL's live `scan_color()` does — fixes the filed symptom but still reads `1.0 0.0 0.0` as near-black, and `0.0 0.0 0.0 1.0` as an invisible face. That is the exact form Geomview's own binary example and Antiprism emit. The lexical rule gets both right for the same effort.

Precedent: every implementation that reads face colors *and* decides — MeshLab/vcglib, OpenMesh, Antiprism — uses the lexical test. CGAL's live path is the lone outlier and is the one that misreads common input.

## The genuinely undecidable case

An all-integer-literal file whose every value is `0` or `1` (`1 0 0`: near-black, or red written without decimal points?) **stays integer**. That keeps behaviour predictable, matches MeshLab and OpenMesh, and respects the issue's own position that guessing wrong silently is worse than predictable behaviour.

It is asserted in a test so the choice is visible and any change to it is deliberate, rather than being an accident of the implementation.

## Alpha

A missing alpha is now resolved *after* the scale is known. "Fully opaque" is `255` on the integer scale and `1` on the float one, so defaulting it at parse time produced alpha `255` on a float file. Caught by a test, not by inspection.

The #284 trailing-comment behaviour (`0 128 0 # green`) is unchanged and asserted.

## Verification

9 new cases. Reverting `scale` to an unconditional `255` fails 5 of them; the suite passes clean.

OpenSCAD output is unaffected — it writes bare integers. `npm run verify` exit 0, 786 unit + 89 assembly.