### PR TITLE
chore(release): 0.8.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,9 +6,15 @@ release (changelog upkeep and tagging had lapsed between `0.1.0` and `0.2.0`).
 
 ## [Unreleased]
 
-A pass over the verification layer. Two gates were reporting green while
+## [0.8.0] - 2026-08-28
+
+Mostly an internal-quality release. Two gates were reporting green while
 checking nothing, and an audit of the remaining fourteen found one more
 invariant with nothing enforcing it.
+
+Two changes are user-visible: a static mount whose `geometry.off` came from a
+tool other than OpenSCAD no longer renders near-black (#287), and switching to
+the CGAL backend now says why the model's colors disappeared (#283).
 
 ### Fixed
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "openscad-web",
-  "version": "0.7.0",
+  "version": "0.8.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "openscad-web",
-      "version": "0.7.0",
+      "version": "0.8.0",
       "dependencies": {
         "@monaco-editor/loader": "^1.4.0",
         "blurhash": "^2.0.5",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "openscad-web",
-  "version": "0.7.0",
+  "version": "0.8.0",
   "private": true,
   "type": "module",
   "homepage": "https://cameronbrooks11.github.io/openscad-web/",


### PR DESCRIPTION
Cuts **v0.8.0**. Eight commits since `v0.7.0`.

## What's in it

Mostly an internal-quality release. Two gates were reporting green while checking nothing, and an audit of the remaining fourteen found one more invariant with nothing enforcing it.

**User-visible (2):**
- A static mount whose `geometry.off` came from a tool other than OpenSCAD no longer renders near-black (#287).
- Switching to the CGAL backend now says why the model's colors disappeared (#283).

**Internal (6):** #286 (`tests/` never type-checked), #278 (perf gate could not fail), #296 (perf provenance self-asserted), #298 (`ok` aggregator's `needs:` list unenforced), #295 / #297 (build configs outside every type-check program).

## Release contents, cross-checked

The merged-PR list alone is **not** authoritative for this window: **#299 does not appear in it.** GitHub 502'd mid-merge, landing the squash commit on `main` but closing the PR without marking it merged. The window was taken from `git log v0.7.0..HEAD` instead, which catches it:

```
4adb15a docs(changelog): record the verification-layer pass (#303)
a9e166b fix(io): read float 0..1 OFF face colors on their own scale (#302)
9f6395a fix(ui): say why colors disappear on the CGAL backend (#301)
04418e2 fix(build): type-check every root-level build and runner config (#300)
63cd8d3 fix(perf): record verifiable run identity on every capture (#299)
26307dd test: enforce that every CI job is gated by the ok aggregator (#298)
6f4a379 fix(perf): re-baseline the perf gate from CI-measured runs (#291)
990c2b8 ci: type-check the Playwright specs (#290)
```

All eight are covered by the changelog section.

## Version bump

`npm version 0.8.0 --no-git-tag-version` — `package.json`, `package-lock.json`, and the build manifests (`viewerVersion: "0.8.0"`) all carry it. No hardcoded `0.7.0` references remain outside changelog history.

A minor rather than a patch: strictly these are fixes, but two change rendering behaviour a consumer can observe, and the project is pre-1.0.

## Verification

`npm run verify` exit 0 — 789 unit, 89 assembly.

## After merge

Tag `v0.8.0` on the merge commit and push it. `release.yml` publishes `openscad-web-publish.zip` and **force-moves the `v0` alias**, so anyone pinned at `@v0` picks this up on their next build.